### PR TITLE
openssl: Add Unreachable and UnreachableExceptTest

### DIFF
--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -154,7 +154,7 @@ func NewOpenSSLError(msg string) error {
 }
 
 // Unreachable marks code that should be unreachable
-// when BoringCrypto is in use. It panics only when
+// when FIPS mode. It panics only when
 // the system is in FIPS mode.
 func Unreachable() {
 	if Enabled() {
@@ -163,7 +163,7 @@ func Unreachable() {
 }
 
 // UnreachableExceptTests marks code that should be unreachable
-// when BoringCrypto is in use. It panics.
+// when FIPS mode is active. It panics.
 func UnreachableExceptTests() {
 	name := os.Args[0]
 	if Enabled() && !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -153,6 +153,25 @@ func NewOpenSSLError(msg string) error {
 	return errors.New(message)
 }
 
+// Unreachable marks code that should be unreachable
+// when BoringCrypto is in use. It panics only when
+// the system is in FIPS mode.
+func Unreachable() {
+	if Enabled() {
+		panic("openssl: invalid code execution")
+	}
+}
+
+// UnreachableExceptTests marks code that should be unreachable
+// when BoringCrypto is in use. It panics.
+func UnreachableExceptTests() {
+	name := os.Args[0]
+	if Enabled() && !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
+		println("openssl: unexpected code execution in", name)
+		panic("openssl: invalid code execution")
+	}
+}
+
 type fail string
 
 func (e fail) Error() string { return "boringcrypto: " + string(e) + " failed" }


### PR DESCRIPTION
Adding these functions back in because they will be used by Go once we
patch this package in in place of the boring package.