### PR TITLE
goopenssl.h: fix wrapper definitions to be compatible with OpenSSL headers

### DIFF
--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -237,8 +237,6 @@ _goboringcrypto_EVP_md5_sha1(void) {
 
 typedef HMAC_CTX GO_HMAC_CTX;
 
-DEFINEFUNC(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))
-DEFINEFUNC(void, HMAC_CTX_cleanup, (GO_HMAC_CTX * arg0), (arg0))
 DEFINEFUNC(int, HMAC_Init_ex,
 		   (GO_HMAC_CTX * arg0, const void *arg1, int arg2, const GO_EVP_MD *arg3, ENGINE *arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
@@ -246,18 +244,18 @@ DEFINEFUNC(int, HMAC_Update, (GO_HMAC_CTX * arg0, const uint8_t *arg1, size_t ar
 DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX * arg0, uint8_t *arg1, unsigned int *arg2), (arg0, arg1, arg2))
 DEFINEFUNC(size_t, HMAC_CTX_copy, (GO_HMAC_CTX *dest, GO_HMAC_CTX *src), (dest, src))
 
-DEFINEFUNCINTERNAL(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNCINTERNAL(void, HMAC_CTX_cleanup, (GO_HMAC_CTX * arg0), (arg0))
 static inline void
 _goboringcrypto_HMAC_CTX_free(HMAC_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
    if (ctx != NULL) {
        _goboringcrypto_HMAC_CTX_cleanup(ctx);
        free(ctx);
    }
-#else
-	_goboringcrypto_internal_HMAC_CTX_free(ctx);
-#endif
 }
+#else
+DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
+#endif
 
 DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
 DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
@@ -276,29 +274,27 @@ _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 #endif
 }
 
-DEFINEFUNCINTERNAL(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))
 static inline GO_HMAC_CTX*
 _goboringcrypto_HMAC_CTX_new(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	GO_HMAC_CTX* ctx = malloc(sizeof(GO_HMAC_CTX));
 	if (ctx != NULL)
-		_goboringcrypto_HMAC_CTX_init(ctx);
+		_goboringcrypto_internal_HMAC_CTX_init(ctx);
 	return ctx;
-#else
-	return _goboringcrypto_internal_HMAC_CTX_new();
-#endif
 }
+#else
+DEFINEFUNC(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
+#endif
 
-DEFINEFUNCINTERNAL(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline void
 _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX* ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	_goboringcrypto_HMAC_CTX_cleanup(ctx);
 	_goboringcrypto_HMAC_CTX_init(ctx);
 #else
-	_goboringcrypto_internal_HMAC_CTX_reset(ctx);
+DEFINEFUNC(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
 #endif
-}
 
 int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest, const GO_HMAC_CTX *src);
 

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -153,7 +153,7 @@ static inline int _goboringcrypto_FIPS_mode(void) {
 #include <openssl/rand.h>
 
 DEFINEFUNC(int, RAND_set_rand_method, (const RAND_METHOD *rand), (rand))
-DEFINEFUNC(RAND_METHOD*, RAND_get_rand_method, (void), ())
+DEFINEFUNC(const RAND_METHOD*, RAND_get_rand_method, (void), ())
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1))
 
 int _goboringcrypto_stub_openssl_rand(void);
@@ -277,7 +277,7 @@ _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 	return _goboringcrypto_internal_EVP_MD_size(arg0->md);
 }
 #else
-DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
+DEFINEFUNCINTERNAL(const EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
 # if OPENSSL_VERSION_NUMBER < 0x30000000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -89,10 +89,24 @@ _goboringcrypto_OPENSSL_setup(void) {
 
 #include <openssl/err.h>
 DEFINEFUNCINTERNAL(void, ERR_print_errors_fp, (FILE* fp), (fp))
-DEFINEFUNCINTERNAL(unsigned long, ERR_get_error, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+DEFINEFUNCINTERNAL(unsigned long, ERR_get_error_line_data,
+		   (const char **file, int *line, const char **data, int *flags),
+		   (file, line, data, flags))
+static inline unsigned long
+_goboringcrypto_internal_ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags)
+{
+	unsigned long e = _goboringcrypto_internal_ERR_get_error_line_data(file, line, data, flags);
+	if (e == 0 && func != NULL) {
+		*func = "unknown";
+	}
+	return e;
+}
+#else
 DEFINEFUNCINTERNAL(unsigned long, ERR_get_error_all,
 		(const char **file, int *line, const char **func, const char **data, int *flags),
 		(file, line, func, data, flags))
+#endif
 DEFINEFUNCINTERNAL(void, ERR_error_string_n, (unsigned long e, unsigned char *buf, size_t len), (e, buf, len))
 
 #include <openssl/crypto.h>

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -257,22 +257,30 @@ _goboringcrypto_HMAC_CTX_free(HMAC_CTX *ctx) {
 DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
 #endif
 
-DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
-DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	return _goboringcrypto_internal_EVP_MD_size(arg0->md);
-#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
-	const EVP_MD* md;
-	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
-	return _goboringcrypto_internal_EVP_MD_get_size(md);
+}
 #else
+DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
+# if OPENSSL_VERSION_NUMBER < 0x30000000L
+static inline size_t
+_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 	const EVP_MD* md;
 	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
 	return _goboringcrypto_internal_EVP_MD_size(md);
-#endif
 }
+# else
+DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
+static inline size_t
+_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
+	const EVP_MD* md;
+	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
+	return _goboringcrypto_internal_EVP_MD_get_size(md);
+}
+# endif
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -76,7 +76,7 @@ _goboringcrypto_DLOPEN_OPENSSL(void)
 #include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 
-DEFINEFUNCINTERNAL(int, OPENSSL_init, (void), ())
+DEFINEFUNCINTERNAL(void, OPENSSL_init, (void), ())
 
 static unsigned long _goboringcrypto_internal_OPENSSL_VERSION_NUMBER(void) {
 	return OPENSSL_VERSION_NUMBER;

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -296,12 +296,14 @@ DEFINEFUNC(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-static inline void
+static inline int
 _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX* ctx) {
 	_goboringcrypto_HMAC_CTX_cleanup(ctx);
 	_goboringcrypto_HMAC_CTX_init(ctx);
+	return 0;
+}
 #else
-DEFINEFUNC(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
+DEFINEFUNC(int, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
 #endif
 
 int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest, const GO_HMAC_CTX *src);
@@ -409,16 +411,14 @@ DEFINEFUNCINTERNAL(int, ECDSA_verify,
 	(int type, const unsigned char *dgst, size_t dgstlen, const unsigned char *sig, unsigned int siglen, EC_KEY *eckey),
 	(type, dgst, dgstlen, sig, siglen, eckey))
 
-DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_new, (void), ())
-DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_create, (void), ())
-
-static inline EVP_MD_CTX* _goboringcrypto_EVP_MD_CTX_create(void) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_EVP_MD_CTX_create();
+DEFINEFUNC(EVP_MD_CTX*, EVP_MD_CTX_create, (void), ())
 #else
+DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_new, (void), ())
+static inline EVP_MD_CTX* _goboringcrypto_EVP_MD_CTX_create(void) {
 	return _goboringcrypto_internal_EVP_MD_CTX_new();
-#endif
 }
+#endif
 
 DEFINEFUNCINTERNAL(int, EVP_PKEY_assign,
 	(EVP_PKEY *pkey, int type, void *eckey),
@@ -455,15 +455,14 @@ DEFINEFUNC(int, EVP_DigestVerifyFinal,
 int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, EVP_PKEY *eckey);
 int _goboringcrypto_EVP_verify(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, const uint8_t *sig, unsigned int slen, EVP_PKEY *key);
 
-DEFINEFUNCINTERNAL(void, EVP_MD_CTX_free, (EVP_MD_CTX *ctx), (ctx))
-DEFINEFUNCINTERNAL(void, EVP_MD_CTX_destroy, (EVP_MD_CTX *ctx), (ctx))
-static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_EVP_MD_CTX_destroy(ctx);
+DEFINEFUNC(void, EVP_MD_CTX_destroy, (EVP_MD_CTX *ctx), (ctx))
 #else
+DEFINEFUNCINTERNAL(void, EVP_MD_CTX_free, (EVP_MD_CTX *ctx), (ctx))
+static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 	return _goboringcrypto_internal_EVP_MD_CTX_free(ctx);
-#endif
 }
+#endif
 
 int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, unsigned int *arg4, GO_EC_KEY *arg5);
 int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, const uint8_t *arg3, unsigned int arg4, GO_EC_KEY *arg5);

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -97,35 +97,32 @@ DEFINEFUNCINTERNAL(void, ERR_error_string_n, (unsigned long e, unsigned char *bu
 
 #include <openssl/crypto.h>
 
-DEFINEFUNCINTERNAL(int, CRYPTO_num_locks, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(int, CRYPTO_num_locks, (void), ())
+#else
 static inline int
 _goboringcrypto_CRYPTO_num_locks(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_CRYPTO_num_locks();
-#else
-	return CRYPTO_num_locks();
-#endif
+	return CRYPTO_num_locks(); /* defined as macro */
 }
-DEFINEFUNCINTERNAL(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function))
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function))
+#else
 static inline void
 _goboringcrypto_CRYPTO_set_id_callback(unsigned long (*id_function)(void)) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	_goboringcrypto_internal_CRYPTO_set_id_callback(id_function);
-#else
-	CRYPTO_set_id_callback(id_function);
-#endif
+	CRYPTO_set_id_callback(id_function); /* defined as macro */
 }
-DEFINEFUNCINTERNAL(void, CRYPTO_set_locking_callback,
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(void, CRYPTO_set_locking_callback,
 	(void (*locking_function)(int mode, int n, const char *file, int line)), 
 	(locking_function))
+#else
 static inline void
 _goboringcrypto_CRYPTO_set_locking_callback(void (*locking_function)(int mode, int n, const char *file, int line)) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	_goboringcrypto_internal_CRYPTO_set_locking_callback(locking_function);
-#else
-	CRYPTO_set_locking_callback(locking_function);
-#endif
+	CRYPTO_set_locking_callback(locking_function); /* defined as macro */
 }
+#endif
 
 int _goboringcrypto_OPENSSL_thread_setup(void);
 

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -124,31 +124,19 @@ func PanicIfStrictFIPS(msg string) {
 func NewOpenSSLError(msg string) error {
 	var e C.ulong
 	message := fmt.Sprintf("\n%v\nopenssl error(s):", msg)
-	if openSSLVersion() >= OPENSSL_VERSION_3_0_0 {
-		for {
-			var buf [256]C.char
-			var file, fnc, data *C.char
-			var line, flags C.int
-			e = C._goboringcrypto_internal_ERR_get_error_all(&file, &line, &fnc, &data, &flags)
-			if e == 0 {
-				break
-			}
+	for {
+		var buf [256]C.char
+		var file, fnc, data *C.char
+		var line, flags C.int
+		e = C._goboringcrypto_internal_ERR_get_error_all(&file, &line, &fnc, &data, &flags)
+		if e == 0 {
+			break
+		}
 
-			C._goboringcrypto_internal_ERR_error_string_n(e, (*C.uchar)(unsafe.Pointer(&buf[0])), 256)
-			message = fmt.Sprintf(
-				"%v\nfile: %v\nline: %v\nfunction: %v\nflags: %v\nerror string: %s\n",
-				message, C.GoString(file), line, C.GoString(fnc), flags, C.GoString(&(buf[0])))
-		}
-	} else {
-		for {
-			var buf [256]C.char
-			e = C._goboringcrypto_internal_ERR_get_error()
-			C._goboringcrypto_internal_ERR_error_string_n(e, (*C.uchar)(unsafe.Pointer(&buf[0])), 256)
-			if e == 0 {
-				break
-			}
-			message = fmt.Sprintf("%v: %v\n", message, buf)
-		}
+		C._goboringcrypto_internal_ERR_error_string_n(e, (*C.uchar)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+		message = fmt.Sprintf(
+			"%v\nfile: %v\nline: %v\nfunction: %v\nflags: %v\nerror string: %s\n",
+			message, C.GoString(file), line, C.GoString(fnc), flags, C.GoString(&(buf[0])))
 	}
 	return errors.New(message)
 }


### PR DESCRIPTION
This transplants https://github.com/golang-fips/go/pull/10 except the last commit fixing `size_t` confusion for review easiness.