### PR TITLE
Add new symbols for go1.19 compat

### DIFF
--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -210,3 +210,29 @@ func bigToBn(bnp **C.GO_BIGNUM, b *big.Int) bool {
 	*bnp = bn
 	return true
 }
+
+// noescape hides a pointer from escape analysis.  noescape is
+// the identity function but escape analysis doesn't think the
+// output depends on the input.  noescape is inlined and currently
+// compiles down to zero instructions.
+// USE CAREFULLY!
+//
+//go:nosplit
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
+}
+
+var zero byte
+
+// addr converts p to its base addr, including a noescape along the way.
+// If p is nil, addr returns a non-nil pointer, so that the result can always
+// be dereferenced.
+//
+//go:nosplit
+func addr(p []byte) *byte {
+	if len(p) == 0 {
+		return &zero
+	}
+	return (*byte)(noescape(unsafe.Pointer(&p[0])))
+}


### PR DESCRIPTION
When boring was merged into the main branch for go1.19
a few new symbols were added. Adding them into this
repo in order to create our Go 1.19 branch.