### PR TITLE
Add Go 1.19 support

### DIFF
--- a/openssl/aes.go
+++ b/openssl/aes.go
@@ -363,6 +363,12 @@ func (c *aesCipher) NewGCM(nonceSize, tagSize int) (cipher.AEAD, error) {
 	return c.newGCM(false)
 }
 
+// NewGCMTLS returns a GCM cipher specific to TLS
+// and should not be used for non-TLS purposes.
+func NewGCMTLS(c cipher.Block) (cipher.AEAD, error) {
+	return c.(*aesCipher).NewGCMTLS()
+}
+
 func (c *aesCipher) NewGCMTLS() (cipher.AEAD, error) {
 	return c.newGCM(true)
 }

--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This is a mirror of crypto/internal/boring/bbig/big.go.
+
+package bbig
+
+import (
+	"math/big"
+	"unsafe"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+)
+
+func Enc(b *big.Int) openssl.BigInt {
+	if b == nil {
+		return nil
+	}
+	x := b.Bits()
+	if len(x) == 0 {
+		return openssl.BigInt{}
+	}
+	// TODO: Use unsafe.Slice((*uint)(&x[0]), len(x)) once go1.16 is no longer supported.
+	return (*(*[]uint)(unsafe.Pointer(&x)))[:len(x)]
+}
+
+func Dec(b openssl.BigInt) *big.Int {
+	if b == nil {
+		return nil
+	}
+	if len(b) == 0 {
+		return new(big.Int)
+	}
+	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
+	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
+	return new(big.Int).SetBits(x)
+}

--- a/openssl/doc.go
+++ b/openssl/doc.go
@@ -10,3 +10,8 @@ package openssl
 func Enabled() bool {
 	return enabled
 }
+
+// A BigInt is the raw words from a BigInt.
+// This definition allows us to avoid importing math/big.
+// Conversion between BigInt and *big.Int is in crypto/internal/boring/bbig.
+type BigInt []uint

--- a/openssl/ecdh_test.go
+++ b/openssl/ecdh_test.go
@@ -1,13 +1,15 @@
-package openssl
+package openssl_test
 
 import (
 	"bytes"
+	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl-fips/openssl/bbig"
 	"math/big"
 	"testing"
 )
 
 func TestSharedKeyECDH(t *testing.T) {
-	if !Enabled() {
+	if !openssl.Enabled() {
 		t.Skip("boringcrypto: skipping test, FIPS not enabled")
 	}
 	// Test vector from CAVS
@@ -53,12 +55,14 @@ func TestSharedKeyECDH(t *testing.T) {
 		0x04, 0x0d, 0xd7, 0x77, 0x89, 0x97, 0xbd, 0x7b,
 	}
 
-	priv, err := NewPrivateKeyECDH("P-256", x, y, k)
+	bx, by, bk := bbig.Enc(x), bbig.Enc(y), bbig.Enc(k)
+
+	priv, err := openssl.NewPrivateKeyECDH("P-256", bx, by, bk)
 	if err != nil {
 		t.Log("NewPrivateKeyECDH failed", err)
 		t.Fail()
 	}
-	derived, err := SharedKeyECDH(priv, peerPublicKey)
+	derived, err := openssl.SharedKeyECDH(priv, peerPublicKey)
 	if err != nil {
 		t.Log("SharedKeyECDH failed", err)
 		t.Fail()

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -10,16 +10,13 @@ package openssl
 // #include "goopenssl.h"
 import "C"
 import (
-	"crypto"
-	"encoding/asn1"
 	"errors"
-	"math/big"
 	"runtime"
 	"unsafe"
 )
 
 type ecdsaSignature struct {
-	R, S *big.Int
+	R, S BigInt
 }
 
 type PrivateKeyECDSA struct {
@@ -58,7 +55,7 @@ func curveNID(curve string) (C.int, error) {
 	return 0, errUnknownCurve
 }
 
-func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
+func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
 	key, err := newECKey(curve, X, Y)
 	if err != nil {
 		return nil, err
@@ -72,7 +69,7 @@ func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
 	return k, nil
 }
 
-func newECKey(curve string, X, Y *big.Int) (*C.GO_EC_KEY, error) {
+func newECKey(curve string, X, Y BigInt) (*C.GO_EC_KEY, error) {
 	nid, err := curveNID(curve)
 	if err != nil {
 		return nil, err
@@ -105,7 +102,7 @@ func newECKey(curve string, X, Y *big.Int) (*C.GO_EC_KEY, error) {
 	return key, nil
 }
 
-func NewPrivateKeyECDSA(curve string, X, Y *big.Int, D *big.Int) (*PrivateKeyECDSA, error) {
+func NewPrivateKeyECDSA(curve string, X, Y BigInt, D BigInt) (*PrivateKeyECDSA, error) {
 	key, err := newECKey(curve, X, Y)
 	if err != nil {
 		return nil, err
@@ -128,67 +125,25 @@ func NewPrivateKeyECDSA(curve string, X, Y *big.Int, D *big.Int) (*PrivateKeyECD
 	return k, nil
 }
 
-func SignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (r, s *big.Int, err error) {
-	// We could use ECDSA_do_sign instead but would need to convert
-	// the resulting BIGNUMs to *big.Int form. If we're going to do a
-	// conversion, converting the ASN.1 form is more convenient and
-	// likely not much more expensive.
-	sig, err := SignMarshalECDSA(priv, hash, h)
-	if err != nil {
-		return nil, nil, err
-	}
-	var esig ecdsaSignature
-	if _, err := asn1.Unmarshal(sig, &esig); err != nil {
-		return nil, nil, err
-	}
-	return esig.R, esig.S, nil
-}
-
-func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) ([]byte, error) {
+func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
 	size := C._goboringcrypto_ECDSA_size(priv.key)
 	sig := make([]byte, size)
 	var sigLen C.uint
-	if h == crypto.Hash(0) {
-		ok := C._goboringcrypto_internal_ECDSA_sign(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), &sigLen, priv.key) > 0
-		if !ok {
-			return nil, NewOpenSSLError(("ECDSA_sign failed"))
-		}
-	} else {
-		md := cryptoHashToMD(h)
-		if md == nil {
-			panic("boring: invalid hash")
-		}
-		if C._goboringcrypto_ECDSA_sign(md, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), &sigLen, priv.key) == 0 {
-			return nil, NewOpenSSLError("ECDSA_sign failed")
-		}
+	ok := C._goboringcrypto_internal_ECDSA_sign(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), &sigLen, priv.key) > 0
+	if !ok {
+		return nil, NewOpenSSLError(("ECDSA_sign failed"))
 	}
+
 	runtime.KeepAlive(priv)
 	return sig[:sigLen], nil
 }
-
-func VerifyECDSA(pub *PublicKeyECDSA, msg []byte, r, s *big.Int, h crypto.Hash) bool {
-	// We could use ECDSA_do_verify instead but would need to convert
-	// r and s to BIGNUM form. If we're going to do a conversion, marshaling
-	// to ASN.1 is more convenient and likely not much more expensive.
-	sig, err := asn1.Marshal(ecdsaSignature{r, s})
-	if err != nil {
-		return false
-	}
-	if h == crypto.Hash(0) {
-		ok := C._goboringcrypto_internal_ECDSA_verify(0, base(msg), C.size_t(len(msg)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
-		runtime.KeepAlive(pub)
-		return ok
-	}
-	md := cryptoHashToMD(h)
-	if md == nil {
-		panic("boring: invalid hash")
-	}
-	ok := C._goboringcrypto_ECDSA_verify(md, base(msg), C.size_t(len(msg)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
+func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
+	ok := C._goboringcrypto_internal_ECDSA_verify(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
 	runtime.KeepAlive(pub)
 	return ok
 }
 
-func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
+func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	nid, err := curveNID(curve)
 	if err != nil {
 		return nil, nil, nil, err

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -369,9 +369,8 @@ DEFINEFUNC(int, BN_set_word, (BIGNUM *a, BN_ULONG w), (a, w))
 DEFINEFUNC(unsigned int, BN_num_bits, (const GO_BIGNUM *arg0), (arg0))
 DEFINEFUNC(int, BN_is_negative, (const GO_BIGNUM *arg0), (arg0))
 DEFINEFUNC(GO_BIGNUM *, BN_bin2bn, (const uint8_t *arg0, size_t arg1, GO_BIGNUM *arg2), (arg0, arg1, arg2))
-DEFINEFUNC(int, BN_bn2le_padded, (uint8_t *out, size_t len, const BIGNUM *in), (out, len, in))
-DEFINEFUNC(GO_BIGNUM *, BN_le2bn, (const uint8_t *in, size_t len, BIGNUM *ret), (in, len, ret))
-DEFINEFUNC(size_t, BN_bn2bin, (const GO_BIGNUM *arg0, uint8_t *arg1), (arg0, arg1))
+DEFINEFUNC(GO_BIGNUM *, BN_lebin2bn, (const unsigned char *s, size_t len, BIGNUM *ret), (s, len, ret))
+DEFINEFUNC(int, BN_bn2lebinpad, (const BIGNUM *a, unsigned char *to, size_t tolen), (a, to, tolen))
 
 static inline unsigned int
 _goboringcrypto_BN_num_bytes(const GO_BIGNUM* a) {

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -369,6 +369,8 @@ DEFINEFUNC(int, BN_set_word, (BIGNUM *a, BN_ULONG w), (a, w))
 DEFINEFUNC(unsigned int, BN_num_bits, (const GO_BIGNUM *arg0), (arg0))
 DEFINEFUNC(int, BN_is_negative, (const GO_BIGNUM *arg0), (arg0))
 DEFINEFUNC(GO_BIGNUM *, BN_bin2bn, (const uint8_t *arg0, size_t arg1, GO_BIGNUM *arg2), (arg0, arg1, arg2))
+DEFINEFUNC(int, BN_bn2le_padded, (uint8_t *out, size_t len, const BIGNUM *in), (out, len, in))
+DEFINEFUNC(GO_BIGNUM *, BN_le2bn, (const uint8_t *in, size_t len, BIGNUM *ret), (in, len, ret))
 DEFINEFUNC(size_t, BN_bn2bin, (const GO_BIGNUM *arg0, uint8_t *arg1), (arg0, arg1))
 
 static inline unsigned int

--- a/openssl/notboring.go
+++ b/openssl/notboring.go
@@ -10,8 +10,8 @@ package openssl
 import (
 	"crypto"
 	"crypto/cipher"
-	"crypto/internal/boring/sig"
 	"hash"
+	"io"
 )
 
 var enabled = false
@@ -19,10 +19,6 @@ var enabled = false
 // Unreachable marks code that should be unreachable
 // when BoringCrypto is in use. It is a no-op without BoringCrypto.
 func Unreachable() {
-	// Code that's unreachable when using BoringCrypto
-	// is exactly the code we want to detect for reporting
-	// standard Go crypto.
-	sig.StandardCrypto()
 }
 
 // UnreachableExceptTests marks code that should be unreachable

--- a/openssl/notboring.go
+++ b/openssl/notboring.go
@@ -12,8 +12,6 @@ import (
 	"crypto/cipher"
 	"crypto/internal/boring/sig"
 	"hash"
-	"io"
-	"math/big"
 )
 
 var enabled = false
@@ -55,35 +53,35 @@ func NewAESCipher(key []byte) (cipher.Block, error) { panic("boringcrypto: not a
 type PublicKeyECDSA struct{ _ int }
 type PrivateKeyECDSA struct{ _ int }
 
-func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
+func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	panic("boringcrypto: not available")
 }
-func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*PrivateKeyECDSA, error) {
+func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error) {
 	panic("boringcrypto: not available")
 }
-func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
+func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
 	panic("boringcrypto: not available")
 }
-func SignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (r, s *big.Int, err error) {
+func SignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (r, s BigInt, err error) {
 	panic("boringcrypto: not available")
 }
 func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) ([]byte, error) {
 	panic("boringcrypto: not available")
 }
-func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s *big.Int, h crypto.Hash) bool {
+func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s BigInt, h crypto.Hash) bool {
 	panic("boringcrypto: not available")
 }
 
 type PublicKeyECDH struct{ _ int }
 type PrivateKeyECDH struct{ _ int }
 
-func GenerateKeyECDH(curve string) (X, Y, D *big.Int, err error) {
+func GenerateKeyECDH(curve string) (X, Y, D BigInt, err error) {
 	panic("boringcrypto: not available")
 }
-func NewPrivateKeyECDH(curve string, X, Y, D *big.Int) (*PrivateKeyECDH, error) {
+func NewPrivateKeyECDH(curve string, X, Y, D BigInt) (*PrivateKeyECDH, error) {
 	panic("boringcrypto: not available")
 }
-func NewPublicKeyECDH(curve string, X, Y *big.Int) (*PublicKeyECDH, error) {
+func NewPublicKeyECDH(curve string, X, Y BigInt) (*PublicKeyECDH, error) {
 	panic("boringcrypto: not available")
 }
 func SharedKeyECDH(priv *PrivateKeyECDH, peerPublicKey []byte) ([]byte, error) {
@@ -111,13 +109,13 @@ func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 	panic("boringcrypto: not available")
 }
-func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	panic("boringcrypto: not available")
 }
-func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, error) {
+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error) {
 	panic("boringcrypto: not available")
 }
-func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) { panic("boringcrypto: not available") }
+func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) { panic("boringcrypto: not available") }
 func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, msgHashed bool) ([]byte, error) {
 	panic("boringcrypto: not available")
 }

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -193,12 +193,12 @@ func wbase(b BigInt) *C.uint8_t {
 const wordBytes = bits.UintSize / 8
 
 func bigToBN(x BigInt) *C.GO_BIGNUM {
-	return C._goboringcrypto_BN_le2bn(wbase(x), C.size_t(len(x)*wordBytes), nil)
+	return C._goboringcrypto_BN_lebin2bn(wbase(x), C.size_t(len(x)*wordBytes), nil)
 }
 
 func bnToBig(bn *C.GO_BIGNUM) BigInt {
 	x := make(BigInt, (C._goboringcrypto_BN_num_bytes(bn)+wordBytes-1)/wordBytes)
-	if C._goboringcrypto_BN_bn2le_padded(wbase(x), C.size_t(len(x)*wordBytes), bn) == 0 {
+	if C._goboringcrypto_BN_bn2lebinpad(bn, wbase(x), C.size_t(len(x)*wordBytes)) == 0 {
 		panic("boringcrypto: bignum conversion failed")
 	}
 	return x

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -13,14 +13,13 @@ import (
 	"crypto"
 	"errors"
 	"hash"
-	"math/big"
 	"runtime"
 	"strconv"
 	"unsafe"
 )
 
-func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
-	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
+	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		return nil, nil, nil, nil, nil, nil, nil, nil, e
 	}
 
@@ -46,7 +45,7 @@ type PublicKeyRSA struct {
 	_key *C.GO_RSA
 }
 
-func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
+func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
 	key := C._goboringcrypto_RSA_new()
 	if key == nil {
 		return nil, NewOpenSSLError("RSA_new failed")
@@ -77,7 +76,7 @@ type PrivateKeyRSA struct {
 	_key *C.GO_RSA
 }
 
-func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, error) {
+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error) {
 	key := C._goboringcrypto_RSA_new()
 	if key == nil {
 		return nil, NewOpenSSLError("RSA_new failed")


### PR DESCRIPTION
There are more changes necessary to support Go 1.19 and many of them are backwards incompatible as there are function signature changes. This patch introduces a series of changes to support Go 1.19 but will not be backwards compatible with older versions.

This is acceptable because we only intend to support Go 1.19+ using this particular architecture.