### PR TITLE
Implement FIPS() and SetFIPS()

### DIFF
--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -11,14 +11,18 @@
 
 #define DEFINEFUNC(ret, func, args, argscall)                  ret (*_g_##func)args;
 #define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)       DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_3_0(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
 
 FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
 #undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 
 
@@ -41,8 +45,18 @@ go_openssl_load_functions(void* handle, int major, int minor)
     {                                                     \
         DEFINEFUNC_INTERNAL(func, #func)                  \
     }
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)  \
+    if (major == 1)                                     \
+    {                                                   \
+        DEFINEFUNC_INTERNAL(func, #func)                \
+    }
 #define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     if (major == 3 || (major == 1 && minor == 1))     \
+    {                                                 \
+        DEFINEFUNC_INTERNAL(func, #func)              \
+    }
+#define DEFINEFUNC_3_0(ret, func, args, argscall)     \
+    if (major == 3)                                   \
     {                                                 \
         DEFINEFUNC_INTERNAL(func, #func)              \
     }
@@ -60,7 +74,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
 #undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 }
 

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -21,7 +21,11 @@ void go_openssl_load_functions(void* handle, int major, int minor);
     }
 #define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)    \
     DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)  \
+    DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)   \
+    DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_3_0(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
@@ -30,5 +34,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 
 #undef DEFINEFUNC
 #undef DEFINEFUNC_LEGACY_1_0
+#undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -113,7 +113,7 @@ func SetFIPS(enabled bool) error {
 			mode = C.int(0)
 		}
 		if C.go_openssl_FIPS_mode_set(mode) != 1 {
-			return fail("openssl: FIPS_mode_set")
+			return fail("FIPS_mode_set")
 		}
 		return nil
 	case 3:
@@ -129,7 +129,7 @@ func SetFIPS(enabled bool) error {
 		if !providerAvailable(props) {
 			// If not, fallback to provName provider.
 			if C.go_openssl_OSSL_PROVIDER_load(nil, provName) == nil {
-				return fail("openssl: OSSL_PROVIDER_try_load")
+				return fail("OSSL_PROVIDER_try_load")
 			}
 			// Make sure we now have a provider available.
 			if !providerAvailable(props) {
@@ -137,7 +137,7 @@ func SetFIPS(enabled bool) error {
 			}
 		}
 		if C.go_openssl_EVP_set_default_properties(nil, props) != 1 {
-			return fail("openssl: EVP_set_default_properties")
+			return fail("EVP_set_default_properties")
 		}
 		return nil
 	default:

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -54,3 +54,93 @@ func (e fail) Error() string { return "openssl: " + string(e) + " failed" }
 func VersionText() string {
 	return C.GoString(C.go_openssl_OpenSSL_version(0))
 }
+
+var (
+	providerNameFips    = C.CString("fips")
+	providerNameDefault = C.CString("default")
+	propFipsYes         = C.CString("fips=yes")
+	propFipsNo          = C.CString("fips=no")
+	algProve            = C.CString("SHA2-256")
+)
+
+// providerAvailable looks through provider's digests
+// checking if there is any that matches the props query.
+func providerAvailable(props *C.char) bool {
+	C.go_openssl_ERR_set_mark()
+	defer C.go_openssl_ERR_pop_to_mark()
+	md := C.go_openssl_EVP_MD_fetch(nil, algProve, props)
+	if md == nil {
+		return false
+	}
+	C.go_openssl_EVP_MD_free(md)
+	return true
+}
+
+// FIPS returns true if OpenSSL is running in FIPS mode, else returns false.
+func FIPS() bool {
+	switch vMajor {
+	case 1:
+		return C.go_openssl_FIPS_mode() == 1
+	case 3:
+		// If FIPS is not enabled via default properties, then we are sure FIPS is not used.
+		if C.go_openssl_EVP_default_properties_is_fips_enabled(nil) == 0 {
+			return false
+		}
+		// EVP_default_properties_is_fips_enabled can return true even if the FIPS provider isn't loaded,
+		// it is only based on the default properties.
+		// We can be sure that the FIPS provider is available if we can fetch an algorithm, e.g., SHA2-256,
+		// explictly setting `fips=yes`.
+		return providerAvailable(propFipsYes)
+	default:
+		panic(errUnsupportedVersion())
+	}
+}
+
+// SetFIPS enables or disables FIPS mode.
+//
+// It implements the following provider fallback logic for OpenSSL 3:
+//   - The "fips" provider is loaded if enabled=true and no loaded provider matches "fips=yes".
+//   - The "default" provider is loaded if enabled=false and no loaded provider matches "fips=no".
+//
+// This logic allows advanced users to define their own providers that match "fips=yes" and "fips=no" using the OpenSSL config file.
+func SetFIPS(enabled bool) error {
+	switch vMajor {
+	case 1:
+		var mode C.int
+		if enabled {
+			mode = C.int(1)
+		} else {
+			mode = C.int(0)
+		}
+		if C.go_openssl_FIPS_mode_set(mode) != 1 {
+			return fail("openssl: FIPS_mode_set")
+		}
+		return nil
+	case 3:
+		var props, provName *C.char
+		if enabled {
+			props = propFipsYes
+			provName = providerNameFips
+		} else {
+			props = propFipsNo
+			provName = providerNameDefault
+		}
+		// Check if there is any provider that matches props.
+		if !providerAvailable(props) {
+			// If not, fallback to provName provider.
+			if C.go_openssl_OSSL_PROVIDER_load(nil, provName) == nil {
+				return fail("openssl: OSSL_PROVIDER_try_load")
+			}
+			// Make sure we now have a provider available.
+			if !providerAvailable(props) {
+				return fail("SetFIPS(" + strconv.FormatBool(enabled) + ") not supported")
+			}
+		}
+		if C.go_openssl_EVP_set_default_properties(nil, props) != 1 {
+			return fail("openssl: EVP_set_default_properties")
+		}
+		return nil
+	default:
+		panic(errUnsupportedVersion())
+	}
+}

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -18,6 +18,8 @@ func TestMain(m *testing.M) {
 		// or that there is a bug in the Init code.
 		panic(err)
 	}
+	_ = openssl.SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
 	fmt.Println("OpenSSL version:", openssl.VersionText())
+	fmt.Println("FIPS enabled:", openssl.FIPS())
 	os.Exit(m.Run())
 }

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -10,6 +10,9 @@ enum {
 };
 
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
+typedef void* GO_OSSL_LIB_CTX_PTR;
+typedef void* GO_OSSL_PROVIDER_PTR;
+typedef void* GO_EVP_MD_PTR;
 
 // FOR_ALL_OPENSSL_FUNCTIONS is the list of all functions from libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -30,12 +33,21 @@ typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 // when using 1.0.x. This indicates the function is required when using 1.0.x, but is unused when using later versions.
 // It also might not exist in later versions.
 //
+// DEFINEFUNC_LEGACY_1 acts like DEFINEFUNC but only aborts the process if the function can't be loaded
+// when using 1.x. This indicates the function is required when using 1.x, but is unused when using later versions.
+// It also might not exist in later versions.
+//
 // DEFINEFUNC_1_1 acts like DEFINEFUNC but only aborts the process if function can't be loaded
 // when using 1.1.0 or higher.
+//
+// DEFINEFUNC_3_0 acts like DEFINEFUNC but only aborts the process if function can't be loaded
+// when using 3.0.0 or higher.
 //
 // DEFINEFUNC_RENAMED_1_1 acts like DEFINEFUNC but tries to load the function using the new name when using >= 1.1.x
 // and the old name when using 1.0.2. In both cases the function will have the new name.
 #define FOR_ALL_OPENSSL_FUNCTIONS \
+DEFINEFUNC(int, ERR_set_mark, (void), ()) \
+DEFINEFUNC(int, ERR_pop_to_mark, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(const char *, OpenSSL_version, SSLeay_version, (int type), (type)) \
 DEFINEFUNC(void, OPENSSL_init, (void), ()) \
 DEFINEFUNC_LEGACY_1_0(void, ERR_load_crypto_strings, (void), ()) \
@@ -44,4 +56,11 @@ DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_id_callback, (unsigned long (*id_function
 DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_locking_callback, (void (*locking_function)(int mode, int n, const char *file, int line)), (locking_function)) \
 DEFINEFUNC_LEGACY_1_0(void, OPENSSL_add_all_algorithms_conf, (void), ()) \
 DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const GO_OPENSSL_INIT_SETTINGS_PTR settings), (ops, settings)) \
+DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \
+DEFINEFUNC_LEGACY_1(int, FIPS_mode_set, (int r), (r)) \
+DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (GO_OSSL_LIB_CTX_PTR libctx), (libctx)) \
+DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, const char *propq), (libctx, propq)) \
+DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
+DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
+DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1))


### PR DESCRIPTION
This PR adds two new exported functions, `FIPS() bool` and `SetFIPS(enabled bool) error`, both ported from `microsoft/go-crypto-openssl`.

### func FIPS

`golang-fips/openssl-fips` also implements `FIPS()` in the unexported [fipsModeEnabled](https://github.com/golang-fips/openssl-fips/blob/60f04d7f65e2dacaaed870f38db900807caf37f0/openssl/openssl.go#L82). The problem is that ir relies on `FIPS_mode()`, which works on OpenSSL 1.x,  but has been removed from OpenSSL 3. RedHat could probably use it because their OpenSSL 3 binaries are patched to support this function, but we can't generally assume it will be there.

I've used instead a combination of tips explained in https://wiki.openssl.org/index.php/OpenSSL_3.0#Using_the_FIPS_Module_in_applications:
- First check [EVP_default_properties_is_fips_enabled()](https://www.openssl.org/docs/man3.0/man3/EVP_default_properties_enable_fips.html) == true
- Then check that `EVP_MD_fetch(NULL, "SHA2-256", "fips=yes")` succeed.

### func FIPS

On OpenSSL 1.x uses the good-old `FIPS_mode_set(1)`. On OpenSSL 3 it tries to load the FIPS provider, if not already loaded, and updates the default EVP properties to use FIPS.