### PR TITLE
Lower version requirement in go.mod to Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/golang-fips/openssl-fips
 
-go 1.18
+go 1.16


### PR DESCRIPTION
Users should be able to use older toolchain versions to bootstrap newer distributions. This change lowers the version requirement for the host compiler to Go 1.16.