### PR TITLE
Implement NewSHAX and one-shot SHAX

### DIFF
--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -1,0 +1,26 @@
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import "crypto"
+
+// cryptoHashToMD converts a crypto.Hash to a GO_EVP_MD_PTR.
+func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {
+	switch ch {
+	case crypto.MD5:
+		// TODO: not necessary yet
+	case crypto.MD5SHA1:
+		// TODO: not necessary yet
+	case crypto.SHA1:
+		return C.go_openssl_EVP_sha1()
+	case crypto.SHA224:
+		return C.go_openssl_EVP_sha224()
+	case crypto.SHA256:
+		return C.go_openssl_EVP_sha256()
+	case crypto.SHA384:
+		return C.go_openssl_EVP_sha384()
+	case crypto.SHA512:
+		return C.go_openssl_EVP_sha512()
+	}
+	return nil
+}

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -38,3 +38,17 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
+
+// go_shaX is a SHA generic wrapper which hash p into out.
+// One shot sha functions are expected to be fast, so
+// we maximize performance by batching all cgo calls.
+static inline int
+go_shaX(GO_EVP_MD_PTR md, void *p, size_t n, void *out)
+{
+    GO_EVP_MD_CTX_PTR ctx = go_openssl_EVP_MD_CTX_new();
+    go_openssl_EVP_DigestInit_ex(ctx, md, NULL);
+    int ret = go_openssl_EVP_DigestUpdate(ctx, p, n) &&
+        go_openssl_EVP_DigestFinal_ex(ctx, out, NULL);
+    go_openssl_EVP_MD_CTX_free(ctx);
+    return ret;
+}

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -43,7 +43,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 // One shot sha functions are expected to be fast, so
 // we maximize performance by batching all cgo calls.
 static inline int
-go_shaX(GO_EVP_MD_PTR md, void *p, size_t n, void *out)
+go_shaX(GO_EVP_MD_PTR md, const void *p, size_t n, void *out)
 {
     GO_EVP_MD_CTX_PTR ctx = go_openssl_EVP_MD_CTX_new();
     go_openssl_EVP_DigestInit_ex(ctx, md, NULL);

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"strconv"
 	"sync"
+	"unsafe"
 )
 
 var (
@@ -143,4 +144,39 @@ func SetFIPS(enabled bool) error {
 	default:
 		panic(errUnsupportedVersion())
 	}
+}
+
+// noescape hides a pointer from escape analysis. noescape is
+// the identity function but escape analysis doesn't think the
+// output depends on the input. noescape is inlined and currently
+// compiles down to zero instructions.
+// USE CAREFULLY!
+//
+//go:nosplit
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0)
+}
+
+var zero byte
+
+// addr converts p to its base addr, including a noescape along the way.
+// If p is nil, addr returns a non-nil pointer, so that the result can always
+// be dereferenced.
+//
+//go:nosplit
+func addr(p []byte) *byte {
+	if len(p) == 0 {
+		return &zero
+	}
+	return (*byte)(noescape(unsafe.Pointer(&p[0])))
+}
+
+// base returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
+func base(b []byte) *C.uchar {
+	if len(b) == 0 {
+		return nil
+	}
+	return (*C.uchar)(unsafe.Pointer(&b[0]))
 }

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -1,0 +1,578 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"crypto"
+	"errors"
+	"hash"
+	"runtime"
+	"strconv"
+	"unsafe"
+)
+
+// NOTE: Implementation ported from https://go-review.googlesource.com/c/go/+/404295.
+// The cgo calls in this file are arranged to avoid marking the parameters as escaping.
+// To do that, we call noescape (including via addr).
+// We must also make sure that the data pointer arguments have the form unsafe.Pointer(&...)
+// so that cgo does not annotate them with cgoCheckPointer calls. If it did that, it might look
+// beyond the byte slice and find Go pointers in unprocessed parts of a larger allocation.
+// To do both of these simultaneously, the idiom is unsafe.Pointer(&*addr(p)),
+// where addr returns the base pointer of p, substituting a non-nil pointer for nil,
+// and applying a noescape along the way.
+// This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
+
+func shaX(md C.GO_EVP_MD_PTR, p []byte, sum []byte) bool {
+	return C.go_shaX(md, unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum))) != 0
+}
+
+func SHA1(p []byte) (sum [20]byte) {
+	if !shaX(C.go_openssl_EVP_sha1(), p, sum[:]) {
+		panic("openssl: SHA1 failed")
+	}
+	return
+}
+
+func SHA224(p []byte) (sum [28]byte) {
+	if !shaX(C.go_openssl_EVP_sha224(), p, sum[:]) {
+		panic("openssl: SHA224 failed")
+	}
+	return
+}
+
+func SHA256(p []byte) (sum [32]byte) {
+	if !shaX(C.go_openssl_EVP_sha256(), p, sum[:]) {
+		panic("openssl: SHA256 failed")
+	}
+	return
+}
+
+func SHA384(p []byte) (sum [48]byte) {
+	if !shaX(C.go_openssl_EVP_sha384(), p, sum[:]) {
+		panic("openssl: SHA384 failed")
+	}
+	return
+}
+
+func SHA512(p []byte) (sum [64]byte) {
+	if !shaX(C.go_openssl_EVP_sha512(), p, sum[:]) {
+		panic("openssl: SHA512 failed")
+	}
+	return
+}
+
+// evpHash implements generic hash methods.
+type evpHash struct {
+	md  C.GO_EVP_MD_PTR
+	ctx C.GO_EVP_MD_CTX_PTR
+	// ctx2 is used in evpHash.sum to avoid changing
+	// the state of ctx. Having it here allows reusing the
+	// same allocated object multiple times.
+	ctx2      C.GO_EVP_MD_CTX_PTR
+	size      int
+	blockSize int
+}
+
+func newEvpHash(ch crypto.Hash, size, blockSize int) *evpHash {
+	md := cryptoHashToMD(ch)
+	if md == nil {
+		panic("openssl: unsupported hash function: " + strconv.Itoa(int(ch)))
+	}
+	ctx := C.go_openssl_EVP_MD_CTX_new()
+	ctx2 := C.go_openssl_EVP_MD_CTX_new()
+	h := &evpHash{
+		md:        md,
+		ctx:       ctx,
+		ctx2:      ctx2,
+		size:      size,
+		blockSize: blockSize,
+	}
+	runtime.SetFinalizer(h, (*evpHash).finalize)
+	h.Reset()
+	return h
+}
+
+func (h *evpHash) finalize() {
+	C.go_openssl_EVP_MD_CTX_free(h.ctx)
+	C.go_openssl_EVP_MD_CTX_free(h.ctx2)
+}
+
+func (h *evpHash) Reset() {
+	// There is no need to reset h.ctx2 because it is always reset after
+	// use in evpHash.sum.
+	if C.go_openssl_EVP_DigestInit(h.ctx, h.md) != 1 {
+		panic("openssl: EVP_DigestInit failed")
+	}
+	runtime.KeepAlive(h)
+}
+
+func (h *evpHash) Write(p []byte) (int, error) {
+	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&*addr(p)), C.size_t(len(p))) != 1 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	runtime.KeepAlive(h)
+	return len(p), nil
+}
+
+func (h *evpHash) Size() int {
+	return h.size
+}
+
+func (h *evpHash) BlockSize() int {
+	return h.blockSize
+}
+
+func (h *evpHash) sum(out []byte) {
+	// Make copy of context because Go hash.Hash mandates
+	// that Sum has no effect on the underlying stream.
+	// In particular it is OK to Sum, then Write more, then Sum again,
+	// and the second Sum acts as if the first didn't happen.
+	if C.go_openssl_EVP_MD_CTX_copy(h.ctx2, h.ctx) != 1 {
+		panic("openssl: EVP_MD_CTX_copy failed")
+	}
+	if C.go_openssl_EVP_DigestFinal(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
+		panic("openssl: EVP_DigestFinal failed")
+	}
+	runtime.KeepAlive(h)
+}
+
+// shaState returns a pointer to the internal sha structure.
+//
+// The EVP_MD_CTX memory layout has changed in OpenSSL 3
+// and the property holding the internal structure is no longer md_data but algctx.
+func (h *evpHash) shaState() unsafe.Pointer {
+	switch vMajor {
+	case 1:
+		// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/crypto/evp/evp_local.h#L12.
+		type mdCtx struct {
+			_       [2]unsafe.Pointer
+			_       C.ulong
+			md_data unsafe.Pointer
+		}
+		return (*mdCtx)(unsafe.Pointer(h.ctx)).md_data
+	case 3:
+		// https://github.com/openssl/openssl/blob/5675a5aaf6a2e489022bcfc18330dae9263e598e/crypto/evp/evp_local.h#L16.
+		type mdCtx struct {
+			_      [3]unsafe.Pointer
+			_      C.ulong
+			_      [3]unsafe.Pointer
+			algctx unsafe.Pointer
+		}
+		return (*mdCtx)(unsafe.Pointer(h.ctx)).algctx
+	default:
+		panic(errUnsupportedVersion())
+	}
+}
+
+// NewSHA1 returns a new SHA1 hash.
+func NewSHA1() hash.Hash {
+	return &sha1Hash{
+		evpHash: newEvpHash(crypto.SHA1, 20, 64),
+	}
+}
+
+type sha1Hash struct {
+	*evpHash
+	out [20]byte
+}
+
+func (h *sha1Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// sha1State layout is taken from
+// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/include/openssl/sha.h#L34.
+type sha1State struct {
+	h      [5]uint32
+	nl, nh uint32
+	x      [64]byte
+	nx     uint32
+}
+
+const (
+	sha1Magic         = "sha\x01"
+	sha1MarshaledSize = len(sha1Magic) + 5*4 + 64 + 8
+)
+
+func (h *sha1Hash) MarshalBinary() ([]byte, error) {
+	d := (*sha1State)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha1: can't retrieve hash state")
+	}
+	b := make([]byte, 0, sha1MarshaledSize)
+	b = append(b, sha1Magic...)
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
+	b = append(b, d.x[:d.nx]...)
+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return b, nil
+}
+
+func (h *sha1Hash) UnmarshalBinary(b []byte) error {
+	if len(b) < len(sha1Magic) || string(b[:len(sha1Magic)]) != sha1Magic {
+		return errors.New("crypto/sha1: invalid hash state identifier")
+	}
+	if len(b) != sha1MarshaledSize {
+		return errors.New("crypto/sha1: invalid hash state size")
+	}
+	d := (*sha1State)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha1: can't retrieve hash state")
+	}
+	b = b[len(sha1Magic):]
+	b, d.h[0] = consumeUint32(b)
+	b, d.h[1] = consumeUint32(b)
+	b, d.h[2] = consumeUint32(b)
+	b, d.h[3] = consumeUint32(b)
+	b, d.h[4] = consumeUint32(b)
+	b = b[copy(d.x[:], b):]
+	_, n := consumeUint64(b)
+	d.nl = uint32(n << 3)
+	d.nh = uint32(n >> 29)
+	d.nx = uint32(n) % 64
+	return nil
+}
+
+// NewSHA224 returns a new SHA224 hash.
+func NewSHA224() hash.Hash {
+	return &sha224Hash{
+		evpHash: newEvpHash(crypto.SHA224, 224/8, 64),
+	}
+}
+
+type sha224Hash struct {
+	*evpHash
+	out [224 / 8]byte
+}
+
+func (h *sha224Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// NewSHA256 returns a new SHA256 hash.
+func NewSHA256() hash.Hash {
+	return &sha256Hash{
+		evpHash: newEvpHash(crypto.SHA256, 256/8, 64),
+	}
+}
+
+type sha256Hash struct {
+	*evpHash
+	out [256 / 8]byte
+}
+
+func (h *sha256Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+const (
+	magic224         = "sha\x02"
+	magic256         = "sha\x03"
+	marshaledSize256 = len(magic256) + 8*4 + 64 + 8
+)
+
+// sha256State layout is taken from
+// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/include/openssl/sha.h#L51.
+type sha256State struct {
+	h      [8]uint32
+	nl, nh uint32
+	x      [64]byte
+	nx     uint32
+}
+
+func (h *sha224Hash) MarshalBinary() ([]byte, error) {
+	d := (*sha256State)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
+	}
+	b := make([]byte, 0, marshaledSize256)
+	b = append(b, magic224...)
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
+	b = appendUint32(b, d.h[5])
+	b = appendUint32(b, d.h[6])
+	b = appendUint32(b, d.h[7])
+	b = append(b, d.x[:d.nx]...)
+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return b, nil
+}
+
+func (h *sha256Hash) MarshalBinary() ([]byte, error) {
+	d := (*sha256State)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
+	}
+	b := make([]byte, 0, marshaledSize256)
+	b = append(b, magic256...)
+	b = appendUint32(b, d.h[0])
+	b = appendUint32(b, d.h[1])
+	b = appendUint32(b, d.h[2])
+	b = appendUint32(b, d.h[3])
+	b = appendUint32(b, d.h[4])
+	b = appendUint32(b, d.h[5])
+	b = appendUint32(b, d.h[6])
+	b = appendUint32(b, d.h[7])
+	b = append(b, d.x[:d.nx]...)
+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return b, nil
+}
+
+func (h *sha224Hash) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic224) || string(b[:len(magic224)]) != magic224 {
+		return errors.New("crypto/sha256: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize256 {
+		return errors.New("crypto/sha256: invalid hash state size")
+	}
+	d := (*sha256State)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha256: can't retrieve hash state")
+	}
+	b = b[len(magic224):]
+	b, d.h[0] = consumeUint32(b)
+	b, d.h[1] = consumeUint32(b)
+	b, d.h[2] = consumeUint32(b)
+	b, d.h[3] = consumeUint32(b)
+	b, d.h[4] = consumeUint32(b)
+	b, d.h[5] = consumeUint32(b)
+	b, d.h[6] = consumeUint32(b)
+	b, d.h[7] = consumeUint32(b)
+	b = b[copy(d.x[:], b):]
+	_, n := consumeUint64(b)
+	d.nl = uint32(n << 3)
+	d.nh = uint32(n >> 29)
+	d.nx = uint32(n) % 64
+	return nil
+}
+
+func (h *sha256Hash) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic256) || string(b[:len(magic256)]) != magic256 {
+		return errors.New("crypto/sha256: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize256 {
+		return errors.New("crypto/sha256: invalid hash state size")
+	}
+	d := (*sha256State)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha256: can't retrieve hash state")
+	}
+	b = b[len(magic256):]
+	b, d.h[0] = consumeUint32(b)
+	b, d.h[1] = consumeUint32(b)
+	b, d.h[2] = consumeUint32(b)
+	b, d.h[3] = consumeUint32(b)
+	b, d.h[4] = consumeUint32(b)
+	b, d.h[5] = consumeUint32(b)
+	b, d.h[6] = consumeUint32(b)
+	b, d.h[7] = consumeUint32(b)
+	b = b[copy(d.x[:], b):]
+	_, n := consumeUint64(b)
+	d.nl = uint32(n << 3)
+	d.nh = uint32(n >> 29)
+	d.nx = uint32(n) % 64
+	return nil
+}
+
+// NewSHA384 returns a new SHA384 hash.
+func NewSHA384() hash.Hash {
+	return &sha384Hash{
+		evpHash: newEvpHash(crypto.SHA384, 384/8, 128),
+	}
+}
+
+type sha384Hash struct {
+	*evpHash
+	out [384 / 8]byte
+}
+
+func (h *sha384Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// NewSHA512 returns a new SHA512 hash.
+func NewSHA512() hash.Hash {
+	return &sha512Hash{
+		evpHash: newEvpHash(crypto.SHA512, 512/8, 128),
+	}
+}
+
+type sha512Hash struct {
+	*evpHash
+	out [512 / 8]byte
+}
+
+func (h *sha512Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// sha256State layout is taken from
+// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/include/openssl/sha.h#L95.
+type sha512State struct {
+	h      [8]uint64
+	nl, nh uint64
+	x      [128]byte
+	nx     uint32
+}
+
+const (
+	magic384         = "sha\x04"
+	magic512_224     = "sha\x05"
+	magic512_256     = "sha\x06"
+	magic512         = "sha\x07"
+	marshaledSize512 = len(magic512) + 8*8 + 128 + 8
+)
+
+func (h *sha384Hash) MarshalBinary() ([]byte, error) {
+	d := (*sha512State)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
+	}
+	b := make([]byte, 0, marshaledSize512)
+	b = append(b, magic384...)
+	b = appendUint64(b, d.h[0])
+	b = appendUint64(b, d.h[1])
+	b = appendUint64(b, d.h[2])
+	b = appendUint64(b, d.h[3])
+	b = appendUint64(b, d.h[4])
+	b = appendUint64(b, d.h[5])
+	b = appendUint64(b, d.h[6])
+	b = appendUint64(b, d.h[7])
+	b = append(b, d.x[:d.nx]...)
+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = appendUint64(b, d.nl>>3|d.nh<<61)
+	return b, nil
+}
+
+func (h *sha512Hash) MarshalBinary() ([]byte, error) {
+	d := (*sha512State)(h.shaState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
+	}
+	b := make([]byte, 0, marshaledSize512)
+	b = append(b, magic512...)
+	b = appendUint64(b, d.h[0])
+	b = appendUint64(b, d.h[1])
+	b = appendUint64(b, d.h[2])
+	b = appendUint64(b, d.h[3])
+	b = appendUint64(b, d.h[4])
+	b = appendUint64(b, d.h[5])
+	b = appendUint64(b, d.h[6])
+	b = appendUint64(b, d.h[7])
+	b = append(b, d.x[:d.nx]...)
+	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
+	b = appendUint64(b, d.nl>>3|d.nh<<61)
+	return b, nil
+}
+
+func (h *sha384Hash) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic512) {
+		return errors.New("crypto/sha512: invalid hash state identifier")
+	}
+	if string(b[:len(magic384)]) != magic384 {
+		return errors.New("crypto/sha512: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize512 {
+		return errors.New("crypto/sha512: invalid hash state size")
+	}
+	d := (*sha512State)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha512: can't retrieve hash state")
+	}
+	b = b[len(magic512):]
+	b, d.h[0] = consumeUint64(b)
+	b, d.h[1] = consumeUint64(b)
+	b, d.h[2] = consumeUint64(b)
+	b, d.h[3] = consumeUint64(b)
+	b, d.h[4] = consumeUint64(b)
+	b, d.h[5] = consumeUint64(b)
+	b, d.h[6] = consumeUint64(b)
+	b, d.h[7] = consumeUint64(b)
+	b = b[copy(d.x[:], b):]
+	_, n := consumeUint64(b)
+	d.nl = n << 3
+	d.nh = n >> 61
+	d.nx = uint32(n) % 128
+	return nil
+}
+
+func (h *sha512Hash) UnmarshalBinary(b []byte) error {
+	if len(b) < len(magic512) {
+		return errors.New("crypto/sha512: invalid hash state identifier")
+	}
+	if string(b[:len(magic512)]) != magic512 {
+		return errors.New("crypto/sha512: invalid hash state identifier")
+	}
+	if len(b) != marshaledSize512 {
+		return errors.New("crypto/sha512: invalid hash state size")
+	}
+	d := (*sha512State)(h.shaState())
+	if d == nil {
+		return errors.New("crypto/sha512: can't retrieve hash state")
+	}
+	b = b[len(magic512):]
+	b, d.h[0] = consumeUint64(b)
+	b, d.h[1] = consumeUint64(b)
+	b, d.h[2] = consumeUint64(b)
+	b, d.h[3] = consumeUint64(b)
+	b, d.h[4] = consumeUint64(b)
+	b, d.h[5] = consumeUint64(b)
+	b, d.h[6] = consumeUint64(b)
+	b, d.h[7] = consumeUint64(b)
+	b = b[copy(d.x[:], b):]
+	_, n := consumeUint64(b)
+	d.nl = n << 3
+	d.nh = n >> 61
+	d.nx = uint32(n) % 128
+	return nil
+}
+
+// appendUint64 appends x into b as a big endian byte sequence.
+func appendUint64(b []byte, x uint64) []byte {
+	return append(b,
+		byte(x>>56),
+		byte(x>>48),
+		byte(x>>40),
+		byte(x>>32),
+		byte(x>>24),
+		byte(x>>16),
+		byte(x>>8),
+		byte(x),
+	)
+}
+
+// appendUint32 appends x into b as a big endian byte sequence.
+func appendUint32(b []byte, x uint32) []byte {
+	return append(b, byte(x>>24), byte(x>>16), byte(x>>8), byte(x))
+}
+
+// consumeUint64 reads a big endian uint64 number from b.
+func consumeUint64(b []byte) ([]byte, uint64) {
+	_ = b[7]
+	x := uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
+		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
+	return b[8:], x
+}
+
+// consumeUint32 reads a big endian uint32 number from b.
+func consumeUint32(b []byte) ([]byte, uint32) {
+	_ = b[3]
+	x := uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+	return b[4:], x
+}

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -422,7 +422,7 @@ func (h *sha512Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
-// sha256State layout is taken from
+// sha512State layout is taken from
 // https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/include/openssl/sha.h#L95.
 type sha512State struct {
 	h      [8]uint64

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -1,0 +1,157 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl_test
+
+import (
+	"bytes"
+	"encoding"
+	"hash"
+	"testing"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+)
+
+func TestSha(t *testing.T) {
+	msg := []byte("testig")
+	var tests = []struct {
+		name string
+		fn   func() hash.Hash
+	}{
+		{"sha1", openssl.NewSHA1},
+		{"sha224", openssl.NewSHA224},
+		{"sha256", openssl.NewSHA256},
+		{"sha384", openssl.NewSHA384},
+		{"sha512", openssl.NewSHA512},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := tt.fn()
+			initSum := h.Sum(nil)
+			n, err := h.Write(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(msg) {
+				t.Errorf("got: %d, want: %d", n, len(msg))
+			}
+			sum := h.Sum(nil)
+			if size := h.Size(); len(sum) != size {
+				t.Errorf("got: %d, want: %d", len(sum), size)
+			}
+			if bytes.Equal(sum, initSum) {
+				t.Error("Write didn't change internal hash state")
+			}
+
+			state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+			if err != nil {
+				t.Errorf("could not marshal: %v", err)
+			}
+			h2 := tt.fn()
+			if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
+				t.Errorf("could not unmarshal: %v", err)
+			}
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
+			}
+
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+		})
+	}
+}
+
+func TestSHA_OneShot(t *testing.T) {
+	msg := []byte("testing")
+	var tests = []struct {
+		name    string
+		want    func() hash.Hash
+		oneShot func([]byte) []byte
+	}{
+		{"sha1", openssl.NewSHA1, func(p []byte) []byte {
+			b := openssl.SHA1(p)
+			return b[:]
+		}},
+		{"sha224", openssl.NewSHA224, func(p []byte) []byte {
+			b := openssl.SHA224(p)
+			return b[:]
+		}},
+		{"sha256", openssl.NewSHA256, func(p []byte) []byte {
+			b := openssl.SHA256(p)
+			return b[:]
+		}},
+		{"sha384", openssl.NewSHA384, func(p []byte) []byte {
+			b := openssl.SHA384(p)
+			return b[:]
+		}},
+		{"sha512", openssl.NewSHA512, func(p []byte) []byte {
+			b := openssl.SHA512(p)
+			return b[:]
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.oneShot(msg)
+			h := tt.want()
+			h.Write(msg)
+			want := h.Sum(nil)
+			if !bytes.Equal(got[:], want) {
+				t.Errorf("got:%x want:%x", got, want)
+			}
+		})
+	}
+}
+
+type cgoData struct {
+	Data [16]byte
+	Ptr  *cgoData
+}
+
+func TestCgo(t *testing.T) {
+	// Test that Write does not cause cgo to scan the entire cgoData struct for pointers.
+	// The scan (if any) should be limited to the [16]byte.
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+	d := new(cgoData)
+	d.Ptr = d
+	h := openssl.NewSHA256()
+	h.Write(d.Data[:])
+	h.Sum(nil)
+
+	openssl.SHA256(d.Data[:])
+}
+
+func BenchmarkHash8Bytes(b *testing.B) {
+	b.StopTimer()
+	h := openssl.NewSHA256()
+	sum := make([]byte, h.Size())
+	size := 8
+	buf := make([]byte, size)
+	b.StartTimer()
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h.Reset()
+		h.Write(buf)
+		h.Sum(sum[:0])
+	}
+}
+
+func BenchmarkSHA256(b *testing.B) {
+	b.StopTimer()
+	size := 8
+	buf := make([]byte, size)
+	b.StartTimer()
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		openssl.SHA256(buf)
+	}
+}

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -12,7 +12,9 @@ enum {
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 typedef void* GO_OSSL_LIB_CTX_PTR;
 typedef void* GO_OSSL_PROVIDER_PTR;
+typedef void* GO_ENGINE_PTR;
 typedef void* GO_EVP_MD_PTR;
+typedef void* GO_EVP_MD_CTX_PTR;
 
 // FOR_ALL_OPENSSL_FUNCTIONS is the list of all functions from libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -74,4 +76,17 @@ DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, con
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
-DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1))
+DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
+DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
+DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
+DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
+DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
+DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
+DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha256, (void), ()) \
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha384, (void), ()) \
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ())


### PR DESCRIPTION
This PR implements `NewSHA1`, `NewSHA224`, `NewSHA256`, `NewSHA384`, `NewSHA512`, and their corresponding one-shot versions.

It is a clean port from Microsoft repo, which is built on top of RedHat implementation, with the following changes:

- Remove all legacy SHA OpenSSL functions and objects (`SHA512_CTX`, `SHA384_Init()`, `SHA512_Update()`, etc.) and use only the EVP interface (`EVP_MD_PTR`, `EVP_DigestInit`, `EVP_DigestUpdate`, etc.).
- Support `UnmarshalBinary` and `MarshalBinary` for OpenSSL 3, which stores the sha state in a different place than OpenSSL 1.x.

This time I'll wait for a +1 from @ueno 😄 