### PR TITLE
Implement newOpenSSLError

### DIFF
--- a/openssl/rand.go
+++ b/openssl/rand.go
@@ -14,7 +14,7 @@ func (randReader) Read(b []byte) (int, error) {
 	// We check it even so.
 	if len(b) > 0 && C.go_openssl_RAND_bytes((*C.uchar)(unsafe.Pointer(&b[0])), C.int(len(b))) == 0 {
 		// TODO: use NewOpenSSLError once implemented.
-		return 0, fail("RAND_bytes")
+		return 0, newOpenSSLError("RAND_bytes")
 	}
 	return len(b), nil
 }

--- a/openssl/rand.go
+++ b/openssl/rand.go
@@ -13,7 +13,6 @@ func (randReader) Read(b []byte) (int, error) {
 	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
 	// We check it even so.
 	if len(b) > 0 && C.go_openssl_RAND_bytes((*C.uchar)(unsafe.Pointer(&b[0])), C.int(len(b))) == 0 {
-		// TODO: use NewOpenSSLError once implemented.
 		return 0, newOpenSSLError("RAND_bytes")
 	}
 	return len(b), nil

--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -104,14 +104,14 @@ func (h *evpHash) Reset() {
 	// There is no need to reset h.ctx2 because it is always reset after
 	// use in evpHash.sum.
 	if C.go_openssl_EVP_DigestInit(h.ctx, h.md) != 1 {
-		panic("openssl: EVP_DigestInit failed")
+		panic(newOpenSSLError("EVP_DigestInit"))
 	}
 	runtime.KeepAlive(h)
 }
 
 func (h *evpHash) Write(p []byte) (int, error) {
 	if len(p) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&*addr(p)), C.size_t(len(p))) != 1 {
-		panic("openssl: EVP_DigestUpdate failed")
+		panic(newOpenSSLError("EVP_DigestUpdate"))
 	}
 	runtime.KeepAlive(h)
 	return len(p), nil
@@ -131,10 +131,10 @@ func (h *evpHash) sum(out []byte) {
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
 	if C.go_openssl_EVP_MD_CTX_copy(h.ctx2, h.ctx) != 1 {
-		panic("openssl: EVP_MD_CTX_copy failed")
+		panic(newOpenSSLError("EVP_MD_CTX_copy"))
 	}
 	if C.go_openssl_EVP_DigestFinal(h.ctx2, (*C.uchar)(noescape(unsafe.Pointer(base(out)))), nil) != 1 {
-		panic("openssl: EVP_DigestFinal failed")
+		panic(newOpenSSLError("EVP_DigestFinal"))
 	}
 	runtime.KeepAlive(h)
 }

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -61,6 +61,9 @@ typedef void* GO_EVP_MD_CTX_PTR;
 #define FOR_ALL_OPENSSL_FUNCTIONS \
 DEFINEFUNC(int, ERR_set_mark, (void), ()) \
 DEFINEFUNC(int, ERR_pop_to_mark, (void), ()) \
+DEFINEFUNC(void, ERR_error_string_n, (unsigned long e, char *buf, size_t len), (e, buf, len)) \
+DEFINEFUNC_LEGACY_1(unsigned long, ERR_get_error_line, (const char **file, int *line), (file, line)) \
+DEFINEFUNC_3_0(unsigned long, ERR_get_error_all, (const char **file, int *line, const char **func, const char **data, int *flags), (file, line, func, data, flags)) \
 DEFINEFUNC_RENAMED_1_1(const char *, OpenSSL_version, SSLeay_version, (int type), (type)) \
 DEFINEFUNC(void, OPENSSL_init, (void), ()) \
 DEFINEFUNC_LEGACY_1_0(void, ERR_load_crypto_strings, (void), ()) \


### PR DESCRIPTION
This PR implements `newOpenSSLError` using RedHat code with the following modifications:

- Do not export the function, there is no need to call it from outside.
- Use plain string concatenation and `strconv` instead of `fmt` to construct the error message. Upstream try to avoid importing `fmt` in low level crypto packages, so do we.
-  RedHat code appends the error flags to the error string. These flags don't give information about the error, but about the error data, which we don't use. Therefore, we can use `ERR_get_error_line` instead of `ERR_get_error_line_data` and skip also the flags.
-  The formatted error string has been modified to be more *idiomatic*. Example:
```
panic: FIPS_mode_set
openssl error(s):
error:0F06D065:common libcrypto routines:FIPS_mode_set:fips mode not supported
        ../crypto/o_fips.c:22
```

instead of 

```
panic: FIPS_mode_set
openssl error(s):
file: ../crypto/o_fips.c
line: 22
function: unknown
flags: 0
error string: error:0F06D065:common libcrypto routines:FIPS_mode_set:fips mode not supported
```