### PR TITLE
Implement HMAC

### DIFF
--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -2,7 +2,27 @@ package openssl
 
 // #include "goopenssl.h"
 import "C"
-import "crypto"
+import (
+	"crypto"
+	"hash"
+)
+
+// hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.
+func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
+	switch h.(type) {
+	case *sha1Hash:
+		return C.go_openssl_EVP_sha1()
+	case *sha224Hash:
+		return C.go_openssl_EVP_sha224()
+	case *sha256Hash:
+		return C.go_openssl_EVP_sha256()
+	case *sha384Hash:
+		return C.go_openssl_EVP_sha384()
+	case *sha512Hash:
+		return C.go_openssl_EVP_sha512()
+	}
+	return nil
+}
 
 // cryptoHashToMD converts a crypto.Hash to a GO_EVP_MD_PTR.
 func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {

--- a/openssl/goopenssl.c
+++ b/openssl/goopenssl.c
@@ -15,6 +15,7 @@
 #define DEFINEFUNC_1_1(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_3_0(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_RENAMED_3_0(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
 
 FOR_ALL_OPENSSL_FUNCTIONS
 
@@ -24,6 +25,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
+#undef DEFINEFUNC_RENAMED_3_0
 
 
 // Load all the functions stored in FOR_ALL_OPENSSL_FUNCTIONS
@@ -69,6 +71,15 @@ go_openssl_load_functions(void* handle, int major, int minor)
     {                                                               \
         DEFINEFUNC_INTERNAL(func, #func)                            \
     }
+#define DEFINEFUNC_RENAMED_3_0(ret, func, oldfunc, args, argscall)  \
+    if (major == 1)                                                 \
+    {                                                               \
+        DEFINEFUNC_INTERNAL(func, #oldfunc)                         \
+    }                                                               \
+    else                                                            \
+    {                                                               \
+        DEFINEFUNC_INTERNAL(func, #func)                            \
+    }
 
 FOR_ALL_OPENSSL_FUNCTIONS
 
@@ -78,6 +89,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
+#undef DEFINEFUNC_RENAMED_3_0
 }
 
 static unsigned long

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -29,6 +29,8 @@ void go_openssl_load_functions(void* handle, int major, int minor);
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_RENAMED_3_0(ret, func, oldfunc, args, argscall)     \
+    DEFINEFUNC(ret, func, args, argscall)
 
 FOR_ALL_OPENSSL_FUNCTIONS
 
@@ -38,6 +40,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
+#undef DEFINEFUNC_RENAMED_3_0
 
 // go_shaX is a SHA generic wrapper which hash p into out.
 // One shot sha functions are expected to be fast, so

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -1,0 +1,150 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"hash"
+	"runtime"
+	"unsafe"
+)
+
+// NewHMAC returns a new HMAC using OpenSSL.
+// The function h must return a hash implemented by
+// OpenSSL (for example, h could be openssl.NewSHA256).
+// If h is not recognized, NewHMAC returns nil.
+func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
+	ch := h()
+	md := hashToMD(ch)
+	if md == nil {
+		return nil
+	}
+
+	var hkey []byte
+	if len(key) > 0 {
+		// Note: Could hash down long keys here using EVP_Digest.
+		hkey = make([]byte, len(key))
+		copy(hkey, key)
+	} else {
+		// This is supported in OpenSSL/Standard lib and as such
+		// we must support it here. When using HMAC with a null key
+		// HMAC_Init will try and reuse the key from the ctx. This is
+		// not the bahavior previously implemented, so as a workaround
+		// we pass an "empty" key.
+		hkey = make([]byte, C.GO_EVP_MAX_MD_SIZE)
+	}
+
+	return newHMAC(md, ch, hkey)
+}
+
+type opensslHMAC struct {
+	md        C.GO_EVP_MD_PTR
+	ctx       C.GO_HMAC_CTX_PTR
+	size      int
+	blockSize int
+	key       []byte
+	sum       []byte
+}
+
+func newHMAC(md C.GO_EVP_MD_PTR, h hash.Hash, key []byte) *opensslHMAC {
+	hmac := &opensslHMAC{
+		md:        md,
+		size:      h.Size(),
+		blockSize: h.BlockSize(),
+		key:       key,
+		ctx:       hmacCtxNew(),
+	}
+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
+	hmac.Reset()
+	return hmac
+}
+
+func (h *opensslHMAC) Reset() {
+	hmacCtxReset(h.ctx)
+
+	if C.go_openssl_HMAC_Init_ex(h.ctx, unsafe.Pointer(&h.key[0]), C.int(len(h.key)), h.md, nil) == 0 {
+		panic("openssl: HMAC_Init failed")
+	}
+	if size := C.go_openssl_EVP_MD_get_size(h.md); size != C.int(h.size) {
+		println("openssl: HMAC size:", size, "!=", h.size)
+		panic("openssl: HMAC size mismatch")
+	}
+	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
+	h.sum = nil
+}
+
+func (h *opensslHMAC) finalize() {
+	hmacCtxFree(h.ctx)
+}
+
+func (h *opensslHMAC) Write(p []byte) (int, error) {
+	if len(p) > 0 {
+		C.go_openssl_HMAC_Update(h.ctx, base(p), C.size_t(len(p)))
+	}
+	runtime.KeepAlive(h)
+	return len(p), nil
+}
+
+func (h *opensslHMAC) Size() int {
+	return h.size
+}
+
+func (h *opensslHMAC) BlockSize() int {
+	return h.blockSize
+}
+
+func (h *opensslHMAC) Sum(in []byte) []byte {
+	if h.sum == nil {
+		size := h.Size()
+		h.sum = make([]byte, size)
+	}
+	// Make copy of context because Go hash.Hash mandates
+	// that Sum has no effect on the underlying stream.
+	// In particular it is OK to Sum, then Write more, then Sum again,
+	// and the second Sum acts as if the first didn't happen.
+	ctx2 := hmacCtxNew()
+	defer hmacCtxFree(ctx2)
+	if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx) == 0 {
+		panic("openssl: HMAC_CTX_copy failed")
+	}
+	C.go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
+	return append(in, h.sum...)
+}
+
+func hmacCtxNew() C.GO_HMAC_CTX_PTR {
+	if vMajor == 1 && vMinor == 0 {
+		// 0x120 is the sizeof value when building against OpenSSL 1.0.2 on Ubuntu 16.04.
+		ctx := (C.GO_HMAC_CTX_PTR)(C.malloc(0x120))
+		if ctx != nil {
+			C.go_openssl_HMAC_CTX_init(ctx)
+		}
+		return ctx
+	}
+	return C.go_openssl_HMAC_CTX_new()
+}
+
+func hmacCtxReset(ctx C.GO_HMAC_CTX_PTR) {
+	if ctx == nil {
+		return
+	}
+	if vMajor == 1 && vMinor == 0 {
+		C.go_openssl_HMAC_CTX_cleanup(ctx)
+		C.go_openssl_HMAC_CTX_init(ctx)
+		return
+	}
+	C.go_openssl_HMAC_CTX_reset(ctx)
+}
+
+func hmacCtxFree(ctx C.GO_HMAC_CTX_PTR) {
+	if ctx == nil {
+		return
+	}
+	if vMajor == 1 && vMinor == 0 {
+		C.go_openssl_HMAC_CTX_cleanup(ctx)
+		C.free(unsafe.Pointer(ctx))
+		return
+	}
+	C.go_openssl_HMAC_CTX_free(ctx)
+}

--- a/openssl/hmac_test.go
+++ b/openssl/hmac_test.go
@@ -1,0 +1,91 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+import (
+	"bytes"
+	"hash"
+	"testing"
+)
+
+func TestHMAC(t *testing.T) {
+	var tests = []struct {
+		name string
+		fn   func() hash.Hash
+	}{
+		{"sha1", NewSHA1},
+		{"sha224", NewSHA224},
+		{"sha256", NewSHA256},
+		{"sha384", NewSHA384},
+		{"sha512", NewSHA512},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello"))
+			sumHello := h.Sum(nil)
+
+			h = NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello world"))
+			sumHelloWorld := h.Sum(nil)
+
+			// Test that Sum has no effect on future Sum or Write operations.
+			// This is a bit unusual as far as usage, but it's allowed
+			// by the definition of Go hash.Hash, and some clients expect it to work.
+			h = NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("1st Sum after hello = %x, want %x", sum, sumHello)
+			}
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("2nd Sum after hello = %x, want %x", sum, sumHello)
+			}
+
+			h.Write([]byte(" world"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHelloWorld) {
+				t.Fatalf("1st Sum after hello world = %x, want %x", sum, sumHelloWorld)
+			}
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHelloWorld) {
+				t.Fatalf("2nd Sum after hello world = %x, want %x", sum, sumHelloWorld)
+			}
+
+			h.Reset()
+			h.Write([]byte("hello"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("Sum after Reset + hello = %x, want %x", sum, sumHello)
+			}
+		})
+	}
+}
+
+func BenchmarkHMACSHA256_32(b *testing.B) {
+	b.StopTimer()
+	key := make([]byte, 32)
+	buf := make([]byte, 32)
+	h := NewHMAC(NewSHA256, key)
+	b.SetBytes(int64(len(buf)))
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h.Write(buf)
+		mac := h.Sum(nil)
+		h.Reset()
+		buf[0] = mac[0]
+	}
+}
+
+func BenchmarkHMACNewWriteSum(b *testing.B) {
+	b.StopTimer()
+	buf := make([]byte, 32)
+	b.SetBytes(int64(len(buf)))
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h := NewHMAC(NewSHA256, make([]byte, 32))
+		h.Write(buf)
+		mac := h.Sum(nil)
+		buf[0] = mac[0]
+	}
+}

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -9,12 +9,18 @@ enum {
     GO_OPENSSL_INIT_LOAD_CONFIG = 0x00000040L
 };
 
+// #include <openssl/evp.h>
+enum {
+    GO_EVP_MAX_MD_SIZE = 64
+};
+
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 typedef void* GO_OSSL_LIB_CTX_PTR;
 typedef void* GO_OSSL_PROVIDER_PTR;
 typedef void* GO_ENGINE_PTR;
 typedef void* GO_EVP_MD_PTR;
 typedef void* GO_EVP_MD_CTX_PTR;
+typedef void* GO_HMAC_CTX_PTR;
 
 // FOR_ALL_OPENSSL_FUNCTIONS is the list of all functions from libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -47,6 +53,9 @@ typedef void* GO_EVP_MD_CTX_PTR;
 //
 // DEFINEFUNC_RENAMED_1_1 acts like DEFINEFUNC but tries to load the function using the new name when using >= 1.1.x
 // and the old name when using 1.0.2. In both cases the function will have the new name.
+//
+// DEFINEFUNC_RENAMED_3_0 acts like DEFINEFUNC but tries to load the function using the new name when using >= 3.x
+// and the old name when using 1.x. In both cases the function will have the new name.
 //
 // #include <openssl/crypto.h>
 // #include <openssl/err.h>
@@ -89,4 +98,14 @@ DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha1, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha256, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha384, (void), ()) \
-DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ())
+DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ()) \
+DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_size, EVP_MD_size, (const GO_EVP_MD_PTR arg0), (arg0)) \
+DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (GO_HMAC_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_cleanup, (GO_HMAC_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, HMAC_Init_ex, (GO_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const GO_EVP_MD_PTR arg3, GO_ENGINE_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(int, HMAC_Update, (GO_HMAC_CTX_PTR arg0, const unsigned char *arg1, size_t arg2), (arg0, arg1, arg2)) \
+DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX_PTR arg0, unsigned char *arg1, unsigned int *arg2), (arg0, arg1, arg2)) \
+DEFINEFUNC(int, HMAC_CTX_copy, (GO_HMAC_CTX_PTR dest, GO_HMAC_CTX_PTR src), (dest, src)) \
+DEFINEFUNC_1_1(void, HMAC_CTX_free, (GO_HMAC_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC_1_1(GO_HMAC_CTX_PTR, HMAC_CTX_new, (void), ()) \
+DEFINEFUNC_1_1(int, HMAC_CTX_reset, (GO_HMAC_CTX_PTR arg0), (arg0))


### PR DESCRIPTION
This PR is almost a direct port from Microsoft repo, which was heavily based on RedHat implementation. These are the only additions:

- Unit testing.
- Use [EVP_MD_get_size](https://beta.openssl.org/docs/manmaster/man3/EVP_MD_get_size.html) instead of the deprecated `HMAC_size`.
- `HMAC_CTX_copy_ex` does not exist in OpenSSL, use [HMAC_CTX_copy](https://beta.openssl.org/docs/manmaster/man3/HMAC_CTX_copy.html) directly instead or renaming the symbol.
- In OpenSSL 1.0.2, allocate a `HMAC_CTX` using `malloc(0x120)` rather than `malloc(sizeof(GO_HMAC_CTX))`. Would be nice to do the later, but it would require importing the OpenSSL headers, which we try to avoid for the sake of portability. `0x120` is big enough to fit an HMAC context in 32- and 64-bits platforms. This value has been used for a long time in the [.NET OpenSSL bindings](https://github.com/dotnet/runtime/blob/f8d5706ab6e63b970a898ec293e04b47039abb70/src/native/libs/System.Security.Cryptography.Native/openssl_1_0_structs.h#L52) without issues.

I have a PR opened in the Microsoft repo to manage HMACs only using the EVP interface with APIs available since OpenSSL 3: https://github.com/microsoft/go-crypto-openssl/pull/40. I'll port that code after merging this one.