### PR TITLE
Update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Red Hat, Inc.
+Copyright (c) 2022 The Golang FIPS Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Multiple organizations are now contributing to this repository.  To avoid licensing and copyright confusion, this commit changes the copyright notice in the LICENSE file to The Golang FIPS Authors.

See golang-fips/openssl-fips#17.