### PR TITLE
Fix integer size confusion

### DIFF
--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -131,7 +131,7 @@ func NewPrivateKeyECDSA(curve string, X, Y BigInt, D BigInt) (*PrivateKeyECDSA, 
 func HashSignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (*big.Int, *big.Int, error) {
 	size := C._goboringcrypto_ECDSA_size(priv.key)
 	sig := make([]byte, size)
-	var sigLen C.uint
+	var sigLen C.size_t
 	md := cryptoHashToMD(h)
 	if md == nil {
 		panic("boring: invalid hash")

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -414,7 +414,7 @@ typedef ECDSA_SIG GO_ECDSA_SIG;
 DEFINEFUNC(GO_ECDSA_SIG *, ECDSA_SIG_new, (void), ())
 DEFINEFUNC(void, ECDSA_SIG_free, (GO_ECDSA_SIG * arg0), (arg0))
 DEFINEFUNC(GO_ECDSA_SIG *, ECDSA_do_sign, (const uint8_t *arg0, size_t arg1, const GO_EC_KEY *arg2), (arg0, arg1, arg2))
-DEFINEFUNC(int, ECDSA_do_verify, (const uint8_t *arg0, size_t arg1, const GO_ECDSA_SIG *arg2, const GO_EC_KEY *arg3), (arg0, arg1, arg2, arg3))
+DEFINEFUNC(int, ECDSA_do_verify, (const uint8_t *arg0, size_t arg1, const GO_ECDSA_SIG *arg2, GO_EC_KEY *arg3), (arg0, arg1, arg2, arg3))
 DEFINEFUNC(size_t, ECDSA_size, (const GO_EC_KEY *arg0), (arg0))
 
 DEFINEFUNCINTERNAL(int, ECDSA_sign, 
@@ -449,25 +449,25 @@ _goboringcrypto_EVP_PKEY_assign_RSA(EVP_PKEY *pkey, RSA *rsa) {
 }
 
 DEFINEFUNC(int, EVP_DigestSignInit,
-	(EVP_MD_CTX* ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, const EVP_PKEY *pkey),
+	(EVP_MD_CTX* ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey),
 	(ctx, pctx, type, e, pkey))
 
 DEFINEFUNC(int, EVP_DigestUpdate,
 	(EVP_MD_CTX* ctx, const void *d, size_t cnt),
 	(ctx, d, cnt))
 DEFINEFUNC(int, EVP_DigestSignFinal,
-	(EVP_MD_CTX* ctx, unsigned char *sig, unsigned int *siglen),
+	(EVP_MD_CTX* ctx, unsigned char *sig, size_t *siglen),
 	(ctx, sig, siglen))
 
 DEFINEFUNC(int, EVP_DigestVerifyInit,
-	(EVP_MD_CTX* ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, const EVP_PKEY *pkey),
+	(EVP_MD_CTX* ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey),
 	(ctx, pctx, type, e, pkey))
 DEFINEFUNC(int, EVP_DigestVerifyFinal,
 	(EVP_MD_CTX* ctx, const uint8_t *sig, unsigned int siglen),
 	(ctx, sig, siglen))
 
 typedef RSA GO_RSA;
-int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, EVP_PKEY *eckey);
+int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, size_t *slen, EVP_PKEY *eckey);
 int _goboringcrypto_EVP_sign_raw(EVP_MD *md, EVP_PKEY_CTX *ctx, const uint8_t *msg,
                                                               size_t msgLen, uint8_t *sig, size_t *slen,
                                                               GO_RSA *key);
@@ -486,7 +486,7 @@ static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 DEFINEFUNC(void, EVP_MD_CTX_free, (EVP_MD_CTX *ctx), (ctx))
 #endif
 
-int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, unsigned int *arg4, GO_EC_KEY *arg5);
+int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, size_t *arg4, GO_EC_KEY *arg5);
 int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, const uint8_t *arg3, unsigned int arg4, GO_EC_KEY *arg5);
 
 #include <openssl/rsa.h>
@@ -494,7 +494,7 @@ int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, c
 // Note: order of struct fields here is unchecked.
 typedef BN_GENCB GO_BN_GENCB;
 
-int _goboringcrypto_EVP_RSA_sign(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, unsigned int *slen, RSA *rsa);
+int _goboringcrypto_EVP_RSA_sign(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, size_t *slen, RSA *rsa);
 int _goboringcrypto_EVP_RSA_verify(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, const uint8_t *sig, unsigned int slen, GO_RSA *rsa);
 
 DEFINEFUNC(GO_RSA *, RSA_new, (void), ())
@@ -796,10 +796,10 @@ _goboringcrypto_EVP_PKEY_CTX_set_rsa_mgf1_md(GO_EVP_PKEY_CTX * ctx, const GO_EVP
 }
 
 DEFINEFUNC(int, EVP_PKEY_decrypt,
-		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4),
+		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, size_t arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
 DEFINEFUNC(int, EVP_PKEY_encrypt,
-		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4),
+		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, size_t arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
 DEFINEFUNC(int, EVP_PKEY_decrypt_init, (GO_EVP_PKEY_CTX * arg0), (arg0))
 DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX * arg0), (arg0))

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -218,10 +218,16 @@ DEFINEFUNC(const GO_EVP_MD *, EVP_sha512, (void), ())
 DEFINEFUNC(const GO_EVP_MD *, EVP_md_null, (void), ())
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 DEFINEFUNCINTERNAL(int, EVP_MD_type, (const GO_EVP_MD *arg0), (arg0))
+DEFINEFUNCINTERNAL(int, EVP_MD_size, (const GO_EVP_MD *arg0), (arg0))
+static inline int
+_goboringcrypto_EVP_MD_get_size(const GO_EVP_MD *arg0)
+{
+	return _goboringcrypto_internal_EVP_MD_size(arg0);
+}
 #else
 DEFINEFUNCINTERNAL(int, EVP_MD_get_type, (const GO_EVP_MD *arg0), (arg0))
+DEFINEFUNC(int, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
 #endif
-DEFINEFUNCINTERNAL(size_t, EVP_MD_size, (const GO_EVP_MD *arg0), (arg0))
 DEFINEFUNCINTERNAL(const GO_EVP_MD*, EVP_md5_sha1, (void), ())
 
 # include <openssl/md5.h>
@@ -275,26 +281,16 @@ DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-	return _goboringcrypto_internal_EVP_MD_size(arg0->md);
+	return _goboringcrypto_EVP_MD_get_size(arg0->md);
 }
 #else
 DEFINEFUNCINTERNAL(const EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
-# if OPENSSL_VERSION_NUMBER < 0x30000000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 	const EVP_MD* md;
 	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
-	return _goboringcrypto_internal_EVP_MD_size(md);
+	return _goboringcrypto_EVP_MD_get_size(md);
 }
-# else
-DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
-static inline size_t
-_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-	const EVP_MD* md;
-	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
-	return _goboringcrypto_internal_EVP_MD_get_size(md);
-}
-# endif
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/openssl/openssl_ecdsa_signature.c
+++ b/openssl/openssl_ecdsa_signature.c
@@ -7,7 +7,7 @@
 #include "goopenssl.h"
 
 int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *msg, size_t msgLen,
-                               uint8_t *sig, unsigned int *slen,
+                               uint8_t *sig, size_t *slen,
                                GO_EC_KEY *eckey) {
   int result;
   EVP_PKEY *key = _goboringcrypto_EVP_PKEY_new();

--- a/openssl/openssl_evp.c
+++ b/openssl/openssl_evp.c
@@ -7,7 +7,7 @@
 #include "goopenssl.h"
 
 int _goboringcrypto_EVP_sign(EVP_MD *md, EVP_PKEY_CTX *ctx, const uint8_t *msg,
-                             size_t msgLen, uint8_t *sig, unsigned int *slen,
+                             size_t msgLen, uint8_t *sig, size_t *slen,
                              EVP_PKEY *key) {
   EVP_MD_CTX *mdctx = NULL;
   int ret = 0;

--- a/openssl/openssl_port_rsa.c
+++ b/openssl/openssl_port_rsa.c
@@ -21,7 +21,7 @@ int _goboringcrypto_RSA_generate_key_fips(GO_RSA *rsa, int size,
 }
 
 int _goboringcrypto_RSA_digest_and_sign_pss_mgf1(
-    GO_RSA *rsa, unsigned int *out_len, uint8_t *out, size_t max_out,
+    GO_RSA *rsa, size_t *out_len, uint8_t *out, size_t max_out,
     const uint8_t *in, size_t in_len, EVP_MD *md, const EVP_MD *mgf1_md,
     int salt_len) {
   EVP_PKEY_CTX *ctx;
@@ -184,7 +184,7 @@ err:
 
 int _goboringcrypto_EVP_RSA_sign(EVP_MD *md, const uint8_t *msg,
                                  unsigned int msgLen, uint8_t *sig,
-                                 unsigned int *slen, RSA *rsa) {
+                                 size_t *slen, RSA *rsa) {
   int result;
   EVP_PKEY *key = _goboringcrypto_EVP_PKEY_new();
   if (!key) {

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -199,7 +199,7 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 	init func(*C.GO_EVP_PKEY_CTX) C.int,
-	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.uint, *C.uint8_t, C.uint) C.int,
+	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.size_t, *C.uint8_t, C.size_t) C.int,
 	in []byte) ([]byte, error) {
 
 	pkey, ctx, err := setupRSA(withKey, padding, h, label, saltLen, ch, init)
@@ -209,12 +209,12 @@ func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 	defer C._goboringcrypto_EVP_PKEY_free(pkey)
 	defer C._goboringcrypto_EVP_PKEY_CTX_free(ctx)
 
-	var outLen C.uint
-	if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) == 0 {
+	var outLen C.size_t
+	if crypt(ctx, nil, &outLen, base(in), C.size_t(len(in))) == 0 {
 		return nil, NewOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
 	}
 	out := make([]byte, outLen)
-	if crypt(ctx, base(out), &outLen, base(in), C.uint(len(in))) <= 0 {
+	if crypt(ctx, base(out), &outLen, base(in), C.size_t(len(in))) <= 0 {
 		return nil, NewOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
 	}
 	return out[:outLen], nil
@@ -250,7 +250,7 @@ func decryptInit(ctx *C.GO_EVP_PKEY_CTX) C.int {
 	return C._goboringcrypto_EVP_PKEY_decrypt_init(ctx)
 }
 
-func decrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+func decrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uint8_t, inLen C.size_t) C.int {
 	return C._goboringcrypto_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
 }
 
@@ -258,7 +258,7 @@ func encryptInit(ctx *C.GO_EVP_PKEY_CTX) C.int {
 	return C._goboringcrypto_EVP_PKEY_encrypt_init(ctx)
 }
 
-func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uint8_t, inLen C.size_t) C.int {
 	return C._goboringcrypto_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
 }
 
@@ -326,7 +326,7 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte, msgIsHashed
 	}
 
 	var out []byte
-	var outLen C.uint
+	var outLen C.size_t
 
 	if priv.withKey(func(key *C.GO_RSA) C.int {
 		return C._goboringcrypto_EVP_RSA_sign(md, base(msg), C.uint(len(msg)), base(out), &outLen, key)


### PR DESCRIPTION
This makes the internal wrapper functions around OpenSSL functions consistently use `size_t` (or `size_t *`) where appropriate, instead of `unsigned int` (or `unsigned int *`).

The previous code had an issue on 64-bit big-endian systems where `sizeof(size_t)` is longer than `sizeof(unsigned int)` is 32, as the value returned through `unsigned int *` were truncated.