### PR TITLE
Implement RSA

### DIFF
--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This is a mirror of crypto/internal/boring/bbig/big.go.
+// This is a mirror of
+// https://github.com/golang/go/blob/36b87f273cc43e21685179dc1664ebb5493d26ae/src/crypto/internal/boring/bbig/big.go.
 
 package bbig
 

--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This is a mirror of crypto/internal/boring/bbig/big.go.
+
+package bbig
+
+import (
+	"math/big"
+	"unsafe"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+)
+
+func Enc(b *big.Int) openssl.BigInt {
+	if b == nil {
+		return nil
+	}
+	x := b.Bits()
+	if len(x) == 0 {
+		return openssl.BigInt{}
+	}
+	return unsafe.Slice((*uint)(&x[0]), len(x))
+}
+
+func Dec(b openssl.BigInt) *big.Int {
+	if b == nil {
+		return nil
+	}
+	if len(b) == 0 {
+		return new(big.Int)
+	}
+	x := unsafe.Slice((*big.Word)(&b[0]), len(b))
+	return new(big.Int).SetBits(x)
+}

--- a/openssl/big.go
+++ b/openssl/big.go
@@ -1,0 +1,11 @@
+package openssl
+
+// This file does not have build constraints to
+// facilitate using BigInt in Go crypto.
+// Go crypto references BigInt unconditionally,
+// even if it is not finally used.
+
+// A BigInt is the raw words from a BigInt.
+// This definition allows us to avoid importing math/big.
+// Conversion between BigInt and *big.Int is in openssl/bbig.
+type BigInt []uint

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -4,7 +4,9 @@ package openssl
 import "C"
 import (
 	"crypto"
+	"errors"
 	"hash"
+	"unsafe"
 )
 
 // hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.
@@ -47,4 +49,230 @@ func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {
 		return C.go_openssl_EVP_sha512()
 	}
 	return nil
+}
+
+func generateEVPPKey(id C.int, bits int) (C.GO_EVP_PKEY_PTR, error) {
+	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(id, nil)
+	if ctx == nil {
+		return nil, newOpenSSLError("EVP_PKEY_CTX_new_id failed")
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	if C.go_openssl_EVP_PKEY_keygen_init(ctx) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_keygen_init failed")
+	}
+	if bits != 0 {
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, C.GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS, C.int(bits), nil) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	var pkey C.GO_EVP_PKEY_PTR
+	if C.go_openssl_EVP_PKEY_keygen(ctx, &pkey) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_keygen failed")
+	}
+	return pkey, nil
+}
+
+type withKeyFunc func(func(C.GO_EVP_PKEY_PTR) C.int) C.int
+type initFunc func(C.GO_EVP_PKEY_CTX_PTR) error
+type cryptFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, *C.size_t, *C.uchar, C.size_t) error
+type verifyFunc func(C.GO_EVP_PKEY_CTX_PTR, *C.uchar, C.size_t, *C.uchar, C.size_t) error
+
+func setupEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
+	init initFunc) (ctx C.GO_EVP_PKEY_CTX_PTR, err error) {
+	defer func() {
+		if err != nil {
+			if ctx != nil {
+				C.go_openssl_EVP_PKEY_CTX_free(ctx)
+				ctx = nil
+			}
+		}
+	}()
+
+	withKey(func(pkey C.GO_EVP_PKEY_PTR) C.int {
+		ctx = C.go_openssl_EVP_PKEY_CTX_new(pkey, nil)
+		return 1
+	})
+	if ctx == nil {
+		return nil, newOpenSSLError("EVP_PKEY_CTX_new failed")
+	}
+	if err := init(ctx); err != nil {
+		return nil, err
+	}
+	if padding == 0 {
+		return ctx, nil
+	}
+	// Each padding type has its own requirements in terms of when to apply the padding,
+	// so it can't be just set at this point.
+	setPadding := func() error {
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_PADDING, padding, nil) != 1 {
+			return newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+		return nil
+	}
+	switch padding {
+	case C.GO_RSA_PKCS1_OAEP_PADDING:
+		md := hashToMD(h)
+		if md == nil {
+			return nil, errors.New("crypto/rsa: unsupported hash function")
+		}
+		// setPadding must happen before setting EVP_PKEY_CTRL_RSA_OAEP_MD.
+		if err := setPadding(); err != nil {
+			return nil, err
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
+		// OpenSSL 1.1.1 and higher does not take ownership of the label if the length is zero,
+		// so better avoid the allocation.
+		var clabel *C.uchar
+		if len(label) > 0 {
+			// Go guarantees C.malloc never returns nil.
+			clabel = (*C.uchar)(C.malloc(C.size_t(len(label))))
+			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel)) != 1 {
+			if clabel != nil {
+				C.free(unsafe.Pointer(clabel))
+			}
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	case C.GO_RSA_PKCS1_PSS_PADDING:
+		md := cryptoHashToMD(ch)
+		if md == nil {
+			return nil, errors.New("crypto/rsa: unsupported hash function")
+		}
+		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(md)) != 1 {
+			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
+		if err := setPadding(); err != nil {
+			return nil, err
+		}
+		if saltLen != 0 {
+			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil) != 1 {
+				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+			}
+		}
+
+	case C.GO_RSA_PKCS1_PADDING:
+		if ch != 0 {
+			// We support unhashed messages.
+			md := cryptoHashToMD(ch)
+			if md == nil {
+				return nil, errors.New("crypto/rsa: unsupported hash function")
+			}
+			if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, -1, C.GO_EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(md)) != 1 {
+				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+			}
+			if err := setPadding(); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		if err := setPadding(); err != nil {
+			return nil, err
+		}
+	}
+	return ctx, nil
+}
+
+func cryptEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
+	init initFunc, crypt cryptFunc, in []byte) ([]byte, error) {
+
+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
+	if err != nil {
+		return nil, err
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	pkeySize := withKey(func(pkey C.GO_EVP_PKEY_PTR) C.int {
+		return C.go_openssl_EVP_PKEY_get_size(pkey)
+	})
+	outLen := C.size_t(pkeySize)
+	out := make([]byte, pkeySize)
+	if err := crypt(ctx, base(out), &outLen, base(in), C.size_t(len(in))); err != nil {
+		return nil, err
+	}
+	// The size returned by EVP_PKEY_get_size() is only preliminary and not exact,
+	// so the final contents of the out buffer may be smaller.
+	return out[:outLen], nil
+}
+
+func verifyEVP(withKey withKeyFunc, padding C.int,
+	h hash.Hash, label []byte, saltLen C.int, ch crypto.Hash,
+	init initFunc, verify verifyFunc,
+	sig, in []byte) error {
+
+	ctx, err := setupEVP(withKey, padding, h, label, saltLen, ch, init)
+	if err != nil {
+		return err
+	}
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	return verify(ctx, base(sig), C.size_t(len(sig)), base(in), C.size_t(len(in)))
+}
+
+func evpEncrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
+	encryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
+		if ret := C.go_openssl_EVP_PKEY_encrypt_init(ctx); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_encrypt_init failed")
+		}
+		return nil
+	}
+	encrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
+		if ret := C.go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_encrypt failed")
+		}
+		return nil
+	}
+	return cryptEVP(withKey, padding, h, label, 0, 0, encryptInit, encrypt, msg)
+}
+
+func evpDecrypt(withKey withKeyFunc, padding C.int, h hash.Hash, label, msg []byte) ([]byte, error) {
+	decryptInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
+		if ret := C.go_openssl_EVP_PKEY_decrypt_init(ctx); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_decrypt_init failed")
+		}
+		return nil
+	}
+	decrypt := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
+		if ret := C.go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_decrypt failed")
+		}
+		return nil
+	}
+	return cryptEVP(withKey, padding, h, label, 0, 0, decryptInit, decrypt, msg)
+}
+
+func evpSign(withKey withKeyFunc, padding C.int, saltLen C.int, h crypto.Hash, hashed []byte) ([]byte, error) {
+	signtInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
+		if ret := C.go_openssl_EVP_PKEY_sign_init(ctx); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_sign_init failed")
+		}
+		return nil
+	}
+	sign := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen *C.size_t, in *C.uchar, inLen C.size_t) error {
+		if ret := C.go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_sign failed")
+		}
+		return nil
+	}
+	return cryptEVP(withKey, padding, nil, nil, saltLen, h, signtInit, sign, hashed)
+}
+
+func evpVerify(withKey withKeyFunc, padding C.int, saltLen C.int, h crypto.Hash, sig, hashed []byte) error {
+	verifyInit := func(ctx C.GO_EVP_PKEY_CTX_PTR) error {
+		if ret := C.go_openssl_EVP_PKEY_verify_init(ctx); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_verify_init failed")
+		}
+		return nil
+	}
+	verify := func(ctx C.GO_EVP_PKEY_CTX_PTR, out *C.uchar, outLen C.size_t, in *C.uchar, inLen C.size_t) error {
+		if ret := C.go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen); ret != 1 {
+			return newOpenSSLError("EVP_PKEY_verify failed")
+		}
+		return nil
+	}
+	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
 }

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -1,0 +1,385 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"crypto"
+	"crypto/subtle"
+	"errors"
+	"hash"
+	"runtime"
+	"strconv"
+	"unsafe"
+)
+
+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
+	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
+		return nil, nil, nil, nil, nil, nil, nil, nil, e
+	}
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_RSA, bits)
+	if err != nil {
+		return bad(err)
+	}
+	defer C.go_openssl_EVP_PKEY_free(pkey)
+	key := C.go_openssl_EVP_PKEY_get1_RSA(pkey)
+	if key == nil {
+		return bad(newOpenSSLError("EVP_PKEY_get1_RSA failed"))
+	}
+	N, E, D = rsaGetKey(key)
+	P, Q = rsaGetFactors(key)
+	Dp, Dq, Qinv = rsaGetCRTParams(key)
+	return
+}
+
+type PublicKeyRSA struct {
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey C.GO_EVP_PKEY_PTR
+}
+
+func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
+	key := C.go_openssl_RSA_new()
+	if key == nil {
+		return nil, newOpenSSLError("RSA_new failed")
+	}
+	if !rsaSetKey(key, N, E, nil) {
+		return nil, fail("RSA_set0_key")
+	}
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		C.go_openssl_RSA_free(key)
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		C.go_openssl_RSA_free(key)
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	k := &PublicKeyRSA{_pkey: pkey}
+	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
+	return k, nil
+}
+
+func (k *PublicKeyRSA) finalize() {
+	C.go_openssl_EVP_PKEY_free(k._pkey)
+}
+
+func (k *PublicKeyRSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
+	// Because of the finalizer, any time _pkey is passed to cgo, that call must
+	// be followed by a call to runtime.KeepAlive, to make sure k is not
+	// collected (and finalized) before the cgo call returns.
+	defer runtime.KeepAlive(k)
+	return f(k._pkey)
+}
+
+type PrivateKeyRSA struct {
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey C.GO_EVP_PKEY_PTR
+}
+
+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error) {
+	key := C.go_openssl_RSA_new()
+	if key == nil {
+		return nil, newOpenSSLError("RSA_new failed")
+	}
+	if !rsaSetKey(key, N, E, D) {
+		return nil, fail("RSA_set0_key")
+	}
+	if P != nil && Q != nil {
+		if !rsaSetFactors(key, P, Q) {
+			return nil, fail("RSA_set0_factors")
+		}
+	}
+	if Dp != nil && Dq != nil && Qinv != nil {
+		if !rsaSetCRTParams(key, Dp, Dq, Qinv) {
+			return nil, fail("RSA_set0_crt_params")
+		}
+	}
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		C.go_openssl_RSA_free(key)
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		C.go_openssl_RSA_free(key)
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	k := &PrivateKeyRSA{_pkey: pkey}
+	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
+	return k, nil
+}
+
+func (k *PrivateKeyRSA) finalize() {
+	C.go_openssl_EVP_PKEY_free(k._pkey)
+}
+
+func (k *PrivateKeyRSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
+	// Because of the finalizer, any time _pkey is passed to cgo, that call must
+	// be followed by a call to runtime.KeepAlive, to make sure k is not
+	// collected (and finalized) before the cgo call returns.
+	defer runtime.KeepAlive(k)
+	return f(k._pkey)
+}
+
+func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, ciphertext)
+}
+
+func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, msg)
+}
+
+func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
+	return evpDecrypt(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, ciphertext)
+}
+
+func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
+	return evpEncrypt(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, msg)
+}
+
+func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
+	ret, err := evpDecrypt(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	// We could return here, but the Go standard library test expects DecryptRSANoPadding to verify the result
+	// in order to defend against errors in the CRT computation.
+	//
+	// The following code tries to replicate the verification implemented in the upstream function decryptAndCheck, found at
+	// https://github.com/golang/go/blob/9de1ac6ac2cad3871760d0aa288f5ca713afd0a6/src/crypto/rsa/rsa.go#L569-L582.
+	pub := &PublicKeyRSA{_pkey: priv._pkey}
+	// A private EVP_PKEY can be used as a public key as it contains the public information.
+	enc, err := EncryptRSANoPadding(pub, ret)
+	if err != nil {
+		return nil, err
+	}
+	// Upstream does not do a constant time comparison because it works with math/big instead of byte slices,
+	// and math/big does not support constant-time arithmetic yet. See #20654 for more info.
+	if subtle.ConstantTimeCompare(ciphertext, enc) != 1 {
+		return nil, errors.New("rsa: internal error")
+	}
+	return ret, nil
+}
+
+func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
+	return evpEncrypt(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, msg)
+}
+
+func saltLength(saltLen int, sign bool) (C.int, error) {
+	// A salt length of -2 is valid in OpenSSL, but not in crypto/rsa, so reject
+	// it, and lengths < -2, before we convert to the OpenSSL sentinel values.
+	if saltLen <= -2 {
+		return 0, errors.New("crypto/rsa: PSSOptions.SaltLength cannot be negative")
+	}
+	// OpenSSL uses sentinel salt length values like Go crypto does,
+	// but the values don't fully match for rsa.PSSSaltLengthAuto (0).
+	if saltLen == 0 {
+		if sign {
+			if vMajor == 1 {
+				// OpenSSL 1.x uses -2 to mean maximal size when signing where Go crypto uses 0.
+				return C.GO_RSA_PSS_SALTLEN_MAX_SIGN, nil
+			}
+			// OpenSSL 3.x deprecated RSA_PSS_SALTLEN_MAX_SIGN
+			// and uses -3 to mean maximal size when signing where Go crypto uses 0.
+			return C.GO_RSA_PSS_SALTLEN_MAX, nil
+		}
+		// OpenSSL uses -2 to mean auto-detect size when verifying where Go crypto uses 0.
+		return C.GO_RSA_PSS_SALTLEN_AUTO, nil
+	}
+	return C.int(saltLen), nil
+}
+
+func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
+	cSaltLen, err := saltLength(saltLen, true)
+	if err != nil {
+		return nil, err
+	}
+	return evpSign(priv.withKey, C.GO_RSA_PKCS1_PSS_PADDING, cSaltLen, h, hashed)
+}
+
+func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
+	cSaltLen, err := saltLength(saltLen, false)
+	if err != nil {
+		return err
+	}
+	return evpVerify(pub.withKey, C.GO_RSA_PKCS1_PSS_PADDING, cSaltLen, h, sig, hashed)
+}
+
+func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
+	return evpSign(priv.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, hashed)
+}
+
+func HashSignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte) ([]byte, error) {
+	md := cryptoHashToMD(h)
+	if md == nil {
+		return nil, errors.New("crypto/rsa: unsupported hash function: " + strconv.Itoa(int(h)))
+	}
+	var out []byte
+	var outLen C.size_t
+	if priv.withKey(func(key C.GO_EVP_PKEY_PTR) C.int {
+		ctx := C.go_openssl_EVP_MD_CTX_new()
+		if ctx == nil {
+			return 0
+		}
+		defer C.go_openssl_EVP_MD_CTX_free(ctx)
+		if ret := C.go_openssl_EVP_DigestSignInit(ctx, nil, md, nil, key); ret != 1 {
+			return ret
+		}
+		if ret := C.go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), C.size_t(len(msg))); ret != 1 {
+			return ret
+		}
+		// Obtain the signature length
+		if ret := C.go_openssl_EVP_DigestSignFinal(ctx, nil, &outLen); ret != 1 {
+			return ret
+		}
+		out = make([]byte, outLen)
+		// Obtain the signature
+		return C.go_openssl_EVP_DigestSignFinal(ctx, base(out), &outLen)
+	}) == 0 {
+		return nil, newOpenSSLError("RSA_sign failed")
+	}
+
+	return out[:outLen], nil
+}
+
+func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
+	if pub.withKey(func(pkey C.GO_EVP_PKEY_PTR) C.int {
+		size := C.go_openssl_EVP_PKEY_get_size(pkey)
+		if len(sig) < int(size) {
+			return 0
+		}
+		return 1
+	}) == 0 {
+		return errors.New("crypto/rsa: verification error")
+	}
+	return evpVerify(pub.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, sig, hashed)
+}
+
+func HashVerifyRSAPKCS1v15(priv *PublicKeyRSA, h crypto.Hash, msg, sig []byte) error {
+	md := cryptoHashToMD(h)
+	if md == nil {
+		return errors.New("crypto/rsa: unsupported hash function: " + strconv.Itoa(int(h)))
+	}
+	if priv.withKey(func(key C.GO_EVP_PKEY_PTR) C.int {
+		ctx := C.go_openssl_EVP_MD_CTX_new()
+		if ctx == nil {
+			return 0
+		}
+		defer C.go_openssl_EVP_MD_CTX_free(ctx)
+		if ret := C.go_openssl_EVP_DigestVerifyInit(ctx, nil, md, nil, key); ret != 1 {
+			return ret
+		}
+		if ret := C.go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), C.size_t(len(msg))); ret != 1 {
+			return ret
+		}
+		// Obtain the signature
+		return C.go_openssl_EVP_DigestVerifyFinal(ctx, base(sig), C.size_t(len(sig)))
+	}) == 0 {
+		return errors.New("crypto/rsa: verification error")
+	}
+
+	return nil
+}
+
+// rsa_st_1_0_2 is rsa_st memory layout in OpenSSL 1.0.2.
+type rsa_st_1_0_2 struct {
+	_                C.int
+	_                C.long
+	_                [2]unsafe.Pointer
+	n, e, d          C.GO_BIGNUM_PTR
+	p, q             C.GO_BIGNUM_PTR
+	dmp1, dmq1, iqmp C.GO_BIGNUM_PTR
+	// It contains more fields, but we are not interesed on them.
+}
+
+func bnSet(b1 *C.GO_BIGNUM_PTR, b2 BigInt) {
+	if b2 == nil {
+		return
+	}
+	if *b1 != nil {
+		C.go_openssl_BN_clear_free(*b1)
+	}
+	*b1 = bigToBN(b2)
+}
+
+func rsaSetKey(key C.GO_RSA_PTR, n, e, d BigInt) bool {
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		//r.d and d will be nil for public keys.
+		if (r.n == nil && n == nil) ||
+			(r.e == nil && e == nil) {
+			return false
+		}
+		bnSet(&r.n, n)
+		bnSet(&r.e, e)
+		bnSet(&r.d, d)
+		return true
+	}
+	return C.go_openssl_RSA_set0_key(key, bigToBN(n), bigToBN(e), bigToBN(d)) == 1
+}
+
+func rsaSetFactors(key C.GO_RSA_PTR, p, q BigInt) bool {
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		if (r.p == nil && p == nil) ||
+			(r.q == nil && q == nil) {
+			return false
+		}
+		bnSet(&r.p, p)
+		bnSet(&r.q, q)
+		return true
+	}
+	return C.go_openssl_RSA_set0_factors(key, bigToBN(p), bigToBN(q)) == 1
+}
+
+func rsaSetCRTParams(key C.GO_RSA_PTR, dmp1, dmq1, iqmp BigInt) bool {
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		if (r.dmp1 == nil && dmp1 == nil) ||
+			(r.dmq1 == nil && dmq1 == nil) ||
+			(r.iqmp == nil && iqmp == nil) {
+			return false
+		}
+		bnSet(&r.dmp1, dmp1)
+		bnSet(&r.dmq1, dmq1)
+		bnSet(&r.iqmp, iqmp)
+		return true
+	}
+	return C.go_openssl_RSA_set0_crt_params(key, bigToBN(dmp1), bigToBN(dmq1), bigToBN(iqmp)) == 1
+}
+
+func rsaGetKey(key C.GO_RSA_PTR) (BigInt, BigInt, BigInt) {
+	var n, e, d C.GO_BIGNUM_PTR
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		n, e, d = r.n, r.e, r.d
+	} else {
+		C.go_openssl_RSA_get0_key(key, &n, &e, &d)
+	}
+	return bnToBig(n), bnToBig(e), bnToBig(d)
+}
+
+func rsaGetFactors(key C.GO_RSA_PTR) (BigInt, BigInt) {
+	var p, q C.GO_BIGNUM_PTR
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		p, q = r.p, r.q
+	} else {
+		C.go_openssl_RSA_get0_factors(key, &p, &q)
+	}
+	return bnToBig(p), bnToBig(q)
+}
+
+func rsaGetCRTParams(key C.GO_RSA_PTR) (BigInt, BigInt, BigInt) {
+	var dmp1, dmq1, iqmp C.GO_BIGNUM_PTR
+	if vMajor == 1 && vMinor == 0 {
+		r := (*rsa_st_1_0_2)(unsafe.Pointer(key))
+		dmp1, dmq1, iqmp = r.dmp1, r.dmq1, r.iqmp
+	} else {
+		C.go_openssl_RSA_get0_crt_params(key, &dmp1, &dmq1, &iqmp)
+	}
+	return bnToBig(dmp1), bnToBig(dmq1), bnToBig(iqmp)
+}

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build linux && !android
+// +build linux,!android
+
+package openssl_test
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl-fips/openssl/bbig"
+)
+
+func TestRSAKeyGeneration(t *testing.T) {
+	for _, size := range []int{2048, 3072} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			t.Parallel()
+			priv, pub := newRSAKey(t, size)
+			msg := []byte("hi!")
+			enc, err := openssl.EncryptRSAPKCS1(pub, msg)
+			if err != nil {
+				t.Fatalf("EncryptPKCS1v15: %v", err)
+			}
+			dec, err := openssl.DecryptRSAPKCS1(priv, enc)
+			if err != nil {
+				t.Fatalf("DecryptPKCS1v15: %v", err)
+			}
+			if !bytes.Equal(dec, msg) {
+				t.Fatalf("got:%x want:%x", dec, msg)
+			}
+		})
+	}
+}
+
+func TestEncryptDecryptOAEP(t *testing.T) {
+	sha256 := openssl.NewSHA256()
+	msg := []byte("hi!")
+	label := []byte("ho!")
+	priv, pub := newRSAKey(t, 2048)
+	enc, err := openssl.EncryptRSAOAEP(sha256, pub, msg, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := openssl.DecryptRSAOAEP(sha256, priv, enc, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dec, msg) {
+		t.Errorf("got:%x want:%x", dec, msg)
+	}
+}
+
+func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
+	sha256 := openssl.NewSHA256()
+	msg := []byte("hi!")
+	priv, pub := newRSAKey(t, 2048)
+	enc, err := openssl.EncryptRSAOAEP(sha256, pub, msg, []byte("ho!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := openssl.DecryptRSAOAEP(sha256, priv, enc, []byte("wrong!"))
+	if err == nil {
+		t.Errorf("error expected")
+	}
+	if dec != nil {
+		t.Errorf("got:%x want: nil", dec)
+	}
+}
+
+func TestSignVerifyPKCS1v15(t *testing.T) {
+	sha256 := openssl.NewSHA256()
+	priv, pub := newRSAKey(t, 2048)
+	msg := []byte("hi!")
+	sha256.Write(msg)
+	hashed := sha256.Sum(nil)
+	signed, err := openssl.SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed2, err := openssl.HashSignRSAPKCS1v15(priv, crypto.SHA256, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(signed, signed2) {
+		t.Fatalf("got:%x want:%x", signed, signed2)
+	}
+	err = openssl.VerifyRSAPKCS1v15(pub, crypto.SHA256, hashed, signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = openssl.HashVerifyRSAPKCS1v15(pub, crypto.SHA256, msg, signed2)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignVerifyPKCS1v15_Unhashed(t *testing.T) {
+	msg := []byte("hi!")
+	priv, pub := newRSAKey(t, 2048)
+	signed, err := openssl.SignRSAPKCS1v15(priv, 0, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = openssl.VerifyRSAPKCS1v15(pub, 0, msg, signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
+	sha256 := openssl.NewSHA256()
+	msg := []byte("hi!")
+	priv, pub := newRSAKey(t, 2048)
+	sha256.Write(msg)
+	hashed := sha256.Sum(nil)
+	signed, err := openssl.SignRSAPKCS1v15(priv, crypto.SHA256, hashed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = openssl.VerifyRSAPKCS1v15(pub, crypto.SHA256, msg, signed)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+}
+
+func TestSignVerifyRSAPSS(t *testing.T) {
+	// Test cases taken from
+	// https://github.com/golang/go/blob/54182ff54a687272dd7632c3a963e036ce03cb7c/src/crypto/rsa/pss_test.go#L200.
+	const keyBits = 2048
+	var saltLengthCombinations = []struct {
+		signSaltLength, verifySaltLength int
+		good                             bool
+	}{
+		{rsa.PSSSaltLengthAuto, rsa.PSSSaltLengthAuto, true},
+		{rsa.PSSSaltLengthEqualsHash, rsa.PSSSaltLengthAuto, true},
+		{rsa.PSSSaltLengthEqualsHash, rsa.PSSSaltLengthEqualsHash, true},
+		{rsa.PSSSaltLengthEqualsHash, 8, false},
+		{rsa.PSSSaltLengthAuto, rsa.PSSSaltLengthEqualsHash, false},
+		{8, 8, true},
+		{rsa.PSSSaltLengthAuto, keyBits/8 - 2 - 32, true}, // simulate Go PSSSaltLengthAuto algorithm (32 = sha256 size)
+		{rsa.PSSSaltLengthAuto, 20, false},
+		{rsa.PSSSaltLengthAuto, -2, false},
+	}
+	sha256 := openssl.NewSHA256()
+	priv, pub := newRSAKey(t, keyBits)
+	sha256.Write([]byte("testing"))
+	hashed := sha256.Sum(nil)
+	for i, test := range saltLengthCombinations {
+		signed, err := openssl.SignRSAPSS(priv, crypto.SHA256, hashed, test.signSaltLength)
+		if err != nil {
+			t.Errorf("#%d: error while signing: %s", i, err)
+			continue
+		}
+		err = openssl.VerifyRSAPSS(pub, crypto.SHA256, hashed, signed, test.verifySaltLength)
+		if (err == nil) != test.good {
+			t.Errorf("#%d: bad result, wanted: %t, got: %s", i, test.good, err)
+		}
+	}
+}
+
+func newRSAKey(t *testing.T, size int) (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+	t.Helper()
+	N, E, D, P, Q, Dp, Dq, Qinv, err := openssl.GenerateKeyRSA(size)
+	if err != nil {
+		t.Fatalf("GenerateKeyRSA(%d): %v", size, err)
+	}
+	priv, err := openssl.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
+	if err != nil {
+		t.Fatalf("NewPrivateKeyRSA(%d): %v", size, err)
+	}
+	pub, err := openssl.NewPublicKeyRSA(N, E)
+	if err != nil {
+		t.Fatalf("NewPublicKeyRSA(%d): %v", size, err)
+	}
+	return priv, pub
+}
+
+func fromBase36(base36 string) *big.Int {
+	i, ok := new(big.Int).SetString(base36, 36)
+	if !ok {
+		panic("bad number: " + base36)
+	}
+	return i
+}
+
+func BenchmarkEncryptRSAPKCS1(b *testing.B) {
+	b.StopTimer()
+	// Public key length should be at least of 2048 bits, else OpenSSL will report an error when running in FIPS mode.
+	n := fromBase36("14314132931241006650998084889274020608918049032671858325988396851334124245188214251956198731333464217832226406088020736932173064754214329009979944037640912127943488972644697423190955557435910767690712778463524983667852819010259499695177313115447116110358524558307947613422897787329221478860907963827160223559690523660574329011927531289655711860504630573766609239332569210831325633840174683944553667352219670930408593321661375473885147973879086994006440025257225431977751512374815915392249179976902953721486040787792801849818254465486633791826766873076617116727073077821584676715609985777563958286637185868165868520557")
+	test2048PubKey, err := openssl.NewPublicKeyRSA(bbig.Enc(n), bbig.Enc(big.NewInt(3)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := openssl.EncryptRSAPKCS1(test2048PubKey, []byte("testing")); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGenerateKeyRSA(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, _, _, _, _, err := openssl.GenerateKeyRSA(2048)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -19,18 +19,41 @@ enum {
 enum {
     GO_EVP_CTRL_GCM_GET_TAG = 0x10,
     GO_EVP_CTRL_GCM_SET_TAG = 0x11,
+    GO_EVP_PKEY_CTRL_MD = 1,
+    GO_EVP_PKEY_RSA = 6,
     GO_EVP_MAX_MD_SIZE = 64
+};
+
+// #include <openssl/rsa.h>
+enum {
+    GO_RSA_PKCS1_PADDING = 1,
+    GO_RSA_NO_PADDING = 3,
+    GO_RSA_PKCS1_OAEP_PADDING = 4,
+    GO_RSA_PKCS1_PSS_PADDING = 6,
+    GO_RSA_PSS_SALTLEN_DIGEST = -1,
+    GO_RSA_PSS_SALTLEN_AUTO = -2,
+    GO_RSA_PSS_SALTLEN_MAX_SIGN = -2,
+    GO_RSA_PSS_SALTLEN_MAX = -3,
+    GO_EVP_PKEY_CTRL_RSA_PADDING = 0x1001,
+    GO_EVP_PKEY_CTRL_RSA_PSS_SALTLEN = 0x1002,
+    GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS = 0x1003,
+    GO_EVP_PKEY_CTRL_RSA_OAEP_MD = 0x1009,
+    GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A
 };
 
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 typedef void* GO_OSSL_LIB_CTX_PTR;
 typedef void* GO_OSSL_PROVIDER_PTR;
 typedef void* GO_ENGINE_PTR;
+typedef void* GO_EVP_PKEY_PTR;
+typedef void* GO_EVP_PKEY_CTX_PTR;
 typedef void* GO_EVP_MD_PTR;
 typedef void* GO_EVP_MD_CTX_PTR;
 typedef void* GO_HMAC_CTX_PTR;
 typedef void* GO_EVP_CIPHER_PTR;
 typedef void* GO_EVP_CIPHER_CTX_PTR;
+typedef void* GO_RSA_PTR;
+typedef void* GO_BIGNUM_PTR;
 
 // #include <openssl/md5.h>
 typedef void* GO_MD5_CTX_PTR;
@@ -111,8 +134,12 @@ DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
-DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
-DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
+DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \
+DEFINEFUNC(int, EVP_DigestVerifyInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
+DEFINEFUNC(int, EVP_DigestVerifyFinal, (GO_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen), (ctx, sig, siglen)) \
 DEFINEFUNC_LEGACY_1_0(int, MD5_Init, (GO_MD5_CTX_PTR c), (c)) \
 DEFINEFUNC_LEGACY_1_0(int, MD5_Update, (GO_MD5_CTX_PTR c, const void *data, size_t len), (c, data, len)) \
 DEFINEFUNC_LEGACY_1_0(int, MD5_Final, (unsigned char *md, GO_MD5_CTX_PTR c), (md, c)) \
@@ -158,4 +185,38 @@ DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_256_ctr, (void), ()) \
 DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_256_ecb, (void), ()) \
 DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_256_gcm, (void), ()) \
 DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
-DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr))
+DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
+DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
+/* EVP_PKEY_size pkey parameter is const since OpenSSL 1.1.1. */ \
+/* Exclude it from headercheck tool when using previous OpenSSL versions. */ \
+/*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_size, EVP_PKEY_size, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC(void, EVP_PKEY_free, (GO_EVP_PKEY_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_RSA_PTR, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC(int, EVP_PKEY_assign, (GO_EVP_PKEY_PTR pkey, int type, void *key), (pkey, type, key)) \
+DEFINEFUNC(int, EVP_PKEY_verify, (GO_EVP_PKEY_CTX_PTR ctx, const unsigned char *sig, size_t siglen, const unsigned char *tbs, size_t tbslen), (ctx, sig, siglen, tbs, tbslen)) \
+DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new, (GO_EVP_PKEY_PTR arg0, GO_ENGINE_PTR arg1), (arg0, arg1)) \
+DEFINEFUNC(GO_EVP_PKEY_CTX_PTR, EVP_PKEY_CTX_new_id, (int id, GO_ENGINE_PTR e), (id, e)) \
+DEFINEFUNC(int, EVP_PKEY_keygen_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC(int, EVP_PKEY_keygen, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *ppkey), (ctx, ppkey)) \
+DEFINEFUNC(void, EVP_PKEY_CTX_free, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EVP_PKEY_CTX_ctrl, (GO_EVP_PKEY_CTX_PTR ctx, int keytype, int optype, int cmd, int p1, void *p2), (ctx, keytype, optype, cmd, p1, p2)) \
+DEFINEFUNC(int, EVP_PKEY_decrypt, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(int, EVP_PKEY_encrypt, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(int, EVP_PKEY_decrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
+DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \
+DEFINEFUNC_1_1(int, RSA_set0_factors, (GO_RSA_PTR rsa, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q), (rsa, p, q)) \
+DEFINEFUNC_1_1(int, RSA_set0_crt_params, (GO_RSA_PTR rsa, GO_BIGNUM_PTR dmp1, GO_BIGNUM_PTR dmp2,GO_BIGNUM_PTR iqmp), (rsa, dmp1, dmp2, iqmp)) \
+DEFINEFUNC_1_1(void, RSA_get0_crt_params, (const GO_RSA_PTR r, const GO_BIGNUM_PTR *dmp1, const GO_BIGNUM_PTR *dmq1, const GO_BIGNUM_PTR *iqmp), (r, dmp1, dmq1, iqmp)) \
+DEFINEFUNC_1_1(int, RSA_set0_key, (GO_RSA_PTR r, GO_BIGNUM_PTR n, GO_BIGNUM_PTR e, GO_BIGNUM_PTR d), (r, n, e, d)) \
+DEFINEFUNC_1_1(void, RSA_get0_factors, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *p, const GO_BIGNUM_PTR *q), (rsa, p, q)) \
+DEFINEFUNC_1_1(void, RSA_get0_key, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *n, const GO_BIGNUM_PTR *e, const GO_BIGNUM_PTR *d), (rsa, n, e, d)) \
+DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
+DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
+/* bn_lebin2bn and bn_bn2lebinpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
+/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(GO_BIGNUM_PTR, BN_lebin2bn, bn_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
+/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen))

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -134,8 +134,8 @@ DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
-DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t *s), (ctx, md, s)) \
-DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \
 DEFINEFUNC(int, EVP_DigestVerifyInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -136,9 +136,9 @@ DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
 DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
-DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
+DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \
-DEFINEFUNC(int, EVP_DigestVerifyInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, const GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
+DEFINEFUNC(int, EVP_DigestVerifyInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 DEFINEFUNC(int, EVP_DigestVerifyFinal, (GO_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen), (ctx, sig, siglen)) \
 DEFINEFUNC_LEGACY_1_0(int, MD5_Init, (GO_MD5_CTX_PTR c), (c)) \
 DEFINEFUNC_LEGACY_1_0(int, MD5_Update, (GO_MD5_CTX_PTR c, const void *data, size_t len), (c, data, len)) \


### PR DESCRIPTION
This PR implements the RSA API. The implementation is taken from the MSFT repo, which was heavily based on RedHat version.

Some comments for the reviewers:
- `SignRSAPKCS1v15` and `VerifyRSAPKCS1v15` function signatures are the ones defined by Boring, so they expect the message to be hashed and don't define the `msgIsHashed` parameter.
- I've added the functions `HashSignRSAPKCS1v15` and `HashVerifyRSAPKCS1v15` to cover the on-shot hash+sign use-case. Deciding which function to use is left to the backend layer.
- The `RSA_set0_factors`, `RSA_set0_crt_params`, and friends' fallbacks for OpenSSL 1.0.2 are implemented on the Go side instead of on the C side, following the logic that Go is safer and easier to maintain than C.
- I'm aware that #42 also affects the logic in this PR. I'll cherry pick it and create a follow-up PR once it is merged.