### PR TITLE
Implement ECDSA

### DIFF
--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -158,12 +158,6 @@ func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	return pkey, nil
 }
 
-func bnFree(bn C.GO_BIGNUM_PTR) {
-	if bn != nil {
-		C.go_openssl_BN_free(bn)
-	}
-}
-
 func curveNID(curve string) (C.int, error) {
 	switch curve {
 	case "P-224":

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -1,0 +1,170 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"errors"
+	"runtime"
+)
+
+type PrivateKeyECDSA struct {
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey C.GO_EVP_PKEY_PTR
+}
+
+func (k *PrivateKeyECDSA) finalize() {
+	C.go_openssl_EVP_PKEY_free(k._pkey)
+}
+
+func (k *PrivateKeyECDSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
+	defer runtime.KeepAlive(k)
+	return f(k._pkey)
+}
+
+type PublicKeyECDSA struct {
+	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
+	_pkey C.GO_EVP_PKEY_PTR
+}
+
+func (k *PublicKeyECDSA) finalize() {
+	C.go_openssl_EVP_PKEY_free(k._pkey)
+}
+
+func (k *PublicKeyECDSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
+	defer runtime.KeepAlive(k)
+	return f(k._pkey)
+}
+
+var errUnknownCurve = errors.New("openssl: unknown elliptic curve")
+var errUnsupportedCurve = errors.New("openssl: unsupported elliptic curve")
+
+func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
+	pkey, err := newECKey(curve, X, Y, nil)
+	if err != nil {
+		return nil, err
+	}
+	k := &PublicKeyECDSA{_pkey: pkey}
+	runtime.SetFinalizer(k, (*PublicKeyECDSA).finalize)
+	return k, nil
+}
+
+func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error) {
+	pkey, err := newECKey(curve, X, Y, D)
+	if err != nil {
+		return nil, err
+	}
+	k := &PrivateKeyECDSA{_pkey: pkey}
+	runtime.SetFinalizer(k, (*PrivateKeyECDSA).finalize)
+	return k, nil
+}
+
+func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
+	// Generate the private key.
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer C.go_openssl_EVP_PKEY_free(pkey)
+
+	// Retrieve the internal EC_KEY, which holds the X, Y, and D coordinates.
+	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
+	if key == nil {
+		return nil, nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY failed")
+	}
+	defer C.go_openssl_EC_KEY_free(key)
+
+	// Allocate two big numbers to store the X and Y coordinates.
+	bx, by := C.go_openssl_BN_new(), C.go_openssl_BN_new()
+	defer func() {
+		bnFree(bx)
+		bnFree(by)
+	}()
+	if bx == nil || by == nil {
+		return nil, nil, nil, newOpenSSLError("BN_new failed")
+	}
+
+	// Get X and Y.
+	group := C.go_openssl_EC_KEY_get0_group(key)
+	pt := C.go_openssl_EC_KEY_get0_public_key(key)
+	if C.go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, bx, by, nil) == 0 {
+		return nil, nil, nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp failed")
+	}
+
+	// Get D.
+	bd := C.go_openssl_EC_KEY_get0_private_key(key)
+	return bnToBig(bx), bnToBig(by), bnToBig(bd), nil
+}
+
+func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
+	return evpSign(priv.withKey, 0, 0, 0, hash)
+}
+
+func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
+	return evpVerify(pub.withKey, 0, 0, 0, sig, hash) == nil
+}
+
+func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
+	nid, err := curveNID(curve)
+	if err != nil {
+		return nil, err
+	}
+	// Create a new EC_KEY for the given curve.
+	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
+	if key == nil {
+		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
+	}
+	defer C.go_openssl_EC_KEY_free(key)
+
+	// Convert X, Y, and D coordinates to OpenSSL format.
+	bx, by, bd := bigToBN(X), bigToBN(Y), bigToBN(D)
+	defer func() {
+		bnFree(bx)
+		bnFree(by)
+		bnFree(bd)
+	}()
+	if bx == nil || by == nil || (D != nil && bd == nil) {
+		return nil, newOpenSSLError("BN_lebin2bn failed")
+	}
+
+	// Set the public and private components.
+	if C.go_openssl_EC_KEY_set_public_key_affine_coordinates(key, bx, by) != 1 {
+		return nil, newOpenSSLError("EC_KEY_set_public_key_affine_coordinates failed")
+	}
+	if bd != nil && C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
+		return nil, newOpenSSLError("EC_KEY_set_private_key failed")
+	}
+
+	// Create the EVP_PKEY and assign it the EC_KEY.
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_set1_EC_KEY(pkey, key) != 1 {
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	return pkey, nil
+}
+
+func bnFree(bn C.GO_BIGNUM_PTR) {
+	if bn != nil {
+		C.go_openssl_BN_free(bn)
+	}
+}
+
+func curveNID(curve string) (C.int, error) {
+	switch curve {
+	case "P-224":
+		return C.GO_NID_secp224r1, nil
+	case "P-256":
+		return C.GO_NID_X9_62_prime256v1, nil
+	case "P-384":
+		return C.GO_NID_secp384r1, nil
+	case "P-521":
+		return C.GO_NID_secp521r1, nil
+	}
+	return 0, errUnknownCurve
+}

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -6,6 +6,7 @@ package openssl
 // #include "goopenssl.h"
 import "C"
 import (
+	"crypto"
 	"errors"
 	"runtime"
 )
@@ -102,10 +103,17 @@ func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
 	return evpSign(priv.withKey, 0, 0, 0, hash)
 }
 
+func HashSignECDSA(priv *PrivateKeyECDSA, h crypto.Hash, msg []byte) ([]byte, error) {
+	return evpHashSign(priv.withKey, h, msg)
+}
+
 func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 	return evpVerify(pub.withKey, 0, 0, 0, sig, hash) == nil
 }
 
+func HashVerifyECDSA(pub *PublicKeyECDSA, h crypto.Hash, msg, sig []byte) bool {
+	return evpHashVerify(pub.withKey, h, msg, sig) == nil
+}
 func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	nid, err := curveNID(curve)
 	if err != nil {

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -40,7 +40,6 @@ func (k *PublicKeyECDSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
 }
 
 var errUnknownCurve = errors.New("openssl: unknown elliptic curve")
-var errUnsupportedCurve = errors.New("openssl: unsupported elliptic curve")
 
 func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
 	pkey, err := newECKey(curve, X, Y, nil)

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -114,6 +114,7 @@ func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 func HashVerifyECDSA(pub *PublicKeyECDSA, h crypto.Hash, msg, sig []byte) bool {
 	return evpHashVerify(pub.withKey, h, msg, sig) == nil
 }
+
 func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	nid, err := curveNID(curve)
 	if err != nil {
@@ -126,7 +127,7 @@ func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	}
 	defer C.go_openssl_EC_KEY_free(key)
 
-	// Convert X, Y, and D coordinates to OpenSSL format.
+	// Convert X, Y, and D coordinates to OpenSSL format. D is optional and may be nil.
 	bx, by, bd := bigToBN(X), bigToBN(Y), bigToBN(D)
 	defer func() {
 		bnFree(bx)
@@ -152,7 +153,7 @@ func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	}
 	if C.go_openssl_EVP_PKEY_set1_EC_KEY(pkey, key) != 1 {
 		C.go_openssl_EVP_PKEY_free(pkey)
-		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+		return nil, newOpenSSLError("EVP_PKEY_set1_EC_KEY failed")
 	}
 	return pkey, nil
 }

--- a/openssl/ecdsa_test.go
+++ b/openssl/ecdsa_test.go
@@ -1,0 +1,87 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"testing"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl-fips/openssl/bbig"
+)
+
+func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+	tests := []struct {
+		name  string
+		curve elliptic.Curve
+	}{
+		{"P256", elliptic.P256()},
+		{"P224", elliptic.P224()},
+		{"P384", elliptic.P384()},
+		{"P521", elliptic.P521()},
+	}
+	for _, test := range tests {
+		curve := test.curve
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			f(t, curve)
+		})
+	}
+}
+
+func TestECDSAKeyGeneration(t *testing.T) {
+	testAllCurves(t, testECDSAKeyGeneration)
+}
+
+func testECDSAKeyGeneration(t *testing.T, c elliptic.Curve) {
+	priv, err := generateKeycurve(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.IsOnCurve(priv.PublicKey.X, priv.PublicKey.Y) {
+		t.Errorf("public key invalid: %s", err)
+	}
+}
+
+func TestECDSASignAndVerify(t *testing.T) {
+	testAllCurves(t, testECDSASignAndVerify)
+}
+
+func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
+	key, err := generateKeycurve(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := openssl.NewPrivateKeyECDSA(key.Params().Name, bbig.Enc(key.X), bbig.Enc(key.Y), bbig.Enc(key.D))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashed := []byte("testing")
+	sig, err := openssl.SignMarshalECDSA(priv, hashed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub, err := openssl.NewPublicKeyECDSA(key.Params().Name, bbig.Enc(key.X), bbig.Enc(key.Y))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !openssl.VerifyECDSA(pub, hashed, sig) {
+		t.Errorf("Verify failed")
+	}
+	hashed[0] ^= 0xff
+	if openssl.VerifyECDSA(pub, hashed, sig) {
+		t.Errorf("Verify succeeded despite intentionally invalid hash!")
+	}
+}
+
+func generateKeycurve(c elliptic.Curve) (*ecdsa.PrivateKey, error) {
+	x, y, d, err := openssl.GenerateKeyECDSA(c.Params().Name)
+	if err != nil {
+		return nil, err
+	}
+	return &ecdsa.PrivateKey{PublicKey: ecdsa.PublicKey{Curve: c, X: bbig.Dec(x), Y: bbig.Dec(y)}, D: bbig.Dec(d)}, nil
+}

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -238,3 +238,9 @@ func bnToBig(bn C.GO_BIGNUM_PTR) BigInt {
 	}
 	return x
 }
+
+func bnFree(bn C.GO_BIGNUM_PTR) {
+	if bn != nil {
+		C.go_openssl_BN_free(bn)
+	}
+}

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	//v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
-	err := openssl.Init("1.0.2")
+	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
+	err := openssl.Init(v)
 	if err != nil {
 		// An error here could mean that this Linux distro does not have a supported OpenSSL version
 		// or that there is a bug in the Init code.

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
-	err := openssl.Init(v)
+	//v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
+	err := openssl.Init("1.0.2")
 	if err != nil {
 		// An error here could mean that this Linux distro does not have a supported OpenSSL version
 		// or that there is a bug in the Init code.

--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -18,7 +18,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		return nil, nil, nil, nil, nil, nil, nil, nil, e
 	}
-	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_RSA, bits)
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_RSA, bits, "")
 	if err != nil {
 		return bad(err)
 	}

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -21,7 +21,21 @@ enum {
     GO_EVP_CTRL_GCM_SET_TAG = 0x11,
     GO_EVP_PKEY_CTRL_MD = 1,
     GO_EVP_PKEY_RSA = 6,
+    GO_EVP_PKEY_EC = 408,
     GO_EVP_MAX_MD_SIZE = 64
+};
+
+// #include <openssl/ec.h>
+enum {
+    GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001
+};
+
+// #include <openssl/obj_mac.h>
+enum {
+    GO_NID_X9_62_prime256v1 = 415,
+    GO_NID_secp224r1 = 713,
+    GO_NID_secp384r1 = 715,
+    GO_NID_secp521r1 = 716
 };
 
 // #include <openssl/rsa.h>
@@ -52,8 +66,12 @@ typedef void* GO_EVP_MD_CTX_PTR;
 typedef void* GO_HMAC_CTX_PTR;
 typedef void* GO_EVP_CIPHER_PTR;
 typedef void* GO_EVP_CIPHER_CTX_PTR;
+typedef void* GO_EC_KEY_PTR;
+typedef void* GO_EC_POINT_PTR;
+typedef void* GO_EC_GROUP_PTR;
 typedef void* GO_RSA_PTR;
 typedef void* GO_BIGNUM_PTR;
+typedef void* GO_BN_CTX_PTR;
 
 // #include <openssl/md5.h>
 typedef void* GO_MD5_CTX_PTR;
@@ -207,6 +225,8 @@ DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY_PTR pkey, const GO_EC_KEY_PTR key), (pkey, key)) \
+DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \
 DEFINEFUNC_1_1(int, RSA_set0_factors, (GO_RSA_PTR rsa, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q), (rsa, p, q)) \
@@ -215,8 +235,18 @@ DEFINEFUNC_1_1(void, RSA_get0_crt_params, (const GO_RSA_PTR r, const GO_BIGNUM_P
 DEFINEFUNC_1_1(int, RSA_set0_key, (GO_RSA_PTR r, GO_BIGNUM_PTR n, GO_BIGNUM_PTR e, GO_BIGNUM_PTR d), (r, n, e, d)) \
 DEFINEFUNC_1_1(void, RSA_get0_factors, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *p, const GO_BIGNUM_PTR *q), (rsa, p, q)) \
 DEFINEFUNC_1_1(void, RSA_get0_key, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *n, const GO_BIGNUM_PTR *e, const GO_BIGNUM_PTR *d), (rsa, n, e, d)) \
+DEFINEFUNC(GO_BIGNUM_PTR, BN_new, (void), ()) \
+DEFINEFUNC(void, BN_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
 /* bn_lebin2bn and bn_bn2lebinpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(GO_BIGNUM_PTR, BN_lebin2bn, bn_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
-/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen))
+/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
+DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
+DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
+DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
+DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4))

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -225,7 +225,7 @@ DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
-DEFINEFUNC(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY_PTR pkey, const GO_EC_KEY_PTR key), (pkey, key)) \
+DEFINEFUNC(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY_PTR pkey, GO_EC_KEY_PTR key), (pkey, key)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \


### PR DESCRIPTION
⚠️ This PR will be rebased once #43 is merged. Please review #43 first.

This PR implements the ECDSA API. The implementation is taken from the MSFT repo, which was heavily based on RedHat version.

Some comments for the reviewers:
- I've added the functions `HashSignRSAPKCS1v15` and `HashVerifyRSAPKCS1v15` to cover the on-shot hash+sign use-case. Deciding which function to use is left to the backend layer.