### PR TITLE
Implement ECDH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
     - name: Run Test
-      run: go test -gcflags=all=-d=checkptr -v ./...
+      # Run each test 10 times so the garbage collector chimes in 
+      # and exercises the multiple finalizers we use.
+      # This can detect use-after-free and double-free issues.
+      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}

--- a/cmd/checkheader/main.go
+++ b/cmd/checkheader/main.go
@@ -120,7 +120,7 @@ func generate(header string) (string, error) {
 			}
 			continue
 		}
-		if strings.HasPrefix(l, "enum {") {
+		if strings.HasPrefix(l, "enum {") || strings.HasPrefix(l, "typedef enum {") {
 			enum = true
 			continue
 		}

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"errors"
+	"runtime"
+)
+
+type PublicKeyECDH struct {
+	curve string
+	key   C.GO_EC_POINT_PTR
+	bytes []byte
+}
+
+func (k *PublicKeyECDH) finalize() {
+	C.go_openssl_EC_POINT_free(k.key)
+}
+
+type PrivateKeyECDH struct {
+	curve string
+	key   C.GO_EC_KEY_PTR
+}
+
+func (k *PrivateKeyECDH) finalize() {
+	C.go_openssl_EC_KEY_free(k.key)
+}
+
+func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
+	if len(bytes) < 1 {
+		return nil, errors.New("NewPublicKeyECDH: missing key")
+	}
+
+	nid, err := curveNID(curve)
+	if err != nil {
+		return nil, err
+	}
+
+	group := C.go_openssl_EC_GROUP_new_by_curve_name(nid)
+	if group == nil {
+		return nil, newOpenSSLError("EC_GROUP_new_by_curve_name")
+	}
+	defer C.go_openssl_EC_GROUP_free(group)
+	key := C.go_openssl_EC_POINT_new(group)
+	if key == nil {
+		return nil, newOpenSSLError("EC_POINT_new")
+	}
+	ok := C.go_openssl_EC_POINT_oct2point(group, key, base(bytes), C.size_t(len(bytes)), nil) != 0
+	if !ok {
+		C.go_openssl_EC_POINT_free(key)
+		return nil, errors.New("point not on curve")
+	}
+
+	k := &PublicKeyECDH{curve, key, append([]byte(nil), bytes...)}
+	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
+	return k, nil
+}
+
+func (k *PublicKeyECDH) Bytes() []byte { return k.bytes }
+
+func NewPrivateKeyECDH(curve string, bytes []byte) (*PrivateKeyECDH, error) {
+	nid, err := curveNID(curve)
+	if err != nil {
+		return nil, err
+	}
+	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
+	if key == nil {
+		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
+	}
+	b := bytesToBN(bytes)
+	ok := b != nil && C.go_openssl_EC_KEY_set_private_key(key, b) != 0
+	if b != nil {
+		C.go_openssl_BN_free(b)
+	}
+	if !ok {
+		C.go_openssl_EC_KEY_free(key)
+		return nil, newOpenSSLError("EC_KEY_set_private_key")
+	}
+	k := &PrivateKeyECDH{curve, key}
+	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	return k, nil
+}
+
+func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
+	defer runtime.KeepAlive(k)
+
+	group := C.go_openssl_EC_KEY_get0_group(k.key)
+	if group == nil {
+		return nil, newOpenSSLError("EC_KEY_get0_group")
+	}
+	kbig := C.go_openssl_EC_KEY_get0_private_key(k.key)
+	if kbig == nil {
+		return nil, newOpenSSLError("EC_KEY_get0_private_key")
+	}
+	pt := C.go_openssl_EC_POINT_new(group)
+	if pt == nil {
+		return nil, newOpenSSLError("EC_POINT_new")
+	}
+	if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
+		C.go_openssl_EC_POINT_free(pt)
+		return nil, newOpenSSLError("EC_POINT_mul")
+	}
+	bytes, err := pointBytesECDH(k.curve, group, pt)
+	if err != nil {
+		C.go_openssl_EC_POINT_free(pt)
+		return nil, err
+	}
+	pub := &PublicKeyECDH{k.curve, pt, bytes}
+	// Note: Same as in NewPublicKeyECDH regarding finalizer and KeepAlive.
+	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
+	return pub, nil
+}
+
+func pointBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
+	out := make([]byte, 1+2*curveSize(curve))
+	n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(out), C.size_t(len(out)), nil)
+	if int(n) != len(out) {
+		return nil, newOpenSSLError("EC_POINT_point2oct")
+	}
+	return out, nil
+}
+
+func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
+	group := C.go_openssl_EC_KEY_get0_group(priv.key)
+	if group == nil {
+		return nil, newOpenSSLError("EC_KEY_get0_group")
+	}
+	privBig := C.go_openssl_EC_KEY_get0_private_key(priv.key)
+	if privBig == nil {
+		return nil, newOpenSSLError("EC_KEY_get0_private_key")
+	}
+	pt := C.go_openssl_EC_POINT_new(group)
+	if pt == nil {
+		return nil, newOpenSSLError("EC_POINT_new")
+	}
+	defer C.go_openssl_EC_POINT_free(pt)
+	if C.go_openssl_EC_POINT_mul(group, pt, nil, pub.key, privBig, nil) == 0 {
+		return nil, newOpenSSLError("EC_POINT_mul")
+	}
+	out, err := xCoordBytesECDH(priv.curve, group, pt)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func xCoordBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
+	big := C.go_openssl_BN_new()
+	defer C.go_openssl_BN_free(big)
+	if C.go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, big, nil, nil) == 0 {
+		return nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp")
+	}
+	return bigBytesECDH(curve, big)
+}
+
+func bigBytesECDH(curve string, big C.GO_BIGNUM_PTR) ([]byte, error) {
+	out := make([]byte, curveSize(curve))
+	if C.go_openssl_BN_bn2binpad(big, base(out), C.int(len(out))) == 0 {
+		return nil, newOpenSSLError("BN_bn2binpad")
+	}
+	return out, nil
+}
+
+func curveSize(curve string) int {
+	switch curve {
+	default:
+		panic("openssl: unknown curve " + curve)
+	case "P-256":
+		return 256 / 8
+	case "P-384":
+		return 384 / 8
+	case "P-521":
+		return (521 + 7) / 8
+	}
+}
+
+func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer C.go_openssl_EVP_PKEY_free(pkey)
+	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
+	if key == nil {
+		return nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
+	}
+	group := C.go_openssl_EC_KEY_get0_group(key)
+	if group == nil {
+		C.go_openssl_EC_KEY_free(key)
+		return nil, nil, newOpenSSLError("EC_KEY_get0_group")
+	}
+	b := C.go_openssl_EC_KEY_get0_private_key(key)
+	if b == nil {
+		C.go_openssl_EC_KEY_free(key)
+		return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
+	}
+	bytes, err := bigBytesECDH(curve, b)
+	if err != nil {
+		C.go_openssl_EC_KEY_free(key)
+		return nil, nil, err
+	}
+
+	k := &PrivateKeyECDH{curve, key}
+	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	return k, bytes, nil
+}

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -14,50 +14,77 @@ import (
 )
 
 type PublicKeyECDH struct {
-	curve string
-	key   C.GO_EC_POINT_PTR
+	_pkey C.GO_EVP_PKEY_PTR
 	bytes []byte
+
+	// priv is only set when PublicKeyECDH is derived from a private key,
+	// in which case priv's finalizer is responsible for freeing _pkey.
+	// This ensures priv is not finalized while the public key is alive,
+	// which could cause use-after-free and double-free behavior.
+	//
+	// We could avoid this altogether by using EVP_PKEY_up_ref
+	// when instantiating a derived public key, unfortunately
+	// it is not available on OpenSSL 1.0.2.
+	priv *PrivateKeyECDH
 }
 
 func (k *PublicKeyECDH) finalize() {
-	C.go_openssl_EC_POINT_free(k.key)
+	if k.priv == nil {
+		C.go_openssl_EVP_PKEY_free(k._pkey)
+	}
 }
 
 type PrivateKeyECDH struct {
-	curve string
-	key   C.GO_EC_KEY_PTR
+	_pkey C.GO_EVP_PKEY_PTR
 }
 
 func (k *PrivateKeyECDH) finalize() {
-	C.go_openssl_EC_KEY_free(k.key)
+	C.go_openssl_EVP_PKEY_free(k._pkey)
 }
 
 func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 	if len(bytes) < 1 {
 		return nil, errors.New("NewPublicKeyECDH: missing key")
 	}
-
 	nid, err := curveNID(curve)
 	if err != nil {
 		return nil, err
 	}
-
-	group := C.go_openssl_EC_GROUP_new_by_curve_name(nid)
-	if group == nil {
-		return nil, newOpenSSLError("EC_GROUP_new_by_curve_name")
-	}
-	defer C.go_openssl_EC_GROUP_free(group)
-	key := C.go_openssl_EC_POINT_new(group)
+	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 	if key == nil {
-		return nil, newOpenSSLError("EC_POINT_new")
+		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
 	}
-	ok := C.go_openssl_EC_POINT_oct2point(group, key, base(bytes), C.size_t(len(bytes)), nil) != 0
-	if !ok {
-		C.go_openssl_EC_POINT_free(key)
-		return nil, errors.New("point not on curve")
+	var k *PublicKeyECDH
+	defer func() {
+		if k == nil {
+			C.go_openssl_EC_KEY_free(key)
+		}
+	}()
+	if vMajor == 1 && vMinor == 0 {
+		// EC_KEY_oct2key does not exist on OpenSSL 1.0.2,
+		// we have to simulate it.
+		group := C.go_openssl_EC_KEY_get0_group(key)
+		pt := C.go_openssl_EC_POINT_new(group)
+		if pt == nil {
+			return nil, newOpenSSLError("EC_POINT_new")
+		}
+		defer C.go_openssl_EC_POINT_free(pt)
+		if C.go_openssl_EC_POINT_oct2point(group, pt, base(bytes), C.size_t(len(bytes)), nil) != 1 {
+			return nil, errors.New("point not on curve")
+		}
+		if C.go_openssl_EC_KEY_set_public_key(key, pt) != 1 {
+			return nil, newOpenSSLError("EC_KEY_set_public_key")
+		}
+	} else {
+		if C.go_openssl_EC_KEY_oct2key(key, base(bytes), C.size_t(len(bytes)), nil) != 1 {
+			return nil, newOpenSSLError("EC_KEY_oct2key")
+		}
 	}
-
-	k := &PublicKeyECDH{curve, key, append([]byte(nil), bytes...)}
+	pkey, err := newEVPPKEY(key)
+	if err != nil {
+		return nil, err
+	}
+	k = &PublicKeyECDH{pkey, append([]byte(nil), bytes...), nil}
 	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
 	return k, nil
 }
@@ -69,115 +96,109 @@ func NewPrivateKeyECDH(curve string, bytes []byte) (*PrivateKeyECDH, error) {
 	if err != nil {
 		return nil, err
 	}
+	b := bytesToBN(bytes)
+	if b == nil {
+		return nil, newOpenSSLError("BN_bin2bn")
+	}
+	defer C.go_openssl_BN_free(b)
 	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
 	if key == nil {
 		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
 	}
-	b := bytesToBN(bytes)
-	ok := b != nil && C.go_openssl_EC_KEY_set_private_key(key, b) != 0
-	if b != nil {
-		C.go_openssl_BN_free(b)
-	}
-	if !ok {
-		C.go_openssl_EC_KEY_free(key)
+	var pkey C.GO_EVP_PKEY_PTR
+	defer func() {
+		if pkey == nil {
+			C.go_openssl_EC_KEY_free(key)
+		}
+	}()
+	if C.go_openssl_EC_KEY_set_private_key(key, b) != 1 {
 		return nil, newOpenSSLError("EC_KEY_set_private_key")
 	}
-	k := &PrivateKeyECDH{curve, key}
+	pkey, err = newEVPPKEY(key)
+	if err != nil {
+		return nil, err
+	}
+	k := &PrivateKeyECDH{pkey}
 	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
 	return k, nil
 }
 
 func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 	defer runtime.KeepAlive(k)
-
-	group := C.go_openssl_EC_KEY_get0_group(k.key)
+	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(k._pkey)
+	if key == nil {
+		return nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
+	}
+	defer C.go_openssl_EC_KEY_free(key)
+	group := C.go_openssl_EC_KEY_get0_group(key)
 	if group == nil {
 		return nil, newOpenSSLError("EC_KEY_get0_group")
 	}
-	kbig := C.go_openssl_EC_KEY_get0_private_key(k.key)
-	if kbig == nil {
-		return nil, newOpenSSLError("EC_KEY_get0_private_key")
-	}
-	pt := C.go_openssl_EC_POINT_new(group)
+	pt := C.go_openssl_EC_KEY_get0_public_key(key)
 	if pt == nil {
-		return nil, newOpenSSLError("EC_POINT_new")
+		// The public key will be nil if k has been generated using
+		// NewPrivateKeyECDH instead of GenerateKeyECDH.
+		//
+		// OpenSSL does not expose any method to generate the public
+		// key from the private key [1], so we have to calculate it here
+		// https://github.com/openssl/openssl/issues/18437#issuecomment-1144717206
+		pt = C.go_openssl_EC_POINT_new(group)
+		if pt == nil {
+			return nil, newOpenSSLError("EC_POINT_new")
+		}
+		defer C.go_openssl_EC_POINT_free(pt)
+		kbig := C.go_openssl_EC_KEY_get0_private_key(key)
+		if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
+			return nil, newOpenSSLError("EC_POINT_mul")
+		}
 	}
-	if C.go_openssl_EC_POINT_mul(group, pt, kbig, nil, nil, nil) == 0 {
-		C.go_openssl_EC_POINT_free(pt)
-		return nil, newOpenSSLError("EC_POINT_mul")
+	pt2octfn := func(data []byte) (int, error) {
+		n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(data), C.size_t(len(data)), nil)
+		if n == 0 {
+			return 0, newOpenSSLError("EC_POINT_point2oct")
+		}
+		return int(n), nil
 	}
-	bytes, err := pointBytesECDH(k.curve, group, pt)
+	// Get encoded point size.
+	n, err := pt2octfn(nil)
 	if err != nil {
-		C.go_openssl_EC_POINT_free(pt)
 		return nil, err
 	}
-	pub := &PublicKeyECDH{k.curve, pt, bytes}
+	// Encode point into bytes.
+	bytes := make([]byte, n)
+	_, err = pt2octfn(bytes)
+	if err != nil {
+		return nil, err
+	}
+	pub := &PublicKeyECDH{k._pkey, bytes, k}
 	// Note: Same as in NewPublicKeyECDH regarding finalizer and KeepAlive.
 	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
 	return pub, nil
 }
 
-func pointBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
-	out := make([]byte, 1+2*curveSize(curve))
-	n := C.go_openssl_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(out), C.size_t(len(out)), nil)
-	if int(n) != len(out) {
-		return nil, newOpenSSLError("EC_POINT_point2oct")
-	}
-	return out, nil
-}
-
 func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
-	group := C.go_openssl_EC_KEY_get0_group(priv.key)
-	if group == nil {
-		return nil, newOpenSSLError("EC_KEY_get0_group")
+	defer runtime.KeepAlive(priv)
+	defer runtime.KeepAlive(pub)
+	ctx := C.go_openssl_EVP_PKEY_CTX_new(priv._pkey, nil)
+	if ctx == nil {
+		return nil, newOpenSSLError("EVP_PKEY_CTX_new")
 	}
-	privBig := C.go_openssl_EC_KEY_get0_private_key(priv.key)
-	if privBig == nil {
-		return nil, newOpenSSLError("EC_KEY_get0_private_key")
+	defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	if C.go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 	}
-	pt := C.go_openssl_EC_POINT_new(group)
-	if pt == nil {
-		return nil, newOpenSSLError("EC_POINT_new")
+	if C.go_openssl_EVP_PKEY_derive_set_peer(ctx, pub._pkey) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_derive_set_peer")
 	}
-	defer C.go_openssl_EC_POINT_free(pt)
-	if C.go_openssl_EC_POINT_mul(group, pt, nil, pub.key, privBig, nil) == 0 {
-		return nil, newOpenSSLError("EC_POINT_mul")
+	var outLen C.size_t
+	if C.go_openssl_EVP_PKEY_derive(ctx, nil, &outLen) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 	}
-	out, err := xCoordBytesECDH(priv.curve, group, pt)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func xCoordBytesECDH(curve string, group C.GO_EC_GROUP_PTR, pt C.GO_EC_POINT_PTR) ([]byte, error) {
-	big := C.go_openssl_BN_new()
-	defer C.go_openssl_BN_free(big)
-	if C.go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, big, nil, nil) == 0 {
-		return nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp")
-	}
-	return bigBytesECDH(curve, big)
-}
-
-func bigBytesECDH(curve string, big C.GO_BIGNUM_PTR) ([]byte, error) {
-	out := make([]byte, curveSize(curve))
-	if C.go_openssl_BN_bn2binpad(big, base(out), C.int(len(out))) == 0 {
-		return nil, newOpenSSLError("BN_bn2binpad")
+	out := make([]byte, outLen)
+	if C.go_openssl_EVP_PKEY_derive(ctx, base(out), &outLen) != 1 {
+		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 	}
 	return out, nil
-}
-
-func curveSize(curve string) int {
-	switch curve {
-	default:
-		panic("openssl: unknown curve " + curve)
-	case "P-256":
-		return 256 / 8
-	case "P-384":
-		return 384 / 8
-	case "P-521":
-		return (521 + 7) / 8
-	}
 }
 
 func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
@@ -185,28 +206,27 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	defer C.go_openssl_EVP_PKEY_free(pkey)
+	var k *PrivateKeyECDH
+	defer func() {
+		if k == nil {
+			C.go_openssl_EVP_PKEY_free(pkey)
+		}
+	}()
 	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
 	if key == nil {
 		return nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY")
 	}
-	group := C.go_openssl_EC_KEY_get0_group(key)
-	if group == nil {
-		C.go_openssl_EC_KEY_free(key)
-		return nil, nil, newOpenSSLError("EC_KEY_get0_group")
-	}
+	defer C.go_openssl_EC_KEY_free(key)
 	b := C.go_openssl_EC_KEY_get0_private_key(key)
 	if b == nil {
-		C.go_openssl_EC_KEY_free(key)
 		return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
 	}
-	bytes, err := bigBytesECDH(curve, b)
-	if err != nil {
-		C.go_openssl_EC_KEY_free(key)
-		return nil, nil, err
+	bits := C.go_openssl_EVP_PKEY_get_bits(pkey)
+	out := make([]byte, (bits+7)/8)
+	if C.go_openssl_BN_bn2binpad(b, base(out), C.int(len(out))) == 0 {
+		return nil, nil, newOpenSSLError("BN_bn2binpad")
 	}
-
-	k := &PrivateKeyECDH{curve, key}
+	k = &PrivateKeyECDH{pkey}
 	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
-	return k, bytes, nil
+	return k, out, nil
 }

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -163,8 +163,7 @@ func newECDHPkey1(nid C.int, bytes []byte, isPrivate bool) (pkey C.GO_EVP_PKEY_P
 			return nil, newOpenSSLError("EC_KEY_set_public_key")
 		}
 	}
-	pkey, err = newEVPPKEY(key)
-	return
+	return newEVPPKEY(key)
 }
 
 func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, error) {
@@ -176,8 +175,7 @@ func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, e
 	params.addUTF8(paramGroup, C.GoString(C.go_openssl_OBJ_nid2sn(nid)))
 	var selection C.int
 	if isPrivate {
-		err := params.addBigNumber(paramPrivKey, bytes)
-		if err != nil {
+		if err := params.addBigNumber(paramPrivKey, bytes); err != nil {
 			return nil, err
 		}
 		selection = C.GO_EVP_PKEY_KEYPAIR

--- a/openssl/ecdh_test.go
+++ b/openssl/ecdh_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build linux && !android
+// +build linux,!android
+
+package openssl_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/golang-fips/openssl-fips/openssl"
+)
+
+func TestECDH(t *testing.T) {
+	for _, tt := range []string{"P-256", "P-384", "P-521"} {
+		t.Run(tt, func(t *testing.T) {
+			name := tt
+			aliceKey, alicPrivBytes, err := openssl.GenerateKeyECDH(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bobKey, _, err := openssl.GenerateKeyECDH(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			alicePubKeyFromPriv, err := aliceKey.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			alicePubBytes := alicePubKeyFromPriv.Bytes()
+			want := len(alicPrivBytes)
+			var got int
+			if tt == "X25519" {
+				got = len(alicePubBytes)
+			} else {
+				got = (len(alicePubBytes) - 1) / 2 // subtract encoding prefix and divide by the number of components
+			}
+			if want != got {
+				t.Fatalf("public key size mismatch: want: %v, got: %v", want, got)
+			}
+			alicePubKey, err := openssl.NewPublicKeyECDH(name, alicePubBytes)
+			if err != nil {
+				t.Error(err)
+			}
+
+			bobPubKeyFromPriv, err := bobKey.PublicKey()
+			if err != nil {
+				t.Error(err)
+			}
+			_, err = openssl.NewPublicKeyECDH(name, bobPubKeyFromPriv.Bytes())
+			if err != nil {
+				t.Error(err)
+			}
+
+			bobSecret, err := openssl.ECDH(bobKey, alicePubKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			aliceSecret, err := openssl.ECDH(aliceKey, bobPubKeyFromPriv)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(bobSecret, aliceSecret) {
+				t.Error("two ECDH computations came out different")
+			}
+		})
+	}
+}
+
+// The following vectors have been copied from
+// https://github.com/golang/go/blob/bb0d8297d76cb578baad8fa1485565d9acf44cc5/src/crypto/ecdh/ecdh_test.go.
+
+var ecdhvectors = []struct {
+	Name                  string
+	PrivateKey, PublicKey string
+	PeerPublicKey         string
+	SharedSecret          string
+}{
+	// NIST vectors from CAVS 14.1, ECC CDH Primitive (SP800-56A).
+	{
+		Name:       "P-256",
+		PrivateKey: "7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534",
+		PublicKey: "04ead218590119e8876b29146ff89ca61770c4edbbf97d38ce385ed281d8a6b230" +
+			"28af61281fd35e2fa7002523acc85a429cb06ee6648325389f59edfce1405141",
+		PeerPublicKey: "04700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287" +
+			"db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac",
+		SharedSecret: "46fc62106420ff012e54a434fbdd2d25ccc5852060561e68040dd7778997bd7b",
+	},
+	{
+		Name:       "P-384",
+		PrivateKey: "3cc3122a68f0d95027ad38c067916ba0eb8c38894d22e1b15618b6818a661774ad463b205da88cf699ab4d43c9cf98a1",
+		PublicKey: "049803807f2f6d2fd966cdd0290bd410c0190352fbec7ff6247de1302df86f25d34fe4a97bef60cff548355c015dbb3e5f" +
+			"ba26ca69ec2f5b5d9dad20cc9da711383a9dbe34ea3fa5a2af75b46502629ad54dd8b7d73a8abb06a3a3be47d650cc99",
+		PeerPublicKey: "04a7c76b970c3b5fe8b05d2838ae04ab47697b9eaf52e764592efda27fe7513272734466b400091adbf2d68c58e0c50066" +
+			"ac68f19f2e1cb879aed43a9969b91a0839c4c38a49749b661efedf243451915ed0905a32b060992b468c64766fc8437a",
+		SharedSecret: "5f9d29dc5e31a163060356213669c8ce132e22f57c9a04f40ba7fcead493b457e5621e766c40a2e3d4d6a04b25e533f1",
+	},
+	// For some reason all field elements in the test vector (both scalars and
+	// base field elements), but not the shared secret output, have two extra
+	// leading zero bytes (which in big-endian are irrelevant). Removed here.
+	{
+		Name:       "P-521",
+		PrivateKey: "017eecc07ab4b329068fba65e56a1f8890aa935e57134ae0ffcce802735151f4eac6564f6ee9974c5e6887a1fefee5743ae2241bfeb95d5ce31ddcb6f9edb4d6fc47",
+		PublicKey: "0400602f9d0cf9e526b29e22381c203c48a886c2b0673033366314f1ffbcba240ba42f4ef38a76174635f91e6b4ed34275eb01c8467d05ca80315bf1a7bbd945f550a5" +
+			"01b7c85f26f5d4b2d7355cf6b02117659943762b6d1db5ab4f1dbc44ce7b2946eb6c7de342962893fd387d1b73d7a8672d1f236961170b7eb3579953ee5cdc88cd2d",
+		PeerPublicKey: "0400685a48e86c79f0f0875f7bc18d25eb5fc8c0b07e5da4f4370f3a9490340854334b1e1b87fa395464c60626124a4e70d0f785601d37c09870ebf176666877a2046d" +
+			"01ba52c56fc8776d9e8f5db4f0cc27636d0b741bbe05400697942e80b739884a83bde99e0f6716939e632bc8986fa18dccd443a348b6c3e522497955a4f3c302f676",
+		SharedSecret: "005fc70477c3e63bc3954bd0df3ea0d1f41ee21746ed95fc5e1fdf90930d5e136672d72cc770742d1711c3c3a4c334a0ad9759436a4d3c5bf6e74b9578fac148c831",
+	},
+}
+
+func TestVectors(t *testing.T) {
+	for _, tt := range ecdhvectors {
+		t.Run(tt.Name, func(t *testing.T) {
+			key, err := openssl.NewPrivateKeyECDH(tt.Name, hexDecode(t, tt.PrivateKey))
+			if err != nil {
+				t.Fatal(err)
+			}
+			pub, err := key.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(pub.Bytes(), hexDecode(t, tt.PublicKey)) {
+				t.Error("public key derived from the private key does not match")
+			}
+			peer, err := openssl.NewPublicKeyECDH(tt.Name, hexDecode(t, tt.PeerPublicKey))
+			if err != nil {
+				t.Fatal(err)
+			}
+			secret, err := openssl.ECDH(key, peer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(secret, hexDecode(t, tt.SharedSecret)) {
+				t.Error("shared secret does not match")
+			}
+		})
+	}
+}
+
+func hexDecode(t *testing.T, s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal("invalid hex string:", s)
+	}
+	return b
+}

--- a/openssl/ecdh_test.go
+++ b/openssl/ecdh_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 //go:build linux && !android
 // +build linux,!android
 
@@ -44,12 +41,12 @@ func TestECDH(t *testing.T) {
 			}
 			alicePubKey, err := openssl.NewPublicKeyECDH(name, alicePubBytes)
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
 			}
 
 			bobPubKeyFromPriv, err := bobKey.PublicKey()
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
 			}
 			_, err = openssl.NewPublicKeyECDH(name, bobPubKeyFromPriv.Bytes())
 			if err != nil {
@@ -114,7 +111,7 @@ var ecdhvectors = []struct {
 	},
 }
 
-func TestVectors(t *testing.T) {
+func TestECDHVectors(t *testing.T) {
 	for _, tt := range ecdhvectors {
 		t.Run(tt.Name, func(t *testing.T) {
 			key, err := openssl.NewPrivateKeyECDH(tt.Name, hexDecode(t, tt.PrivateKey))
@@ -125,18 +122,20 @@ func TestVectors(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Equal(pub.Bytes(), hexDecode(t, tt.PublicKey)) {
+			got, want := pub.Bytes(), hexDecode(t, tt.PublicKey)
+			if !bytes.Equal(got, want) {
 				t.Error("public key derived from the private key does not match")
 			}
 			peer, err := openssl.NewPublicKeyECDH(tt.Name, hexDecode(t, tt.PeerPublicKey))
 			if err != nil {
 				t.Fatal(err)
 			}
-			secret, err := openssl.ECDH(key, peer)
+			got, err = openssl.ECDH(key, peer)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Equal(secret, hexDecode(t, tt.SharedSecret)) {
+			want = hexDecode(t, tt.SharedSecret)
+			if !bytes.Equal(got, want) {
 				t.Error("shared secret does not match")
 			}
 		})

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -119,40 +119,37 @@ func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Create a new EC_KEY for the given curve.
-	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
-	if key == nil {
-		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
-	}
-	defer C.go_openssl_EC_KEY_free(key)
-
-	// Convert X, Y, and D coordinates to OpenSSL format. D is optional and may be nil.
-	bx, by, bd := bigToBN(X), bigToBN(Y), bigToBN(D)
+	var bx, by, bd C.GO_BIGNUM_PTR
 	defer func() {
 		bnFree(bx)
 		bnFree(by)
 		bnFree(bd)
 	}()
+	bx = bigToBN(X)
+	by = bigToBN(Y)
+	bd = bigToBN(D)
 	if bx == nil || by == nil || (D != nil && bd == nil) {
 		return nil, newOpenSSLError("BN_lebin2bn failed")
 	}
-
-	// Set the public and private components.
+	key := C.go_openssl_EC_KEY_new_by_curve_name(nid)
+	if key == nil {
+		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
+	}
+	var pkey C.GO_EVP_PKEY_PTR
+	defer func() {
+		if pkey == nil {
+			defer C.go_openssl_EC_KEY_free(key)
+		}
+	}()
 	if C.go_openssl_EC_KEY_set_public_key_affine_coordinates(key, bx, by) != 1 {
 		return nil, newOpenSSLError("EC_KEY_set_public_key_affine_coordinates failed")
 	}
-	if bd != nil && C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
+	if D != nil && C.go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
 		return nil, newOpenSSLError("EC_KEY_set_private_key failed")
 	}
-
-	// Create the EVP_PKEY and assign it the EC_KEY.
-	pkey := C.go_openssl_EVP_PKEY_new()
-	if pkey == nil {
-		return nil, newOpenSSLError("EVP_PKEY_new failed")
-	}
-	if C.go_openssl_EVP_PKEY_set1_EC_KEY(pkey, key) != 1 {
-		C.go_openssl_EVP_PKEY_free(pkey)
-		return nil, newOpenSSLError("EVP_PKEY_set1_EC_KEY failed")
+	pkey, err = newEVPPKEY(key)
+	if err != nil {
+		return nil, err
 	}
 	return pkey, nil
 }

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -70,11 +70,7 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	defer C.go_openssl_EVP_PKEY_free(pkey)
 
 	// Retrieve the internal EC_KEY, which holds the X, Y, and D coordinates.
-	key := C.go_openssl_EVP_PKEY_get1_EC_KEY(pkey)
-	if key == nil {
-		return nil, nil, nil, newOpenSSLError("EVP_PKEY_get1_EC_KEY failed")
-	}
-	defer C.go_openssl_EC_KEY_free(key)
+	key := getECKey(pkey)
 
 	// Allocate two big numbers to store the X and Y coordinates.
 	bx, by := C.go_openssl_BN_new(), C.go_openssl_BN_new()

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -354,7 +354,7 @@ func newEVPPKEY(key C.GO_EC_KEY_PTR) (C.GO_EVP_PKEY_PTR, error) {
 	if pkey == nil {
 		return nil, newOpenSSLError("EVP_PKEY_new failed")
 	}
-	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, unsafe.Pointer(key)) != 1 {
 		C.go_openssl_EVP_PKEY_free(pkey)
 		return nil, newOpenSSLError("EVP_PKEY_assign failed")
 	}
@@ -366,9 +366,8 @@ func newEVPPKEY(key C.GO_EC_KEY_PTR) (C.GO_EVP_PKEY_PTR, error) {
 // The returned key should not be freed.
 func getECKey(pkey C.GO_EVP_PKEY_PTR) (key C.GO_EC_KEY_PTR) {
 	if vMajor == 1 && vMinor == 0 {
-		key0 := C.go_openssl_EVP_PKEY_get0(pkey)
-		if key0 != nil {
-			key = (C.GO_EC_KEY_PTR)(key0)
+		if key0 := C.go_openssl_EVP_PKEY_get0(pkey); key0 != nil {
+			key = C.GO_EC_KEY_PTR(key0)
 		}
 	} else {
 		key = C.go_openssl_EVP_PKEY_get0_EC_KEY(pkey)

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -345,3 +345,15 @@ func evpHashVerify(withKey withKeyFunc, h crypto.Hash, msg, sig []byte) error {
 	}
 	return nil
 }
+
+func newEVPPKEY(key C.GO_EC_KEY_PTR) (C.GO_EVP_PKEY_PTR, error) {
+	pkey := C.go_openssl_EVP_PKEY_new()
+	if pkey == nil {
+		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C.go_openssl_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, (unsafe.Pointer)(key)) != 1 {
+		C.go_openssl_EVP_PKEY_free(pkey)
+		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+	}
+	return pkey, nil
+}

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -143,3 +143,21 @@ go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
 
     return 1;
 };
+
+static inline void
+go_openssl_params_free(OSSL_PARAM params[])
+{
+    if (params == NULL)
+        return;
+
+    // Loop through all the params until the first NULL key.
+    for (; params->key != NULL; params++)
+    {
+        if (params->data != NULL)
+        {
+            free(params->data);
+            params->data = NULL;
+        }
+    }
+    return;
+}

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -247,6 +247,13 @@ func wbase(b BigInt) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(&b[0]))
 }
 
+func bytesToBN(x []byte) C.GO_BIGNUM_PTR {
+	if len(x) == 0 {
+		return nil
+	}
+	return C.go_openssl_BN_bin2bn(base(x), C.int(len(x)), nil)
+}
+
 func bigToBN(x BigInt) C.GO_BIGNUM_PTR {
 	if len(x) == 0 {
 		return nil

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -247,13 +247,6 @@ func wbase(b BigInt) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(&b[0]))
 }
 
-func bytesToBN(x []byte) C.GO_BIGNUM_PTR {
-	if len(x) == 0 {
-		return nil
-	}
-	return C.go_openssl_BN_bin2bn(base(x), C.int(len(x)), nil)
-}
-
 func bigToBN(x BigInt) C.GO_BIGNUM_PTR {
 	if len(x) == 0 {
 		return nil

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -1,0 +1,90 @@
+//go:build linux && !android
+// +build linux,!android
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+var paramEnd = C.OSSL_PARAM{
+	key:         nil,
+	data_type:   0,
+	data:        nil,
+	data_size:   0,
+	return_size: 0,
+}
+
+// paramsBuilder is a container for OSSL_PARAMs.
+// It must be freed using paramsBuilder.free().
+type paramsBuilder struct {
+	params []C.OSSL_PARAM
+}
+
+func newParamsBuilder() paramsBuilder {
+	var pb paramsBuilder
+	pb.params = make([]C.OSSL_PARAM, 1, 5)
+	pb.params[0] = paramEnd
+	return pb
+}
+
+func (pb *paramsBuilder) free() {
+	C.go_openssl_params_free(&pb.params[0])
+	pb.params = pb.params[:1]
+	pb.params[0] = paramEnd
+}
+
+// addUTF8 adds a parameter of type data_type.
+// data is stored in the new parameter without copying,
+// any change to it's content after this call will also
+// affect the created parameter.
+func (pb *paramsBuilder) add(key *C.char, data_type C.uint, data unsafe.Pointer, data_size C.size_t) {
+	var return_size = C.GO_OSSL_PARAM_UNMODIFIED
+	pb.params[len(pb.params)-1] = C.OSSL_PARAM{
+		key:         key,
+		data_type:   data_type,
+		data:        data,
+		data_size:   data_size,
+		return_size: C.size_t(return_size),
+	}
+	pb.params = append(pb.params, paramEnd)
+}
+
+// addUTF8 adds a parameter of type OSSL_PARAM_UTF8_STRING.
+func (pb *paramsBuilder) addUTF8(key *C.char, v string) {
+	pb.add(key, C.GO_OSSL_PARAM_UTF8_STRING, unsafe.Pointer(C.CString(v)), C.size_t(len(v)))
+}
+
+// addOctetString adds a parameter of type OSSL_PARAM_OCTET_STRING.
+// The content of v is copied into the new param,
+// it's safe to change it after this call.
+func (pb *paramsBuilder) addOctetString(key *C.char, v []byte) {
+	pb.add(key, C.GO_OSSL_PARAM_OCTET_STRING, C.CBytes(v), C.size_t(len(v)))
+}
+
+// addBigNumber adds a parameter of type OSSL_PARAM_UNSIGNED_INTEGER.
+// The content of v is copied into the new param,
+// it's safe to change it after this call.
+func (pb *paramsBuilder) addBigNumber(key *C.char, v []byte) error {
+	cbytes := (*C.uchar)(C.CBytes(v))
+	if nativeEndian != binary.BigEndian {
+		// The original bytes represent a big number using big-endian.
+		// Unfortunately, OpenSSL expects that big numbers are passed using native-endian.
+		// The following call re-encodes cbytes as little-endian.
+		// We would have to to this even if we called OSSL_PARAM_construct_BN,
+		// as it also expect a native-endian number.
+		priv := C.go_openssl_BN_bin2bn(cbytes, C.int(len(v)), nil)
+		if priv == nil {
+			return newOpenSSLError("BN_bin2bn")
+		}
+		defer bnFree(priv)
+		if C.go_openssl_BN_bn2lebinpad(priv, cbytes, C.int(len(v))) == -1 {
+			return newOpenSSLError("BN_bn2lebinpad")
+		}
+	}
+	pb.add(key, C.GO_OSSL_PARAM_UNSIGNED_INTEGER, unsafe.Pointer(cbytes), C.size_t(len(v)))
+	return nil
+}

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -39,7 +39,7 @@ func (pb *paramsBuilder) free() {
 
 // addUTF8 adds a parameter of type data_type.
 // data is stored in the new parameter without copying,
-// any change to it's content after this call will also
+// so any change to its content after this call will also
 // affect the created parameter.
 func (pb *paramsBuilder) add(key *C.char, data_type C.uint, data unsafe.Pointer, data_size C.size_t) {
 	var return_size = C.GO_OSSL_PARAM_UNMODIFIED

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -42,6 +42,9 @@ func (pb *paramsBuilder) free() {
 // so any change to its content after this call will also
 // affect the created parameter.
 func (pb *paramsBuilder) add(key *C.char, data_type C.uint, data unsafe.Pointer, data_size C.size_t) {
+	if key == nil {
+		panic("key shouldn't be nil")
+	}
 	var return_size = C.GO_OSSL_PARAM_UNMODIFIED
 	pb.params[len(pb.params)-1] = C.OSSL_PARAM{
 		key:         key,

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -30,6 +30,10 @@ enum {
     GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID = 0x1001
 };
 
+typedef enum {
+    GO_POINT_CONVERSION_UNCOMPRESSED = 4,
+} point_conversion_form_t;
+
 // #include <openssl/obj_mac.h>
 enum {
     GO_NID_X9_62_prime256v1 = 415,
@@ -239,9 +243,11 @@ DEFINEFUNC(GO_BIGNUM_PTR, BN_new, (void), ()) \
 DEFINEFUNC(void, BN_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
-/* bn_lebin2bn and bn_bn2lebinpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
+DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BIGNUM_PTR arg2), (arg0, arg1, arg2)) \
+/* bn_lebin2bn, bn_bn2lebinpad and BN_bn2binpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(GO_BIGNUM_PTR, BN_lebin2bn, bn_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
+/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2binpad, bn_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
 DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
@@ -249,4 +255,11 @@ DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR ar
 DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
-DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4))
+DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
+DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR arg0), (arg0)) \
+DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
+DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
+DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \
+DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
+DEFINEFUNC(size_t, EC_POINT_point2oct, (const GO_EC_GROUP_PTR group, const GO_EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, form, buf, len, ctx)) \
+DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx))

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -252,7 +252,7 @@ DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BI
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2binpad, bn_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
-DEFINEFUNC_LEGACY_1_0(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
+DEFINEFUNC(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
 DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC_1_1(int, EC_KEY_oct2key, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (eckey, buf, len, ctx)) \
@@ -260,6 +260,9 @@ DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR ar
 DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
+DEFINEFUNC_1_1(int, EC_KEY_oct2priv, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len), (eckey, buf, len)) \
+DEFINEFUNC_1_1(size_t, EC_KEY_priv2oct, (const GO_EC_KEY_PTR eckey, unsigned char *buf, size_t len), (eckey, buf, len)) \
+DEFINEFUNC_1_1(size_t, EC_KEY_key2buf, (const GO_EC_KEY_PTR eckey, point_conversion_form_t form, unsigned char **pbuf, GO_BN_CTX_PTR ctx), (eckey, form, pbuf, ctx)) \
 DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
 DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -22,7 +22,10 @@ enum {
     GO_EVP_PKEY_CTRL_MD = 1,
     GO_EVP_PKEY_RSA = 6,
     GO_EVP_PKEY_EC = 408,
-    GO_EVP_MAX_MD_SIZE = 64
+    GO_EVP_MAX_MD_SIZE = 64,
+
+    GO_EVP_PKEY_PUBLIC_KEY = 0x86,
+    GO_EVP_PKEY_KEYPAIR = 0x87
 };
 
 // #include <openssl/ec.h>
@@ -59,6 +62,13 @@ enum {
     GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL = 0x100A
 };
 
+enum {
+    GO_OSSL_PARAM_UNMODIFIED = -1,
+    GO_OSSL_PARAM_UNSIGNED_INTEGER = 2,
+    GO_OSSL_PARAM_UTF8_STRING = 4,
+    GO_OSSL_PARAM_OCTET_STRING = 5
+};
+
 typedef void* GO_OPENSSL_INIT_SETTINGS_PTR;
 typedef void* GO_OSSL_LIB_CTX_PTR;
 typedef void* GO_OSSL_PROVIDER_PTR;
@@ -82,6 +92,19 @@ typedef void* GO_MD5_CTX_PTR;
 
 // #include <openssl/sha.h>
 typedef void* GO_SHA_CTX_PTR;
+
+// OSSL_PARAM does not follow the GO_FOO_PTR pattern
+// because it is not passed around as a pointer but on the stack.
+// We can't abstract it away by using a void*.
+// Copied from
+// https://github.com/openssl/openssl/blob/fcae2ae4f675def607d338b7945b9af1dd9bb746/include/openssl/core.h#L82-L88.
+typedef struct {
+    const char *key;
+    unsigned int data_type;
+    void *data;
+    size_t data_size;
+    size_t return_size;
+} OSSL_PARAM;
 
 // FOR_ALL_OPENSSL_FUNCTIONS is the list of all functions from libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -233,7 +256,14 @@ DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, s
 DEFINEFUNC(int, EVP_PKEY_derive_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_PKEY_derive_set_peer, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR peer), (ctx, peer)) \
 DEFINEFUNC(int, EVP_PKEY_derive, (GO_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen), (ctx, key, keylen)) \
-DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC_LEGACY_1_0(void*, EVP_PKEY_get0, (GO_EVP_PKEY_PTR pkey), (pkey)) \
+/* EVP_PKEY_get0_EC_KEY OpenSSL 1.1.0 and 1.1.1 do not define the inputs and outputs as const  */ \
+/*check:from=3.0.0*/ DEFINEFUNC_1_1(const GO_EC_KEY_PTR, EVP_PKEY_get0_EC_KEY, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
+DEFINEFUNC_3_0(int, EVP_PKEY_fromdata_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC_3_0(int, EVP_PKEY_fromdata, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR *pkey, int selection, OSSL_PARAM params[]), (ctx, pkey, selection, params)) \
+DEFINEFUNC_3_0(int, EVP_PKEY_set1_encoded_public_key, (GO_EVP_PKEY_PTR pkey, const unsigned char *pub, size_t publen), (pkey, pub, publen)) \
+DEFINEFUNC_3_0(size_t, EVP_PKEY_get1_encoded_public_key, (GO_EVP_PKEY_PTR pkey, unsigned char **ppub), (pkey, ppub)) \
+DEFINEFUNC_3_0(int, EVP_PKEY_get_bn_param, (const GO_EVP_PKEY_PTR pkey, const char *key_name, GO_BIGNUM_PTR *bn), (pkey, key_name, bn)) \
 DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \
 DEFINEFUNC_1_1(int, RSA_set0_factors, (GO_RSA_PTR rsa, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q), (rsa, p, q)) \
@@ -255,17 +285,17 @@ DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO
 DEFINEFUNC(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
 DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
-DEFINEFUNC_1_1(int, EC_KEY_oct2key, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (eckey, buf, len, ctx)) \
 DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
-DEFINEFUNC_1_1(int, EC_KEY_oct2priv, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len), (eckey, buf, len)) \
-DEFINEFUNC_1_1(size_t, EC_KEY_priv2oct, (const GO_EC_KEY_PTR eckey, unsigned char *buf, size_t len), (eckey, buf, len)) \
-DEFINEFUNC_1_1(size_t, EC_KEY_key2buf, (const GO_EC_KEY_PTR eckey, point_conversion_form_t form, unsigned char **pbuf, GO_BN_CTX_PTR ctx), (eckey, form, pbuf, ctx)) \
 DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
 DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \
 DEFINEFUNC(int, EC_POINT_get_affine_coordinates_GFp, (const GO_EC_GROUP_PTR arg0, const GO_EC_POINT_PTR arg1, GO_BIGNUM_PTR arg2, GO_BIGNUM_PTR arg3, GO_BN_CTX_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
 DEFINEFUNC(size_t, EC_POINT_point2oct, (const GO_EC_GROUP_PTR group, const GO_EC_POINT_PTR p, point_conversion_form_t form, unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, form, buf, len, ctx)) \
-DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx))
+DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR p, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (group, p, buf, len, ctx)) \
+DEFINEFUNC(const char *, OBJ_nid2sn, (int n), (n)) \
+DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
+DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR group), (group)) \
+

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -209,9 +209,10 @@ DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_256_gcm, (void), ()) \
 DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
-/* EVP_PKEY_size pkey parameter is const since OpenSSL 1.1.1. */ \
+/* EVP_PKEY_size and EVP_PKEY_get_bits pkey parameter is const since OpenSSL 1.1.1. */ \
 /* Exclude it from headercheck tool when using previous OpenSSL versions. */ \
 /*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_size, EVP_PKEY_size, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
+/*check:from=1.1.1*/ DEFINEFUNC_RENAMED_3_0(int, EVP_PKEY_get_bits, EVP_PKEY_bits, (const GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(void, EVP_PKEY_free, (GO_EVP_PKEY_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_RSA_PTR, EVP_PKEY_get1_RSA, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(int, EVP_PKEY_assign, (GO_EVP_PKEY_PTR pkey, int type, void *key), (pkey, type, key)) \
@@ -229,7 +230,9 @@ DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_verify_init, (GO_EVP_PKEY_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_PKEY_sign, (GO_EVP_PKEY_CTX_PTR arg0, unsigned char *arg1, size_t *arg2, const unsigned char *arg3, size_t arg4), (arg0, arg1, arg2, arg3, arg4)) \
-DEFINEFUNC(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY_PTR pkey, GO_EC_KEY_PTR key), (pkey, key)) \
+DEFINEFUNC(int, EVP_PKEY_derive_init, (GO_EVP_PKEY_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC(int, EVP_PKEY_derive_set_peer, (GO_EVP_PKEY_CTX_PTR ctx, GO_EVP_PKEY_PTR peer), (ctx, peer)) \
+DEFINEFUNC(int, EVP_PKEY_derive, (GO_EVP_PKEY_CTX_PTR ctx, unsigned char *key, size_t *keylen), (ctx, key, keylen)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY_PTR pkey), (pkey)) \
 DEFINEFUNC(GO_RSA_PTR, RSA_new, (void), ()) \
 DEFINEFUNC(void, RSA_free, (GO_RSA_PTR arg0), (arg0)) \
@@ -249,14 +252,14 @@ DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BI
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 /*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2binpad, bn_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 DEFINEFUNC(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
+DEFINEFUNC_LEGACY_1_0(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
 DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_GROUP_PTR, EC_KEY_get0_group, (const GO_EC_KEY_PTR arg0), (arg0)) \
+DEFINEFUNC_1_1(int, EC_KEY_oct2key, (GO_EC_KEY_PTR eckey, const unsigned char *buf, size_t len, GO_BN_CTX_PTR ctx), (eckey, buf, len, ctx)) \
 DEFINEFUNC(const GO_BIGNUM_PTR, EC_KEY_get0_private_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(const GO_EC_POINT_PTR, EC_KEY_get0_public_key, (const GO_EC_KEY_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EC_KEY_PTR, EC_KEY_new_by_curve_name, (int arg0), (arg0)) \
 DEFINEFUNC(int, EC_KEY_set_private_key, (GO_EC_KEY_PTR arg0, const GO_BIGNUM_PTR arg1), (arg0, arg1)) \
-DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
-DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EC_POINT_PTR, EC_POINT_new, (const GO_EC_GROUP_PTR arg0), (arg0)) \
 DEFINEFUNC(void, EC_POINT_free, (GO_EC_POINT_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EC_POINT_mul, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PTR r, const GO_BIGNUM_PTR n, const GO_EC_POINT_PTR q, const GO_BIGNUM_PTR m, GO_BN_CTX_PTR ctx), (group, r, n, q, m, ctx)) \


### PR DESCRIPTION
This PR implements the ECDH functions.

@derekparker @ueno I haven't ported `SharedKeyECDH` function. For what I can see, it was only used to support OpenSSL ECDH on `crypto/tls`. Go1.20 implements ECDH using the new `crypto/ecdh` package, so it would be easier for you to just use the ECDH functions from this PR than trying to retrofit `SharedKeyECDH`. Please correct me if I'm wrong, in which case I'll try to port it. 