### PR TITLE
Add SupportsHKDF()

### DIFF
--- a/openssl/hkdf.go
+++ b/openssl/hkdf.go
@@ -19,6 +19,10 @@ type hkdf struct {
 	ctx *C.GO_EVP_PKEY_CTX
 }
 
+func SupportsHKDF() bool {
+	return openSSLVersion() >= OPENSSL_VERSION_1_1_1
+}
+
 func newHKDF(h func() hash.Hash, mode C.int) (*hkdf, error) {
 	if openSSLVersion() < OPENSSL_VERSION_1_1_1 {
 		return nil, NewOpenSSLError("HKDF is not supported")


### PR DESCRIPTION
This commit introduces a function that returns true or false depending on whether the OpenSSL version is expected to support HKDF. It is expected to be used by the crypto/tls library to help determine whether TLS version 1.3 can be used in FIPS mode.