### PR TITLE
Fix memory leak in GenerateKeyRSA

### DIFF
--- a/openssl/rsa.go
+++ b/openssl/rsa.go
@@ -27,6 +27,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	if key == nil {
 		return bad(newOpenSSLError("EVP_PKEY_get1_RSA failed"))
 	}
+	defer C.go_openssl_RSA_free(key)
 	N, E, D = rsaGetKey(key)
 	P, Q = rsaGetFactors(key)
 	Dp, Dq, Qinv = rsaGetCRTParams(key)


### PR DESCRIPTION
`GenerateKeyRSA` calls `EVP_PKEY_get1_RSA` without freeing the returned pointer, causing a leak.