### PR TITLE
Implement HMAC using EVP_MAC_CTX on OpenSSL 3

### DIFF
--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -11,12 +11,6 @@ import (
 	"unsafe"
 )
 
-var (
-	paramPubKey  = C.CString("pub")
-	paramPrivKey = C.CString("priv")
-	paramGroup   = C.CString("group")
-)
-
 type PublicKeyECDH struct {
 	_pkey C.GO_EVP_PKEY_PTR
 	bytes []byte

--- a/openssl/hmac.go
+++ b/openssl/hmac.go
@@ -22,66 +22,126 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
 		return nil
 	}
 
-	var hkey []byte
-	if len(key) > 0 {
-		// Note: Could hash down long keys here using EVP_Digest.
-		hkey = make([]byte, len(key))
-		copy(hkey, key)
-	} else {
+	if len(key) == 0 {
 		// This is supported in OpenSSL/Standard lib and as such
 		// we must support it here. When using HMAC with a null key
 		// HMAC_Init will try and reuse the key from the ctx. This is
 		// not the behavior previously implemented, so as a workaround
 		// we pass an "empty" key.
-		hkey = make([]byte, C.GO_EVP_MAX_MD_SIZE)
+		key = make([]byte, C.GO_EVP_MAX_MD_SIZE)
 	}
 
-	return newHMAC(md, ch, hkey)
+	switch vMajor {
+	case 1:
+		return newHMAC1(key, ch, md)
+	case 3:
+		return newHMAC3(key, ch, md)
+	default:
+		panic(errUnsupportedVersion())
+	}
+}
+
+// hmacCtx3 is used for OpenSSL 1.
+type hmacCtx1 struct {
+	ctx C.GO_HMAC_CTX_PTR
+}
+
+// hmacCtx3 is used for OpenSSL 3.
+type hmacCtx3 struct {
+	ctx C.GO_EVP_MAC_CTX_PTR
+	key []byte
 }
 
 type opensslHMAC struct {
-	md        C.GO_EVP_MD_PTR
-	ctx       C.GO_HMAC_CTX_PTR
+	ctx1      hmacCtx1
+	ctx3      hmacCtx3
 	size      int
 	blockSize int
-	key       []byte
 	sum       []byte
 }
 
-func newHMAC(md C.GO_EVP_MD_PTR, h hash.Hash, key []byte) *opensslHMAC {
+func newHMAC1(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
+	ctx := hmacCtxNew()
+	if ctx == nil {
+		panic("openssl: EVP_MAC_CTX_new failed")
+	}
+	if C.go_openssl_HMAC_Init_ex(ctx, unsafe.Pointer(&key[0]), C.int(len(key)), md, nil) == 0 {
+		panic(newOpenSSLError("HMAC_Init_ex failed"))
+	}
 	hmac := &opensslHMAC{
-		md:        md,
 		size:      h.Size(),
 		blockSize: h.BlockSize(),
-		key:       key,
-		ctx:       hmacCtxNew(),
+		ctx1:      hmacCtx1{ctx},
 	}
 	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
-	hmac.Reset()
+	return hmac
+}
+
+func newHMAC3(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
+	mac := C.go_openssl_EVP_MAC_fetch(nil, paramAlgHMAC, nil)
+	ctx := C.go_openssl_EVP_MAC_CTX_new(mac)
+	if ctx == nil {
+		panic("openssl: EVP_MAC_CTX_new failed")
+	}
+	digest := C.go_openssl_EVP_MD_get0_name(md)
+	params := newParamsBuilder()
+	params.addUTF8(paramDigest, C.GoString(digest))
+	if C.go_openssl_EVP_MAC_init(ctx, base(key), C.size_t(len(key)), &params.params[0]) == 0 {
+		panic(newOpenSSLError("EVP_MAC_init failed"))
+	}
+	hkey := make([]byte, len(key))
+	copy(hkey, key)
+	hmac := &opensslHMAC{
+		size:      h.Size(),
+		blockSize: h.BlockSize(),
+		ctx3:      hmacCtx3{ctx, hkey},
+	}
+	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 	return hmac
 }
 
 func (h *opensslHMAC) Reset() {
-	hmacCtxReset(h.ctx)
+	switch vMajor {
+	case 1:
+		if C.go_openssl_HMAC_Init_ex(h.ctx1.ctx, nil, 0, nil, nil) == 0 {
+			panic(newOpenSSLError("HMAC_Init_ex failed"))
+		}
+	case 3:
+		// EVP_MAC_init only reset the ctx internal state if a key is passed
+		// when using OpenSSL 3.0.1 and 3.0.2.
+		// See https://github.com/openssl/openssl/issues/17811.
+		if C.go_openssl_EVP_MAC_init(h.ctx3.ctx, base(h.ctx3.key), C.size_t(len(h.ctx3.key)), nil) == 0 {
+			panic(newOpenSSLError("EVP_MAC_init failed"))
+		}
+	default:
+		panic(errUnsupportedVersion())
+	}
 
-	if C.go_openssl_HMAC_Init_ex(h.ctx, unsafe.Pointer(&h.key[0]), C.int(len(h.key)), h.md, nil) == 0 {
-		panic("openssl: HMAC_Init failed")
-	}
-	if size := C.go_openssl_EVP_MD_get_size(h.md); size != C.int(h.size) {
-		println("openssl: HMAC size:", size, "!=", h.size)
-		panic("openssl: HMAC size mismatch")
-	}
 	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
 	h.sum = nil
 }
 
 func (h *opensslHMAC) finalize() {
-	hmacCtxFree(h.ctx)
+	switch vMajor {
+	case 1:
+		hmacCtxFree(h.ctx1.ctx)
+	case 3:
+		C.go_openssl_EVP_MAC_CTX_free(h.ctx3.ctx)
+	default:
+		panic(errUnsupportedVersion())
+	}
 }
 
 func (h *opensslHMAC) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		C.go_openssl_HMAC_Update(h.ctx, base(p), C.size_t(len(p)))
+		switch vMajor {
+		case 1:
+			C.go_openssl_HMAC_Update(h.ctx1.ctx, base(p), C.size_t(len(p)))
+		case 3:
+			C.go_openssl_EVP_MAC_update(h.ctx3.ctx, base(p), C.size_t(len(p)))
+		default:
+			panic(errUnsupportedVersion())
+		}
 	}
 	runtime.KeepAlive(h)
 	return len(p), nil
@@ -104,12 +164,27 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	// that Sum has no effect on the underlying stream.
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
-	ctx2 := hmacCtxNew()
-	defer hmacCtxFree(ctx2)
-	if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx) == 0 {
-		panic("openssl: HMAC_CTX_copy failed")
+	switch vMajor {
+	case 1:
+		ctx2 := hmacCtxNew()
+		if ctx2 == nil {
+			panic("openssl: HMAC_CTX_new failed")
+		}
+		defer hmacCtxFree(ctx2)
+		if C.go_openssl_HMAC_CTX_copy(ctx2, h.ctx1.ctx) == 0 {
+			panic("openssl: HMAC_CTX_copy failed")
+		}
+		C.go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
+	case 3:
+		ctx2 := C.go_openssl_EVP_MAC_CTX_dup(h.ctx3.ctx)
+		if ctx2 == nil {
+			panic("openssl: EVP_MAC_CTX_dup failed")
+		}
+		defer C.go_openssl_EVP_MAC_CTX_free(ctx2)
+		C.go_openssl_EVP_MAC_final(ctx2, base(h.sum), nil, C.size_t(len(h.sum)))
+	default:
+		panic(errUnsupportedVersion())
 	}
-	C.go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
 	return append(in, h.sum...)
 }
 
@@ -125,22 +200,7 @@ func hmacCtxNew() C.GO_HMAC_CTX_PTR {
 	return C.go_openssl_HMAC_CTX_new()
 }
 
-func hmacCtxReset(ctx C.GO_HMAC_CTX_PTR) {
-	if ctx == nil {
-		return
-	}
-	if vMajor == 1 && vMinor == 0 {
-		C.go_openssl_HMAC_CTX_cleanup(ctx)
-		C.go_openssl_HMAC_CTX_init(ctx)
-		return
-	}
-	C.go_openssl_HMAC_CTX_reset(ctx)
-}
-
 func hmacCtxFree(ctx C.GO_HMAC_CTX_PTR) {
-	if ctx == nil {
-		return
-	}
 	if vMajor == 1 && vMinor == 0 {
 		C.go_openssl_HMAC_CTX_cleanup(ctx)
 		C.free(unsafe.Pointer(ctx))

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -10,6 +10,14 @@ import (
 	"unsafe"
 )
 
+var (
+	paramAlgHMAC = C.CString("HMAC")
+	paramDigest  = C.CString("digest")
+	paramPubKey  = C.CString("pub")
+	paramPrivKey = C.CString("priv")
+	paramGroup   = C.CString("group")
+)
+
 var paramEnd = C.OSSL_PARAM{
 	key:         nil,
 	data_type:   0,

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 //go:build linux && !android
 // +build linux,!android
 

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -86,6 +86,8 @@ typedef void* GO_EC_GROUP_PTR;
 typedef void* GO_RSA_PTR;
 typedef void* GO_BIGNUM_PTR;
 typedef void* GO_BN_CTX_PTR;
+typedef void* GO_EVP_MAC_PTR;
+typedef void* GO_EVP_MAC_CTX_PTR;
 
 // #include <openssl/md5.h>
 typedef void* GO_MD5_CTX_PTR;
@@ -172,6 +174,7 @@ DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, con
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
+DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
@@ -198,7 +201,6 @@ DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha256, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha384, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ()) \
-DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_size, EVP_MD_size, (const GO_EVP_MD_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_cleanup, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, HMAC_Init_ex, (GO_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const GO_EVP_MD_PTR arg3, GO_ENGINE_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \
@@ -207,7 +209,6 @@ DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX_PTR arg0, unsigned char *arg1, unsigned
 DEFINEFUNC(int, HMAC_CTX_copy, (GO_HMAC_CTX_PTR dest, GO_HMAC_CTX_PTR src), (dest, src)) \
 DEFINEFUNC_1_1(void, HMAC_CTX_free, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_1_1(GO_HMAC_CTX_PTR, HMAC_CTX_new, (void), ()) \
-DEFINEFUNC_1_1(int, HMAC_CTX_reset, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_EVP_CIPHER_CTX_PTR, EVP_CIPHER_CTX_new, (void), ()) \
 DEFINEFUNC(int, EVP_CIPHER_CTX_set_padding, (GO_EVP_CIPHER_CTX_PTR x, int padding), (x, padding)) \
 DEFINEFUNC(int, EVP_CipherInit_ex, (GO_EVP_CIPHER_CTX_PTR ctx, const GO_EVP_CIPHER_PTR type, GO_ENGINE_PTR impl, const unsigned char *key, const unsigned char *iv, int enc), (ctx, type, impl, key, iv, enc)) \
@@ -298,4 +299,11 @@ DEFINEFUNC(int, EC_POINT_oct2point, (const GO_EC_GROUP_PTR group, GO_EC_POINT_PT
 DEFINEFUNC(const char *, OBJ_nid2sn, (int n), (n)) \
 DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
 DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR group), (group)) \
+DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
+DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
+DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_dup, (const GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
+DEFINEFUNC_3_0(int, EVP_MAC_init, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const OSSL_PARAM params[]), (ctx, key, keylen, params)) \
+DEFINEFUNC_3_0(int, EVP_MAC_update, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *data, size_t datalen), (ctx, data, datalen)) \
+DEFINEFUNC_3_0(int, EVP_MAC_final, (GO_EVP_MAC_CTX_PTR ctx, unsigned char *out, size_t *outl, size_t outsize), (ctx, out, outl, outsize)) \
 


### PR DESCRIPTION
This PR updates the HMAC implementation to use `EVP_MAC_CTX` on OpenSSL 3 instead of the deprecated `HMAC_CTX`.

While here, I've changed how OpenSSL 1 resets the context to avoid having to keep the key around. [HMAC_Init_ex](https://www.openssl.org/docs/man1.0.2/man3/HMAC_Init_ex.html) reuses the same key and hash function if they are not passed, as `Reset()` is not changing those parameters, there is no need to pass them.

> HMAC_Init_ex() initializes or reuses a HMAC_CTX structure to use the hash function evp_md and key key. If both are NULL (or evp_md is the same as the previous digest used by ctx and key is NULL) the existing key is reused. ctx must have been created with HMAC_CTX_new() before the first use of an HMAC_CTX in this function. N.B. HMAC_Init() had this undocumented behaviour in previous versions of OpenSSL - failure to switch to HMAC_Init_ex() in programs that expect it will cause them to stop working. 

Unfortunately the same optimization can't be used on OpenSSL 3 due to this bug: https://github.com/openssl/openssl/issues/17811.