### PR TITLE
Remove wrapper around BN_free

### DIFF
--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -145,7 +145,7 @@ func newECDHPkey1(nid C.int, bytes []byte, isPrivate bool) (pkey C.GO_EVP_PKEY_P
 		if priv == nil {
 			return nil, newOpenSSLError("BN_bin2bn")
 		}
-		defer bnFree(priv)
+		defer C.go_openssl_BN_free(priv)
 		if C.go_openssl_EC_KEY_set_private_key(key, priv) != 1 {
 			return nil, newOpenSSLError("EC_KEY_set_private_key")
 		}
@@ -224,7 +224,7 @@ func deriveEcdhPublicKey(pkey C.GO_EVP_PKEY_PTR, curve string) error {
 		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
 			return newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
-		defer bnFree(priv)
+		defer C.go_openssl_BN_free(priv)
 		nid, _ := curveNID(curve)
 		group := C.go_openssl_EC_GROUP_new_by_curve_name(nid)
 		if group == nil {
@@ -312,7 +312,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
 			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
-		defer bnFree(priv)
+		defer C.go_openssl_BN_free(priv)
 	default:
 		panic(errUnsupportedVersion())
 	}

--- a/openssl/ecdsa.go
+++ b/openssl/ecdsa.go
@@ -75,8 +75,8 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 	// Allocate two big numbers to store the X and Y coordinates.
 	bx, by := C.go_openssl_BN_new(), C.go_openssl_BN_new()
 	defer func() {
-		bnFree(bx)
-		bnFree(by)
+		C.go_openssl_BN_free(bx)
+		C.go_openssl_BN_free(by)
 	}()
 	if bx == nil || by == nil {
 		return nil, nil, nil, newOpenSSLError("BN_new failed")
@@ -117,9 +117,9 @@ func newECKey(curve string, X, Y, D BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	}
 	var bx, by, bd C.GO_BIGNUM_PTR
 	defer func() {
-		bnFree(bx)
-		bnFree(by)
-		bnFree(bd)
+		C.go_openssl_BN_free(bx)
+		C.go_openssl_BN_free(by)
+		C.go_openssl_BN_free(bd)
 	}()
 	bx = bigToBN(X)
 	by = bigToBN(Y)

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -277,9 +277,3 @@ func bnToBig(bn C.GO_BIGNUM_PTR) BigInt {
 	}
 	return x
 }
-
-func bnFree(bn C.GO_BIGNUM_PTR) {
-	if bn != nil {
-		C.go_openssl_BN_free(bn)
-	}
-}

--- a/openssl/openssl.go
+++ b/openssl/openssl.go
@@ -106,7 +106,7 @@ func FIPS() bool {
 		// EVP_default_properties_is_fips_enabled can return true even if the FIPS provider isn't loaded,
 		// it is only based on the default properties.
 		// We can be sure that the FIPS provider is available if we can fetch an algorithm, e.g., SHA2-256,
-		// explictly setting `fips=yes`.
+		// explicitly setting `fips=yes`.
 		return providerAvailable(propFipsYes)
 	default:
 		panic(errUnsupportedVersion())

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -77,7 +77,7 @@ func (pb *paramsBuilder) addBigNumber(key *C.char, v []byte) error {
 		// The original bytes represent a big number using big-endian.
 		// Unfortunately, OpenSSL expects that big numbers are passed using native-endian.
 		// The following call re-encodes cbytes as little-endian.
-		// We would have to to this even if we called OSSL_PARAM_construct_BN,
+		// We would have to do this even if we called OSSL_PARAM_construct_BN,
 		// as it also expect a native-endian number.
 		priv := C.go_openssl_BN_bin2bn(cbytes, C.int(len(v)), nil)
 		if priv == nil {

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -83,7 +83,7 @@ func (pb *paramsBuilder) addBigNumber(key *C.char, v []byte) error {
 		if priv == nil {
 			return newOpenSSLError("BN_bin2bn")
 		}
-		defer bnFree(priv)
+		defer C.go_openssl_BN_free(priv)
 		if C.go_openssl_BN_bn2lebinpad(priv, cbytes, C.int(len(v))) == -1 {
 			return newOpenSSLError("BN_bn2lebinpad")
 		}


### PR DESCRIPTION
The wrapper `bnFree` was there only to guard `BN_free` from a potentially
NULL argument, while `BN_free` actually takes care of it as it follows
the same semantics of free.