### PR TITLE
Add GitLeaks configuration

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+#
+# GitLeaks Repo Specific Configuration
+#
+# This allowlist is used to ignore false positives during secret scans.
+
+[allowlist]
+paths = [
+      'openssl/ecdh_test.go',
+]


### PR DESCRIPTION
This adds a configuration file for GitLeaks secret scanning to ignore false-positives:

```console
  $ ./gitleaks detect -v -s ../openssl-fips
  ...
  {
	"Description": "Generic API Key",
	"StartLine": 87,
	"EndLine": 87,
	"StartColumn": 11,
	"EndColumn": 81,
	"Match": "Key: ...",
	"Secret": "...",
	"File": "openssl/ecdh_test.go",
```