### PR TITLE
Backport ECDH implementation from wip/combined-codebase-staging

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+#
+# GitLeaks Repo Specific Configuration
+#
+# This allowlist is used to ignore false positives during secret scans.
+
+[allowlist]
+paths = [
+      'openssl/ecdh_test.go',
+]

--- a/openssl/ecdh.go
+++ b/openssl/ecdh.go
@@ -9,100 +9,310 @@ package openssl
 
 // #include "goopenssl.h"
 import "C"
-import "runtime"
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
 
-// ECDH keys are compatible with ECDSA
-type PublicKeyECDH = PublicKeyECDSA
-type PrivateKeyECDH = PrivateKeyECDSA
+var (
+	paramPubKey  = C.CString("pub")
+	paramPrivKey = C.CString("priv")
+	paramGroup   = C.CString("group")
+)
 
-var NewPublicKeyECDH = NewPublicKeyECDSA
-var NewPrivateKeyECDH = NewPrivateKeyECDSA
-var GenerateKeyECDH = GenerateKeyECDSA
+type PublicKeyECDH struct {
+	_pkey *C.GO_EVP_PKEY
+	bytes []byte
 
-func (k *PrivateKeyECDH) withKey(f func(*C.GO_EC_KEY) C.int) C.int {
-	// Because of the finalizer, any time _key is passed to cgo, that call must
-	// be followed by a call to runtime.KeepAlive, to make sure k is not
-	// collected (and finalized) before the cgo call returns.
-	defer runtime.KeepAlive(k)
-	return f(k.key)
+	// priv is only set when PublicKeyECDH is derived from a private key,
+	// in which case priv's finalizer is responsible for freeing _pkey.
+	// This ensures priv is not finalized while the public key is alive,
+	// which could cause use-after-free and double-free behavior.
+	//
+	// We could avoid this altogether by using EVP_PKEY_up_ref
+	// when instantiating a derived public key, unfortunately
+	// it is not available on OpenSSL 1.0.2.
+	priv *PrivateKeyECDH
 }
 
-func (k *PublicKeyECDH) withKey(f func(*C.GO_EC_KEY) C.int) C.int {
-	// Because of the finalizer, any time _key is passed to cgo, that call must
-	// be followed by a call to runtime.KeepAlive, to make sure k is not
-	// collected (and finalized) before the cgo call returns.
-	defer runtime.KeepAlive(k)
-	return f(k.key)
+func (k *PublicKeyECDH) finalize() {
+	if k.priv == nil {
+		C._goboringcrypto_EVP_PKEY_free(k._pkey)
+	}
 }
 
-func getPeerKey(priv *PrivateKeyECDH, pubBytes []byte) (*PublicKeyECDH, error) {
-	eckey := C._goboringcrypto_EC_KEY_new()
-	if priv.withKey(func(key *C.GO_EC_KEY) C.int {
-		group := C._goboringcrypto_EC_KEY_get0_group(key)
-		return C._goboringcrypto_EC_KEY_set_group(eckey, group)
-	}) != 1 {
-		return nil, NewOpenSSLError("EC_KEY_set_group")
+type PrivateKeyECDH struct {
+	_pkey        *C.GO_EVP_PKEY
+	curve        string
+	hasPublicKey bool
+}
+
+func (k *PrivateKeyECDH) finalize() {
+	C._goboringcrypto_EVP_PKEY_free(k._pkey)
+}
+
+func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
+	if len(bytes) < 1 {
+		return nil, errors.New("NewPublicKeyECDH: missing key")
 	}
-	if C._goboringcrypto_EC_KEY_oct2key(eckey,
-		base(pubBytes), C.size_t(len(pubBytes)),
-		nil) != 1 {
-		return nil, NewOpenSSLError("EC_KEY_oct2key")
+	pkey, err := newECDHPkey(curve, bytes, false)
+	if err != nil {
+		return nil, err
 	}
-	k := &PublicKeyECDSA{eckey}
-	// Note: Because of the finalizer, any time k.key is passed to cgo,
-	// that call must be followed by a call to runtime.KeepAlive(k),
-	// to make sure k is not collected (and finalized) before the cgo
-	// call returns.
+	k := &PublicKeyECDH{pkey, append([]byte(nil), bytes...), nil}
 	runtime.SetFinalizer(k, (*PublicKeyECDH).finalize)
 	return k, nil
 }
 
-func SharedKeyECDH(priv *PrivateKeyECDH, peerPublicKey []byte) ([]byte, error) {
-	pkeyOurs := C._goboringcrypto_EVP_PKEY_new()
-	if pkeyOurs == nil {
-		return nil, NewOpenSSLError("EVP_PKEY_new failed")
-	}
-	defer C._goboringcrypto_EVP_PKEY_free(pkeyOurs)
-	if priv.withKey(func(key *C.GO_EC_KEY) C.int {
-		return C._goboringcrypto_EVP_PKEY_set1_EC_KEY(pkeyOurs, key)
-	}) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_set1_EC_KEY")
-	}
+func (k *PublicKeyECDH) Bytes() []byte { return k.bytes }
 
-	pub, err := getPeerKey(priv, peerPublicKey)
+func NewPrivateKeyECDH(curve string, bytes []byte) (*PrivateKeyECDH, error) {
+	pkey, err := newECDHPkey(curve, bytes, true)
 	if err != nil {
 		return nil, err
 	}
+	k := &PrivateKeyECDH{pkey, curve, false}
+	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	return k, nil
+}
 
-	pkeyPeers := C._goboringcrypto_EVP_PKEY_new()
-	if pkeyPeers == nil {
-		return nil, NewOpenSSLError("EVP_PKEY_new failed")
+func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
+	defer runtime.KeepAlive(k)
+	if !k.hasPublicKey {
+		err := deriveEcdhPublicKey(k._pkey, k.curve)
+		if err != nil {
+			return nil, err
+		}
+		k.hasPublicKey = true
 	}
-	defer C._goboringcrypto_EVP_PKEY_free(pkeyPeers)
-	if pub.withKey(func(key *C.GO_EC_KEY) C.int {
-		return C._goboringcrypto_EVP_PKEY_set1_EC_KEY(pkeyPeers, key)
-	}) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_set1_EC_KEY")
+	var bytes []byte
+	if openSSLVersion() < OPENSSL_VERSION_3_0_0 {
+		key := getECKey(k._pkey)
+		pt := C._goboringcrypto_EC_KEY_get0_public_key(key)
+		if pt == nil {
+			return nil, NewOpenSSLError("EC_KEY_get0_public_key")
+		}
+		group := C._goboringcrypto_EC_KEY_get0_group(key)
+		var err error
+		bytes, err = encodeEcPoint(group, pt)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var cbytes *C.uchar
+		n := C._goboringcrypto_EVP_PKEY_get1_encoded_public_key(k._pkey, &cbytes)
+		if n == 0 {
+			return nil, NewOpenSSLError("EVP_PKEY_get_octet_string_param")
+		}
+		bytes = C.GoBytes(unsafe.Pointer(cbytes), C.int(n))
+		C.free(unsafe.Pointer(cbytes))
 	}
+	pub := &PublicKeyECDH{k._pkey, bytes, k}
+	runtime.SetFinalizer(pub, (*PublicKeyECDH).finalize)
+	return pub, nil
+}
 
-	ctx := C._goboringcrypto_EVP_PKEY_CTX_new(pkeyOurs, nil)
+func newECDHPkey(curve string, bytes []byte, isPrivate bool) (*C.GO_EVP_PKEY, error) {
+	nid, err := curveNID(curve)
+	if err != nil {
+		return nil, err
+	}
+	if openSSLVersion() < OPENSSL_VERSION_3_0_0 {
+		return newECDHPkey1(nid, bytes, isPrivate)
+	} else {
+		return newECDHPkey3(nid, bytes, isPrivate)
+	}
+}
+
+func newECDHPkey1(nid C.int, bytes []byte, isPrivate bool) (pkey *C.GO_EVP_PKEY, err error) {
+	key := C._goboringcrypto_EC_KEY_new_by_curve_name(nid)
+	if key == nil {
+		return nil, NewOpenSSLError("EC_KEY_new_by_curve_name")
+	}
+	defer func() {
+		if pkey == nil {
+			C._goboringcrypto_EC_KEY_free(key)
+		}
+	}()
+	if isPrivate {
+		priv := C._goboringcrypto_BN_bin2bn(base(bytes), C.size_t(len(bytes)), nil)
+		if priv == nil {
+			return nil, NewOpenSSLError("BN_bin2bn")
+		}
+		defer C._goboringcrypto_BN_free(priv)
+		if C._goboringcrypto_EC_KEY_set_private_key(key, priv) != 1 {
+			return nil, NewOpenSSLError("EC_KEY_set_private_key")
+		}
+	} else {
+		group := C._goboringcrypto_EC_KEY_get0_group(key)
+		pub := C._goboringcrypto_EC_POINT_new(group)
+		if pub == nil {
+			return nil, NewOpenSSLError("EC_POINT_new")
+		}
+		defer C._goboringcrypto_EC_POINT_free(pub)
+		if C._goboringcrypto_EC_POINT_oct2point(group, pub, base(bytes), C.size_t(len(bytes)), nil) != 1 {
+			return nil, errors.New("point not on curve")
+		}
+		if C._goboringcrypto_EC_KEY_set_public_key(key, pub) != 1 {
+			return nil, NewOpenSSLError("EC_KEY_set_public_key")
+		}
+	}
+	return newEVPPKEY(key)
+}
+
+func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (*C.GO_EVP_PKEY, error) {
+	params := newParamsBuilder()
+	defer params.free()
+	params.addUTF8(paramGroup, C.GoString(C._goboringcrypto_OBJ_nid2sn(nid)))
+	var selection C.int
+	if isPrivate {
+		if err := params.addBigNumber(paramPrivKey, bytes); err != nil {
+			return nil, err
+		}
+		selection = C.GO_EVP_PKEY_KEYPAIR
+	} else {
+		params.addOctetString(paramPubKey, bytes)
+		selection = C.GO_EVP_PKEY_PUBLIC_KEY
+	}
+	return newEvpFromParams(C.GO_EVP_PKEY_EC, selection, params.params)
+}
+
+// deriveEcdhPublicKey sets the raw public key of pkey by deriving it from
+// the raw private key.
+func deriveEcdhPublicKey(pkey *C.GO_EVP_PKEY, curve string) error {
+	derive := func(group *C.GO_EC_GROUP, priv *C.GO_BIGNUM) (*C.GO_EC_POINT, error) {
+		// OpenSSL does not expose any method to generate the public
+		// key from the private key [1], so we have to calculate it here.
+		// [1] https://github.com/openssl/openssl/issues/18437#issuecomment-1144717206
+		pt := C._goboringcrypto_EC_POINT_new(group)
+		if pt == nil {
+			return nil, NewOpenSSLError("EC_POINT_new")
+		}
+		if C._goboringcrypto_EC_POINT_mul(group, pt, priv, nil, nil, nil) == 0 {
+			C._goboringcrypto_EC_POINT_free(pt)
+			return nil, NewOpenSSLError("EC_POINT_mul")
+		}
+		return pt, nil
+	}
+	if openSSLVersion() < OPENSSL_VERSION_3_0_0 {
+		key := getECKey(pkey)
+		priv := C._goboringcrypto_EC_KEY_get0_private_key(key)
+		if priv == nil {
+			return NewOpenSSLError("EC_KEY_get0_private_key")
+		}
+		group := C._goboringcrypto_EC_KEY_get0_group(key)
+		pub, err := derive(group, priv)
+		if err != nil {
+			return err
+		}
+		defer C._goboringcrypto_EC_POINT_free(pub)
+		if C._goboringcrypto_EC_KEY_set_public_key(key, pub) != 1 {
+			return NewOpenSSLError("EC_KEY_set_public_key")
+		}
+	} else {
+		var priv *C.GO_BIGNUM
+		if C._goboringcrypto_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
+			return NewOpenSSLError("EVP_PKEY_get_bn_param")
+		}
+		defer C._goboringcrypto_BN_free(priv)
+		nid, _ := curveNID(curve)
+		group := C._goboringcrypto_EC_GROUP_new_by_curve_name(nid)
+		if group == nil {
+			return NewOpenSSLError("EC_GROUP_new_by_curve_name")
+		}
+		defer C._goboringcrypto_EC_GROUP_free(group)
+		pt, err := derive(group, priv)
+		if err != nil {
+			return err
+		}
+		defer C._goboringcrypto_EC_POINT_free(pt)
+		pubBytes, err := encodeEcPoint(group, pt)
+		if err != nil {
+			return err
+		}
+		if C._goboringcrypto_EVP_PKEY_set1_encoded_public_key(pkey, base(pubBytes), C.size_t(len(pubBytes))) != 1 {
+			return NewOpenSSLError("EVP_PKEY_set1_encoded_public_key")
+		}
+	}
+	return nil
+}
+
+func encodeEcPoint(group *C.GO_EC_GROUP, pt *C.GO_EC_POINT) ([]byte, error) {
+	// Get encoded point size.
+	n := C._goboringcrypto_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, nil, 0, nil)
+	if n == 0 {
+		return nil, NewOpenSSLError("EC_POINT_point2oct")
+	}
+	// Encode point into bytes.
+	bytes := make([]byte, n)
+	n = C._goboringcrypto_EC_POINT_point2oct(group, pt, C.GO_POINT_CONVERSION_UNCOMPRESSED, base(bytes), n, nil)
+	if n == 0 {
+		return nil, NewOpenSSLError("EC_POINT_point2oct")
+	}
+	return bytes, nil
+}
+
+func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
+	defer runtime.KeepAlive(priv)
+	defer runtime.KeepAlive(pub)
+	ctx := C._goboringcrypto_EVP_PKEY_CTX_new(priv._pkey, nil)
 	if ctx == nil {
-		return nil, NewOpenSSLError("EVP_PKEY_CTX_new failed")
+		return nil, NewOpenSSLError("EVP_PKEY_CTX_new")
 	}
 	defer C._goboringcrypto_EVP_PKEY_CTX_free(ctx)
 	if C._goboringcrypto_EVP_PKEY_derive_init(ctx) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_derive_init failed")
+		return nil, NewOpenSSLError("EVP_PKEY_derive_init")
 	}
-	if C._goboringcrypto_EVP_PKEY_derive_set_peer_ex(ctx, pkeyPeers, 1) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_derive_set_peer_ex failed")
+	if C._goboringcrypto_EVP_PKEY_derive_set_peer_ex(ctx, pub._pkey, 1) != 1 {
+		return nil, NewOpenSSLError("EVP_PKEY_derive_set_peer_ex")
 	}
 	var outLen C.size_t
 	if C._goboringcrypto_EVP_PKEY_derive(ctx, nil, &outLen) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_derive_init failed")
+		return nil, NewOpenSSLError("EVP_PKEY_derive_init")
 	}
 	out := make([]byte, outLen)
 	if C._goboringcrypto_EVP_PKEY_derive(ctx, base(out), &outLen) != 1 {
-		return nil, NewOpenSSLError("EVP_PKEY_derive_init failed")
+		return nil, NewOpenSSLError("EVP_PKEY_derive_init")
 	}
-	return out[:outLen], nil
+	return out, nil
+}
+
+func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
+	pkey, err := generateEVPPKey(C.GO_EVP_PKEY_EC, 0, curve)
+	if err != nil {
+		return nil, nil, err
+	}
+	var k *PrivateKeyECDH
+	defer func() {
+		if k == nil {
+			C._goboringcrypto_EVP_PKEY_free(pkey)
+		}
+	}()
+	var priv *C.GO_BIGNUM
+	if openSSLVersion() < OPENSSL_VERSION_3_0_0 {
+		key := getECKey(pkey)
+		priv = C._goboringcrypto_EC_KEY_get0_private_key(key)
+		if priv == nil {
+			return nil, nil, NewOpenSSLError("EC_KEY_get0_private_key")
+		}
+	} else {
+		if C._goboringcrypto_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
+			return nil, nil, NewOpenSSLError("EVP_PKEY_get_bn_param")
+		}
+		defer C._goboringcrypto_BN_free(priv)
+	}
+	// We should not leak bit length of the secret scalar in the key.
+	// For this reason, we use BN_bn2binpad instead of BN_bn2bin with fixed length.
+	// The fixed length is the order of the large prime subgroup of the curve,
+	// returned by EVP_PKEY_get_bits, which is generally the upper bound for
+	// generating a private ECDH key.
+	bits := C._goboringcrypto_EVP_PKEY_get_bits(pkey)
+	bytes := make([]byte, (bits+7)/8)
+	if C._goboringcrypto_BN_bn2binpad(priv, base(bytes), C.int(len(bytes))) == 0 {
+		return nil, nil, NewOpenSSLError("BN_bn2binpad")
+	}
+	k = &PrivateKeyECDH{pkey, curve, true}
+	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)
+	return k, bytes, nil
 }

--- a/openssl/ecdh_test.go
+++ b/openssl/ecdh_test.go
@@ -1,74 +1,151 @@
+//go:build linux && !android
+// +build linux,!android
+
 package openssl_test
 
 import (
 	"bytes"
-	"github.com/golang-fips/openssl-fips/openssl"
-	"github.com/golang-fips/openssl-fips/openssl/bbig"
-	"math/big"
+	"encoding/hex"
 	"testing"
+
+	"github.com/golang-fips/openssl-fips/openssl"
 )
 
-func TestSharedKeyECDH(t *testing.T) {
-	if !openssl.Enabled() {
-		t.Skip("boringcrypto: skipping test, FIPS not enabled")
-	}
-	// Test vector from CAVS
-	x, ok := new(big.Int).SetString(
-		"ead218590119e8876b29146ff89ca61770c4edbbf97d38ce385ed281d8a6b230",
-		16,
-	)
-	if !ok {
-		panic("bad hex")
-	}
-	y, ok := new(big.Int).SetString(
-		"28af61281fd35e2fa7002523acc85a429cb06ee6648325389f59edfce1405141",
-		16,
-	)
-	if !ok {
-		panic("bad hex")
-	}
-	k, ok := new(big.Int).SetString(
-		"7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534",
-		16,
-	)
-	if !ok {
-		panic("bad hex")
-	}
-	peerPublicKey := []byte{
-		// uncompressed
-		0x04,
-		// X
-		0x70, 0x0c, 0x48, 0xf7, 0x7f, 0x56, 0x58, 0x4c,
-		0x5c, 0xc6, 0x32, 0xca, 0x65, 0x64, 0x0d, 0xb9,
-		0x1b, 0x6b, 0xac, 0xce, 0x3a, 0x4d, 0xf6, 0xb4,
-		0x2c, 0xe7, 0xcc, 0x83, 0x88, 0x33, 0xd2, 0x87,
-		// Y
-		0xdb, 0x71, 0xe5, 0x09, 0xe3, 0xfd, 0x9b, 0x06,
-		0x0d, 0xdb, 0x20, 0xba, 0x5c, 0x51, 0xdc, 0xc5,
-		0x94, 0x8d, 0x46, 0xfb, 0xf6, 0x40, 0xdf, 0xe0,
-		0x44, 0x17, 0x82, 0xca, 0xb8, 0x5f, 0xa4, 0xac,
-	}
-	expected := []byte{
-		0x46, 0xfc, 0x62, 0x10, 0x64, 0x20, 0xff, 0x01,
-		0x2e, 0x54, 0xa4, 0x34, 0xfb, 0xdd, 0x2d, 0x25,
-		0xcc, 0xc5, 0x85, 0x20, 0x60, 0x56, 0x1e, 0x68,
-		0x04, 0x0d, 0xd7, 0x77, 0x89, 0x97, 0xbd, 0x7b,
-	}
+func TestECDH(t *testing.T) {
+	for _, tt := range []string{"P-256", "P-384", "P-521"} {
+		t.Run(tt, func(t *testing.T) {
+			name := tt
+			aliceKey, alicPrivBytes, err := openssl.GenerateKeyECDH(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bobKey, _, err := openssl.GenerateKeyECDH(name)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	bx, by, bk := bbig.Enc(x), bbig.Enc(y), bbig.Enc(k)
+			alicePubKeyFromPriv, err := aliceKey.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			alicePubBytes := alicePubKeyFromPriv.Bytes()
+			want := len(alicPrivBytes)
+			var got int
+			if tt == "X25519" {
+				got = len(alicePubBytes)
+			} else {
+				got = (len(alicePubBytes) - 1) / 2 // subtract encoding prefix and divide by the number of components
+			}
+			if want != got {
+				t.Fatalf("public key size mismatch: want: %v, got: %v", want, got)
+			}
+			alicePubKey, err := openssl.NewPublicKeyECDH(name, alicePubBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	priv, err := openssl.NewPrivateKeyECDH("P-256", bx, by, bk)
+			bobPubKeyFromPriv, err := bobKey.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = openssl.NewPublicKeyECDH(name, bobPubKeyFromPriv.Bytes())
+			if err != nil {
+				t.Error(err)
+			}
+
+			bobSecret, err := openssl.ECDH(bobKey, alicePubKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			aliceSecret, err := openssl.ECDH(aliceKey, bobPubKeyFromPriv)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(bobSecret, aliceSecret) {
+				t.Error("two ECDH computations came out different")
+			}
+		})
+	}
+}
+
+// The following vectors have been copied from
+// https://github.com/golang/go/blob/bb0d8297d76cb578baad8fa1485565d9acf44cc5/src/crypto/ecdh/ecdh_test.go.
+
+var ecdhvectors = []struct {
+	Name                  string
+	PrivateKey, PublicKey string
+	PeerPublicKey         string
+	SharedSecret          string
+}{
+	// NIST vectors from CAVS 14.1, ECC CDH Primitive (SP800-56A).
+	{
+		Name:       "P-256",
+		PrivateKey: "7d7dc5f71eb29ddaf80d6214632eeae03d9058af1fb6d22ed80badb62bc1a534",
+		PublicKey: "04ead218590119e8876b29146ff89ca61770c4edbbf97d38ce385ed281d8a6b230" +
+			"28af61281fd35e2fa7002523acc85a429cb06ee6648325389f59edfce1405141",
+		PeerPublicKey: "04700c48f77f56584c5cc632ca65640db91b6bacce3a4df6b42ce7cc838833d287" +
+			"db71e509e3fd9b060ddb20ba5c51dcc5948d46fbf640dfe0441782cab85fa4ac",
+		SharedSecret: "46fc62106420ff012e54a434fbdd2d25ccc5852060561e68040dd7778997bd7b",
+	},
+	{
+		Name:       "P-384",
+		PrivateKey: "3cc3122a68f0d95027ad38c067916ba0eb8c38894d22e1b15618b6818a661774ad463b205da88cf699ab4d43c9cf98a1",
+		PublicKey: "049803807f2f6d2fd966cdd0290bd410c0190352fbec7ff6247de1302df86f25d34fe4a97bef60cff548355c015dbb3e5f" +
+			"ba26ca69ec2f5b5d9dad20cc9da711383a9dbe34ea3fa5a2af75b46502629ad54dd8b7d73a8abb06a3a3be47d650cc99",
+		PeerPublicKey: "04a7c76b970c3b5fe8b05d2838ae04ab47697b9eaf52e764592efda27fe7513272734466b400091adbf2d68c58e0c50066" +
+			"ac68f19f2e1cb879aed43a9969b91a0839c4c38a49749b661efedf243451915ed0905a32b060992b468c64766fc8437a",
+		SharedSecret: "5f9d29dc5e31a163060356213669c8ce132e22f57c9a04f40ba7fcead493b457e5621e766c40a2e3d4d6a04b25e533f1",
+	},
+	// For some reason all field elements in the test vector (both scalars and
+	// base field elements), but not the shared secret output, have two extra
+	// leading zero bytes (which in big-endian are irrelevant). Removed here.
+	{
+		Name:       "P-521",
+		PrivateKey: "017eecc07ab4b329068fba65e56a1f8890aa935e57134ae0ffcce802735151f4eac6564f6ee9974c5e6887a1fefee5743ae2241bfeb95d5ce31ddcb6f9edb4d6fc47",
+		PublicKey: "0400602f9d0cf9e526b29e22381c203c48a886c2b0673033366314f1ffbcba240ba42f4ef38a76174635f91e6b4ed34275eb01c8467d05ca80315bf1a7bbd945f550a5" +
+			"01b7c85f26f5d4b2d7355cf6b02117659943762b6d1db5ab4f1dbc44ce7b2946eb6c7de342962893fd387d1b73d7a8672d1f236961170b7eb3579953ee5cdc88cd2d",
+		PeerPublicKey: "0400685a48e86c79f0f0875f7bc18d25eb5fc8c0b07e5da4f4370f3a9490340854334b1e1b87fa395464c60626124a4e70d0f785601d37c09870ebf176666877a2046d" +
+			"01ba52c56fc8776d9e8f5db4f0cc27636d0b741bbe05400697942e80b739884a83bde99e0f6716939e632bc8986fa18dccd443a348b6c3e522497955a4f3c302f676",
+		SharedSecret: "005fc70477c3e63bc3954bd0df3ea0d1f41ee21746ed95fc5e1fdf90930d5e136672d72cc770742d1711c3c3a4c334a0ad9759436a4d3c5bf6e74b9578fac148c831",
+	},
+}
+
+func TestECDHVectors(t *testing.T) {
+	for _, tt := range ecdhvectors {
+		t.Run(tt.Name, func(t *testing.T) {
+			key, err := openssl.NewPrivateKeyECDH(tt.Name, hexDecode(t, tt.PrivateKey))
+			if err != nil {
+				t.Fatal(err)
+			}
+			pub, err := key.PublicKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, want := pub.Bytes(), hexDecode(t, tt.PublicKey)
+			if !bytes.Equal(got, want) {
+				t.Error("public key derived from the private key does not match")
+			}
+			peer, err := openssl.NewPublicKeyECDH(tt.Name, hexDecode(t, tt.PeerPublicKey))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err = openssl.ECDH(key, peer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want = hexDecode(t, tt.SharedSecret)
+			if !bytes.Equal(got, want) {
+				t.Error("shared secret does not match")
+			}
+		})
+	}
+}
+
+func hexDecode(t *testing.T, s string) []byte {
+	b, err := hex.DecodeString(s)
 	if err != nil {
-		t.Log("NewPrivateKeyECDH failed", err)
-		t.Fail()
+		t.Fatal("invalid hex string:", s)
 	}
-	derived, err := openssl.SharedKeyECDH(priv, peerPublicKey)
-	if err != nil {
-		t.Log("SharedKeyECDH failed", err)
-		t.Fail()
-	}
-	if !bytes.Equal(derived, expected) {
-		t.Log("derived shared secret doesn't match")
-		t.Fail()
-	}
+	return b
 }

--- a/openssl/evp.go
+++ b/openssl/evp.go
@@ -1,0 +1,82 @@
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"unsafe"
+)
+
+func generateEVPPKey(id C.int, bits int, curve string) (*C.GO_EVP_PKEY, error) {
+	if (bits == 0 && curve == "") || (bits != 0 && curve != "") {
+		return nil, fail("incorrect generateEVPPKey parameters")
+	}
+	ctx := C._goboringcrypto_EVP_PKEY_CTX_new_id(id, nil)
+	if ctx == nil {
+		return nil, NewOpenSSLError("EVP_PKEY_CTX_new_id failed")
+	}
+	defer C._goboringcrypto_EVP_PKEY_CTX_free(ctx)
+	if C._goboringcrypto_EVP_PKEY_keygen_init(ctx) != 1 {
+		return nil, NewOpenSSLError("EVP_PKEY_keygen_init failed")
+	}
+	if bits != 0 {
+		if C._goboringcrypto_EVP_PKEY_CTX_ctrl(ctx, id, -1, C.GO_EVP_PKEY_CTRL_RSA_KEYGEN_BITS, C.int(bits), nil) != 1 {
+			return nil, NewOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	if curve != "" {
+		nid, err := curveNID(curve)
+		if err != nil {
+			return nil, err
+		}
+		if C._goboringcrypto_EVP_PKEY_CTX_ctrl(ctx, id, -1, C.GO_EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, nil) != 1 {
+			return nil, NewOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		}
+	}
+	var pkey *C.GO_EVP_PKEY
+	if C._goboringcrypto_EVP_PKEY_keygen(ctx, &pkey) != 1 {
+		return nil, NewOpenSSLError("EVP_PKEY_keygen failed")
+	}
+	return pkey, nil
+}
+
+func newEVPPKEY(key *C.GO_EC_KEY) (*C.GO_EVP_PKEY, error) {
+	pkey := C._goboringcrypto_EVP_PKEY_new()
+	if pkey == nil {
+		return nil, NewOpenSSLError("EVP_PKEY_new failed")
+	}
+	if C._goboringcrypto_EVP_PKEY_assign(pkey, C.GO_EVP_PKEY_EC, unsafe.Pointer(key)) != 1 {
+		C._goboringcrypto_EVP_PKEY_free(pkey)
+		return nil, NewOpenSSLError("EVP_PKEY_assign failed")
+	}
+	return pkey, nil
+}
+
+// getECKey returns the EC_KEY from pkey.
+// If pkey does not contain an EC_KEY it panics.
+// The returned key should not be freed.
+func getECKey(pkey *C.GO_EVP_PKEY) (key *C.GO_EC_KEY) {
+	key = C._goboringcrypto_EVP_PKEY_get0_EC_KEY(pkey)
+	if key == nil {
+		panic("pkey does not contain an EC_KEY")
+	}
+	return key
+}
+
+func newEvpFromParams(id C.int, selection C.int, params []C.OSSL_PARAM) (*C.GO_EVP_PKEY, error) {
+	ctx := C._goboringcrypto_EVP_PKEY_CTX_new_id(id, nil)
+	if ctx == nil {
+		return nil, NewOpenSSLError("EVP_PKEY_CTX_new_id")
+	}
+	defer C._goboringcrypto_EVP_PKEY_CTX_free(ctx)
+	if C._goboringcrypto_EVP_PKEY_fromdata_init(ctx) != 1 {
+		return nil, NewOpenSSLError("EVP_PKEY_fromdata_init")
+	}
+	var pkey *C.GO_EVP_PKEY
+	if C._goboringcrypto_EVP_PKEY_fromdata(ctx, &pkey, selection, &params[0]) != 1 {
+		return nil, NewOpenSSLError("EVP_PKEY_fromdata")
+	}
+	return pkey, nil
+}

--- a/openssl/notboring.go
+++ b/openssl/notboring.go
@@ -71,16 +71,16 @@ func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s BigInt, h crypto.Hash) b
 type PublicKeyECDH struct{ _ int }
 type PrivateKeyECDH struct{ _ int }
 
-func GenerateKeyECDH(curve string) (X, Y, D BigInt, err error) {
+func NewPublicKeyECDH(curve string, bytes []byte) (*PublicKeyECDH, error) {
 	panic("boringcrypto: not available")
 }
-func NewPrivateKeyECDH(curve string, X, Y, D BigInt) (*PrivateKeyECDH, error) {
+func NewPrivateKeyECDH(curve string, bytes []byte) (*PrivateKeyECDH, error) {
 	panic("boringcrypto: not available")
 }
-func NewPublicKeyECDH(curve string, X, Y BigInt) (*PublicKeyECDH, error) {
+func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
 	panic("boringcrypto: not available")
 }
-func SharedKeyECDH(priv *PrivateKeyECDH, peerPublicKey []byte) ([]byte, error) {
+func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	panic("boringcrypto: not available")
 }
 

--- a/openssl/params.go
+++ b/openssl/params.go
@@ -1,0 +1,93 @@
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+var paramEnd = C.OSSL_PARAM{
+	key:         nil,
+	data_type:   0,
+	data:        nil,
+	data_size:   0,
+	return_size: 0,
+}
+
+// paramsBuilder is a container for OSSL_PARAMs.
+// It must be freed using paramsBuilder.free().
+type paramsBuilder struct {
+	params []C.OSSL_PARAM
+}
+
+func newParamsBuilder() paramsBuilder {
+	var pb paramsBuilder
+	pb.params = make([]C.OSSL_PARAM, 1, 5)
+	pb.params[0] = paramEnd
+	return pb
+}
+
+func (pb *paramsBuilder) free() {
+	C._goboringcrypto_params_free(&pb.params[0])
+	pb.params = pb.params[:1]
+	pb.params[0] = paramEnd
+}
+
+// addUTF8 adds a parameter of type data_type.
+// data is stored in the new parameter without copying,
+// so any change to its content after this call will also
+// affect the created parameter.
+func (pb *paramsBuilder) add(key *C.char, data_type C.uint, data unsafe.Pointer, data_size C.size_t) {
+	if key == nil {
+		panic("key shouldn't be nil")
+	}
+	var return_size = C.GO_OSSL_PARAM_UNMODIFIED
+	pb.params[len(pb.params)-1] = C.OSSL_PARAM{
+		key:         key,
+		data_type:   data_type,
+		data:        data,
+		data_size:   data_size,
+		return_size: C.size_t(return_size),
+	}
+	pb.params = append(pb.params, paramEnd)
+}
+
+// addUTF8 adds a parameter of type OSSL_PARAM_UTF8_STRING.
+func (pb *paramsBuilder) addUTF8(key *C.char, v string) {
+	pb.add(key, C.GO_OSSL_PARAM_UTF8_STRING, unsafe.Pointer(C.CString(v)), C.size_t(len(v)))
+}
+
+// addOctetString adds a parameter of type OSSL_PARAM_OCTET_STRING.
+// The content of v is copied into the new param,
+// it's safe to change it after this call.
+func (pb *paramsBuilder) addOctetString(key *C.char, v []byte) {
+	pb.add(key, C.GO_OSSL_PARAM_OCTET_STRING, C.CBytes(v), C.size_t(len(v)))
+}
+
+// addBigNumber adds a parameter of type OSSL_PARAM_UNSIGNED_INTEGER.
+// The content of v is copied into the new param,
+// it's safe to change it after this call.
+func (pb *paramsBuilder) addBigNumber(key *C.char, v []byte) error {
+	cbytes := (*C.uchar)(C.CBytes(v))
+	if nativeEndian != binary.BigEndian {
+		// The original bytes represent a big number using big-endian.
+		// Unfortunately, OpenSSL expects that big numbers are passed using native-endian.
+		// The following call re-encodes cbytes as little-endian.
+		// We would have to to this even if we called OSSL_PARAM_construct_BN,
+		// as it also expect a native-endian number.
+		priv := C._goboringcrypto_BN_bin2bn(cbytes, C.size_t(len(v)), nil)
+		if priv == nil {
+			return NewOpenSSLError("BN_bin2bn")
+		}
+		defer C._goboringcrypto_BN_free(priv)
+		if C._goboringcrypto_BN_bn2lebinpad(priv, cbytes, C.size_t(len(v))) == -1 {
+			return NewOpenSSLError("BN_bn2lebinpad")
+		}
+	}
+	pb.add(key, C.GO_OSSL_PARAM_UNSIGNED_INTEGER, unsafe.Pointer(cbytes), C.size_t(len(v)))
+	return nil
+}


### PR DESCRIPTION
This backports the ECDH implementation from
wip/combined-codebase-staging, as it better suits Go 1.20 crypto/ecdh
interface.