### PR TITLE
sha: add WriteString and WriteByte method

### DIFF
--- a/openssl/sha.go
+++ b/openssl/sha.go
@@ -117,6 +117,26 @@ func (h *evpHash) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func (h *evpHash) WriteString(s string) (int, error) {
+	// TODO: use unsafe.StringData once we drop support
+	// for go1.19 and earlier.
+	hdr := (*struct {
+		Data *byte
+		Len  int
+	})(unsafe.Pointer(&s))
+	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(hdr.Data), C.size_t(len(s))) == 0 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	return len(s), nil
+}
+
+func (h *evpHash) WriteByte(c byte) error {
+	if C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1) == 0 {
+		panic("openssl: EVP_DigestUpdate failed")
+	}
+	return nil
+}
+
 func (h *evpHash) Size() int {
 	return h.size
 }

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding"
 	"hash"
+	"io"
 	"testing"
 
 	"github.com/golang-fips/openssl-fips/openssl"
@@ -61,6 +62,24 @@ func TestSha(t *testing.T) {
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}
+
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			bw := h.(io.ByteWriter)
+			for i := 0; i < len(msg); i++ {
+				bw.WriteByte(msg[i])
+			}
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+
+			h.(io.StringWriter).WriteString(string(msg))
 		})
 	}
 }

--- a/openssl/sha_test.go
+++ b/openssl/sha_test.go
@@ -63,12 +63,6 @@ func TestSha(t *testing.T) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}
 
-			h.Reset()
-			sum = h.Sum(nil)
-			if !bytes.Equal(sum, initSum) {
-				t.Errorf("got:%x want:%x", sum, initSum)
-			}
-
 			bw := h.(io.ByteWriter)
 			for i := 0; i < len(msg); i++ {
 				bw.WriteByte(msg[i])
@@ -80,6 +74,11 @@ func TestSha(t *testing.T) {
 			}
 
 			h.(io.StringWriter).WriteString(string(msg))
+			h.Reset()
+			sum = h.Sum(nil)
+			if !bytes.Equal(sum, initSum) {
+				t.Errorf("got:%x want:%x", sum, initSum)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR implements WriteString and WriteByte for all supported hashers. These methods will be required by the boring API in go1.21.

See [CL 483816](https://go-review.googlesource.com/c/go/+/483816), [483815](https://go-review.googlesource.com/c/go/+/483815), and [CL 481478](https://go-review.googlesource.com/c/go/+/481478).