### PR TITLE
Add pull request gating workflow

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -1,0 +1,31 @@
+name: "Test Pull Request"
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: read
+  contents: none
+  deployments: none
+  id-token: none
+  issues: read
+  discussions: read
+  packages: none
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  test_pr:
+  # Look up the images for each selected compose
+    name: "Test Pull Request"
+    uses: golang-fips/release/.github/workflows/test-ubi-centos.yml@main
+    with:
+      go_openssl_ref: ${{ github.event.pull_request.head.sha }}
+      composes: "ubi7,ubi8,ubi9,c8s,c9s"


### PR DESCRIPTION
This workflow is taken from golang-fips/go and uses the `go_openssl_ref` parameter to test the main branch of our Go fork against the changes submitted in the PR on the openssl-fips repo.