### PR TITLE
Remove Init fallback logic and provide CheckVersion instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         ok=true
         for t in $(go test ./... -list=. | grep '^Test'); do
-          go test ./... -gcflags=all=-d=checkptr -asan -run $t -v || ok=false
+          go test ./... -gcflags=all=-d=checkptr -asan -run ^$t$ -v || ok=false
         done
         $ok
       env:

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -19,6 +19,7 @@ go_openssl_do_leak_check(void)
 #endif
 }
 
+int go_openssl_fips_enabled(void* handle);
 int go_openssl_version_major(void* handle);
 int go_openssl_version_minor(void* handle);
 int go_openssl_version_patch(void* handle);

--- a/openssl/init.go
+++ b/openssl/init.go
@@ -18,7 +18,6 @@ import (
 // See Init() for details about version.
 func opensslInit(version string) (major, minor, patch int, err error) {
 	// Load the OpenSSL shared library using dlopen.
-	// If version is specified try to load it or error out.
 	handle := dlopen(version)
 	if handle == nil {
 		errstr := C.GoString(C.dlerror())

--- a/openssl/init.go
+++ b/openssl/init.go
@@ -11,16 +11,6 @@ import (
 	"unsafe"
 )
 
-// knownVersions is a list of supported and well-known libcrypto.so suffixes in decreasing version order.
-//
-// FreeBSD library version numbering does not directly align to the version of OpenSSL.
-// Its preferred search order is 11 -> 111.
-//
-// Some distributions use 1.0.0 and others (such as Debian) 1.0.2 to refer to the same OpenSSL 1.0.2 version.
-//
-// Fedora derived distros use different naming for the version 1.0.x.
-var knownVersions = [...]string{"3", "1.1", "11", "111", "1.0.2", "1.0.0", "10"}
-
 // opensslInit loads and initialize OpenSSL.
 // If successful, it returns the major and minor OpenSSL version
 // as reported by the OpenSSL API.
@@ -28,9 +18,11 @@ var knownVersions = [...]string{"3", "1.1", "11", "111", "1.0.2", "1.0.0", "10"}
 // See Init() for details about version.
 func opensslInit(version string) (major, minor, patch int, err error) {
 	// Load the OpenSSL shared library using dlopen.
-	handle, err := loadLibrary(version)
-	if err != nil {
-		return 0, 0, 0, err
+	// If version is specified try to load it or error out.
+	handle := dlopen(version)
+	if handle == nil {
+		errstr := C.GoString(C.dlerror())
+		return 0, 0, 0, errors.New("openssl: can't load libcrypto.so." + version + ": " + errstr)
 	}
 
 	// Retrieve the loaded OpenSSL version and check if it is supported.
@@ -79,26 +71,4 @@ func dlopen(version string) unsafe.Pointer {
 	cv := C.CString("libcrypto.so." + version)
 	defer C.free(unsafe.Pointer(cv))
 	return C.dlopen(cv, C.RTLD_LAZY|C.RTLD_LOCAL)
-}
-
-func loadLibrary(version string) (unsafe.Pointer, error) {
-	if version != "" {
-		// If version is specified try to load it or error out.
-		handle := dlopen(version)
-		if handle == nil {
-			errstr := C.GoString(C.dlerror())
-			return nil, errors.New("openssl: can't load libcrypto.so." + version + ": " + errstr)
-		}
-		return handle, nil
-	}
-	// If the version is not specified, try loading from the list
-	// of well known versions.
-	for _, v := range knownVersions {
-		handle := dlopen(v)
-		if handle == nil {
-			continue
-		}
-		return handle, nil
-	}
-	return nil, errors.New("openssl: can't load libcrypto.so using any known version suffix")
 }

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -12,8 +12,26 @@ import (
 	"github.com/golang-fips/openssl-fips/openssl"
 )
 
-func TestMain(m *testing.M) {
+// getVersion returns the OpenSSL version to use for testing.
+func getVersion() string {
 	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
+	if v != "" {
+		return v
+	}
+	// Try to find a supported version of OpenSSL on the system.
+	// This is useful for local testing, where the user may not
+	// have GO_OPENSSL_VERSION_OVERRIDE set.
+	for _, v = range [...]string{"3", "1.1.1", "1.1", "11", "111", "1.0.2", "1.0.0", "10"} {
+		if ok, _ := openssl.CheckVersion(v); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestMain(m *testing.M) {
+	v := getVersion()
+	fmt.Printf("Using libcrypto.so.%s\n", v)
 	err := openssl.Init(v)
 	if err != nil {
 		// An error here could mean that this Linux distro does not have a supported OpenSSL version
@@ -30,7 +48,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCheckVersion(t *testing.T) {
-	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
+	v := getVersion()
 	exists, fips := openssl.CheckVersion(v)
 	if !exists {
 		t.Fatalf("OpenSSL version %q not found", v)

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -28,3 +28,14 @@ func TestMain(m *testing.M) {
 	openssl.CheckLeaks()
 	os.Exit(status)
 }
+
+func TestCheckVersion(t *testing.T) {
+	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
+	exists, fips := openssl.CheckVersion(v)
+	if !exists {
+		t.Fatalf("OpenSSL version %q not found", v)
+	}
+	if want := openssl.FIPS(); want != fips {
+		t.Fatalf("FIPS mismatch: want %v, got %v", want, fips)
+	}
+}

--- a/openssl/shims.h
+++ b/openssl/shims.h
@@ -170,7 +170,8 @@ DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const GO_OPENSSL_INIT_SE
 DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \
 DEFINEFUNC_LEGACY_1(int, FIPS_mode_set, (int r), (r)) \
 DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (GO_OSSL_LIB_CTX_PTR libctx), (libctx)) \
-DEFINEFUNC_3_0(int, EVP_set_default_properties, (GO_OSSL_LIB_CTX_PTR libctx, const char *propq), (libctx, propq)) \
+DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (GO_OSSL_LIB_CTX_PTR libctx, int enable), (libctx, enable)) \
+DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \


### PR DESCRIPTION
This PR removes the fallback logic of `openssl.Init("")`, which would try to load OpenSSL versions from a list of well-known shared library sufixes. The reasoning to do so is that the fallback process assumes all Go forks using `openssl-fips` have the same OpenSSL requirements and priorities, and that the list is static and hardly changes. For example, the MSFT Go fork wants to prioritize FIPS-enabled OpenSSL versions, even if it's not the highest available version.

A better approach, implemented also in this PR, is to expose the necessary functions so the caller always calls `openssl.Init` with the right version. To do so, I've implemented `openssl.CheckVersion`, which checks if a given version exists and is FIPS capable.

Downstream users could implement the initialization process as follows:

```go
func init() {
	var knownVersions = []string{"3", "1.1", "1.0"}
	fallbackIdx := -1
	for i, v := range knownVersions {
		exists, fips := openssl.CheckVersion(v)
		if exists && fips {
			_ = openssl.Init(v)
			return
		}
		if exists && fallbackIdx == -1 {
			fallbackIdx = i
		}
	}
	if fallbackIdx != -1 {
		_ = openssl.Init(knownVersions[fallbackIdx])
	}
}
```

Additionally, I've updated the `openssl.SetFips` so it always tries to load a provider named `fips` when `enabled` is true. It previously implemented some logic to allow other provider names if the OpenSSL config file was properly configured. I no longer think this is a good thing to support, first because we are not testing that code path, but more importantly because no other framework (i.e. [nodejs](https://github.com/nodejs/node/blob/607c8f4eacd5dded97a33f0da49da0aed7404187/src/crypto/crypto_util.cc#L120-L138), [python](https://github.com/pyca/cryptography/blob/5efbc110905230f771d5bde918c059cd3d029e22/src/cryptography/hazmat/bindings/openssl/binding.py#L86-L100), and [ruby](https://github.com/ruby/ruby/blob/d5ef373b1194bac64784ae316d125d7a2cf1988a/ext/openssl/ossl.c#L447-L459)) supports this use case. Being this in the critical security path, I would rather be cautious and don't support things that aren't fully understood.