### PR TITLE
Return nil in NewHMAC if HMAC doesn't support the hash function

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -110,8 +110,8 @@ func buildHMAC3Params(digest *C.char) C.GO_OSSL_PARAM_PTR {
 }
 
 func isHMAC3DigestSupported(digest string) bool {
-	if _, ok := hmacDigestsSupported.Load(digest); ok {
-		return true
+	if v, ok := hmacDigestsSupported.Load(digest); ok {
+		return v.(bool)
 	}
 	ctx := C.go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
 	if ctx == nil {

--- a/shims.h
+++ b/shims.h
@@ -344,6 +344,7 @@ DEFINEFUNC(GO_EC_GROUP_PTR, EC_GROUP_new_by_curve_name, (int nid), (nid)) \
 DEFINEFUNC(void, EC_GROUP_free, (GO_EC_GROUP_PTR group), (group)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_PTR, EVP_MAC_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_new, (GO_EVP_MAC_PTR arg0), (arg0)) \
+DEFINEFUNC_3_0(int, EVP_MAC_CTX_set_params, (GO_EVP_MAC_CTX_PTR ctx, const GO_OSSL_PARAM_PTR params), (ctx, params)) \
 DEFINEFUNC_3_0(void, EVP_MAC_CTX_free, (GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_3_0(GO_EVP_MAC_CTX_PTR, EVP_MAC_CTX_dup, (const GO_EVP_MAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_3_0(int, EVP_MAC_init, (GO_EVP_MAC_CTX_PTR ctx, const unsigned char *key, size_t keylen, const GO_OSSL_PARAM_PTR params), (ctx, key, keylen, params)) \


### PR DESCRIPTION
This PR adds a check in the OpenSSL 3 `NewHMAC` code path to prove that the fetched HMAC can be used with the given hash function. If that's not possible, then `NewHMAC` will return `nil`. Note that this was already the case if the hash function was not supported as a stand-alone algorithm.

Fixes #153.