### PR TITLE
Use the OpenSSL parameter names as variable names

### DIFF
--- a/ec.go
+++ b/ec.go
@@ -6,11 +6,11 @@ package openssl
 import "C"
 
 var (
-	paramPubKey  = C.CString("pub")
-	paramPrivKey = C.CString("priv")
-	paramGroup   = C.CString("group")
-	paramECPubX  = C.CString("qx")
-	paramECPubY  = C.CString("qy")
+	OSSL_PKEY_PARAM_PUB_KEY    = C.CString("pub")
+	OSSL_PKEY_PARAM_PRIV_KEY   = C.CString("priv")
+	OSSL_PKEY_PARAM_GROUP_NAME = C.CString("group")
+	OSSL_PKEY_PARAM_EC_PUB_X   = C.CString("qx")
+	OSSL_PKEY_PARAM_EC_PUB_Y   = C.CString("qy")
 )
 
 func curveNID(curve string) (C.int, error) {

--- a/ecdh.go
+++ b/ecdh.go
@@ -174,7 +174,7 @@ func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, e
 		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
 	}
 	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramGroup, C.go_openssl_OBJ_nid2sn(nid), 0)
+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
 	var selection C.int
 	if isPrivate {
 		priv := C.go_openssl_BN_bin2bn(base(bytes), C.int(len(bytes)), nil)
@@ -182,14 +182,14 @@ func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, e
 			return nil, newOpenSSLError("BN_bin2bn")
 		}
 		defer C.go_openssl_BN_clear_free(priv)
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, paramPrivKey, priv) != 1 {
+		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1 {
 			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
 		}
 		selection = C.GO_EVP_PKEY_KEYPAIR
 	} else {
 		cbytes := C.CBytes(bytes)
 		defer C.free(cbytes)
-		C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, paramPubKey, cbytes, C.size_t(len(bytes)))
+		C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(bytes)))
 		selection = C.GO_EVP_PKEY_PUBLIC_KEY
 	}
 	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
@@ -235,7 +235,7 @@ func deriveEcdhPublicKey(pkey C.GO_EVP_PKEY_PTR, curve string) error {
 		}
 	case 3:
 		var priv C.GO_BIGNUM_PTR
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 			return newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(priv)
@@ -300,7 +300,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 			return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
 		}
 	case 3:
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &priv) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(priv)

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -91,9 +91,9 @@ func GenerateKeyECDSA(curve string) (X, Y, D BigInt, err error) {
 		// Get Z. We don't need to free it, get0 does not increase the reference count.
 		bd = C.go_openssl_EC_KEY_get0_private_key(key)
 	case 3:
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramECPubX, &bx) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramECPubY, &by) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, paramPrivKey, &bd) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_X, &bx) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_Y, &by) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &bd) != 1 {
 			return nil, nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(bd)
@@ -195,13 +195,13 @@ func newECDSAKey3(nid C.int, bx, by, bd C.GO_BIGNUM_PTR) (C.GO_EVP_PKEY_PTR, err
 		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
 	}
 	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramGroup, C.go_openssl_OBJ_nid2sn(nid), 0)
+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
 	cbytes := C.CBytes(pubBytes)
 	defer C.free(cbytes)
-	C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, paramPubKey, cbytes, C.size_t(len(pubBytes)))
+	C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(pubBytes)))
 	var selection C.int
 	if bd != nil {
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, paramPrivKey, bd) != 1 {
+		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, bd) != 1 {
 			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
 		}
 		selection = C.GO_EVP_PKEY_KEYPAIR

--- a/hmac.go
+++ b/hmac.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-var paramDigest = C.CString("digest")
+var OSSL_MAC_PARAM_DIGEST = C.CString("digest")
 
 var (
 	fetchHMACOnce sync.Once
@@ -103,7 +103,7 @@ func newHMAC3(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
 		panic(newOpenSSLError("OSSL_PARAM_BLD_new"))
 	}
 	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, paramDigest, digest, 0)
+	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_MAC_PARAM_DIGEST, digest, 0)
 	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
 	if params == nil {
 		panic(newOpenSSLError("OSSL_PARAM_BLD_to_param"))

--- a/rsa.go
+++ b/rsa.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	paramRSA_N    = C.CString("n")
-	paramRSA_E    = C.CString("e")
-	paramRSA_D    = C.CString("d")
-	paramRSA_P    = C.CString("rsa-factor1")
-	paramRSA_Q    = C.CString("rsa-factor2")
-	paramRSA_Dp   = C.CString("rsa-exponent1")
-	paramRSA_Dq   = C.CString("rsa-exponent2")
-	paramRSA_Qinv = C.CString("rsa-coefficient1")
+	OSSL_PKEY_PARAM_RSA_N            = C.CString("n")
+	OSSL_PKEY_PARAM_RSA_E            = C.CString("e")
+	OSSL_PKEY_PARAM_RSA_D            = C.CString("d")
+	OSSL_PKEY_PARAM_RSA_FACTOR1      = C.CString("rsa-factor1")
+	OSSL_PKEY_PARAM_RSA_FACTOR2      = C.CString("rsa-factor2")
+	OSSL_PKEY_PARAM_RSA_EXPONENT1    = C.CString("rsa-exponent1")
+	OSSL_PKEY_PARAM_RSA_EXPONENT2    = C.CString("rsa-exponent2")
+	OSSL_PKEY_PARAM_RSA_COEFFICIENT1 = C.CString("rsa-coefficient1")
 )
 
 func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
@@ -73,14 +73,14 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 			C.go_openssl_BN_clear(tmp)
 			return true
 		}
-		if !(setBigInt(&N, paramRSA_N) &&
-			setBigInt(&E, paramRSA_E) &&
-			setBigInt(&D, paramRSA_D) &&
-			setBigInt(&P, paramRSA_P) &&
-			setBigInt(&Q, paramRSA_Q) &&
-			setBigInt(&Dp, paramRSA_Dp) &&
-			setBigInt(&Dq, paramRSA_Dq) &&
-			setBigInt(&Qinv, paramRSA_Qinv)) {
+		if !(setBigInt(&N, OSSL_PKEY_PARAM_RSA_N) &&
+			setBigInt(&E, OSSL_PKEY_PARAM_RSA_E) &&
+			setBigInt(&D, OSSL_PKEY_PARAM_RSA_D) &&
+			setBigInt(&P, OSSL_PKEY_PARAM_RSA_FACTOR1) &&
+			setBigInt(&Q, OSSL_PKEY_PARAM_RSA_FACTOR2) &&
+			setBigInt(&Dp, OSSL_PKEY_PARAM_RSA_EXPONENT1) &&
+			setBigInt(&Dq, OSSL_PKEY_PARAM_RSA_EXPONENT2) &&
+			setBigInt(&Qinv, OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 			return bad(err)
 		}
 	default:
@@ -385,7 +385,7 @@ func newRSAKey3(isPriv bool, N, E, D, P, Q, Dp, Dq, Qinv BigInt) (C.GO_EVP_PKEY_
 	}
 	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
 
-	type bigIntParam struct{
+	type bigIntParam struct {
 		name *C.char
 		num  BigInt
 	}
@@ -393,7 +393,7 @@ func newRSAKey3(isPriv bool, N, E, D, P, Q, Dp, Dq, Qinv BigInt) (C.GO_EVP_PKEY_
 	comps := make([]bigIntParam, 0, 8)
 
 	required := [...]bigIntParam{
-		{paramRSA_N, N}, {paramRSA_E, E}, {paramRSA_D, D},
+		{OSSL_PKEY_PARAM_RSA_N, N}, {OSSL_PKEY_PARAM_RSA_E, E}, {OSSL_PKEY_PARAM_RSA_D, D},
 	}
 	comps = append(comps, required[:]...)
 
@@ -402,8 +402,8 @@ func newRSAKey3(isPriv bool, N, E, D, P, Q, Dp, Dq, Qinv BigInt) (C.GO_EVP_PKEY_
 	// https://github.com/openssl/openssl/pull/22334
 	if P != nil && Q != nil && Dp != nil && Dq != nil && Qinv != nil {
 		precomputed := [...]bigIntParam{
-			{paramRSA_P, P}, {paramRSA_Q, Q},
-			{paramRSA_Dp, Dp}, {paramRSA_Dq, Dq}, {paramRSA_Qinv, Qinv},
+			{OSSL_PKEY_PARAM_RSA_FACTOR1, P}, {OSSL_PKEY_PARAM_RSA_FACTOR2, Q},
+			{OSSL_PKEY_PARAM_RSA_EXPONENT1, Dp}, {OSSL_PKEY_PARAM_RSA_EXPONENT2, Dq}, {OSSL_PKEY_PARAM_RSA_COEFFICIENT1, Qinv},
 		}
 		comps = append(comps, precomputed[:]...)
 	}


### PR DESCRIPTION
When defining OpenSSL parameters, it is better to use the name used in OpenSSL header files and docs. This way it easier to find documentation for a specific parameter.