### PR TITLE
Implement Clone for all hashers

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -230,6 +230,9 @@ func (h *evpHash) sum(out []byte) {
 	runtime.KeepAlive(h)
 }
 
+// clone returns a new evpHash object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *evpHash) clone() (*evpHash, error) {
 	ctx := C.go_openssl_EVP_MD_CTX_new()
 	if ctx == nil {
@@ -305,6 +308,9 @@ func (h *md4Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *md4Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -341,6 +347,9 @@ func (h *md5Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *md5Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -418,6 +427,9 @@ func (h *sha1Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha1Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -506,6 +518,9 @@ func (h *sha224Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha224Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -533,6 +548,9 @@ func (h *sha256Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha256Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -681,6 +699,9 @@ func (h *sha384Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha384Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -708,6 +729,9 @@ func (h *sha512Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha512Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -862,6 +886,9 @@ func (h *sha3_224Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha3_224Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -887,6 +914,9 @@ func (h *sha3_256Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha3_256Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -912,6 +942,9 @@ func (h *sha3_384Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha3_384Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {
@@ -937,6 +970,9 @@ func (h *sha3_512Hash) Sum(in []byte) []byte {
 	return append(in, h.out[:]...)
 }
 
+// Clone returns a new [hash.Hash] object that is a deep clone of itself.
+// The duplicate object contains all state and data contained in the
+// original object at the point of duplication.
 func (h *sha3_512Hash) Clone() (hash.Hash, error) {
 	c, err := h.clone()
 	if err != nil {

--- a/hash_test.go
+++ b/hash_test.go
@@ -136,6 +136,8 @@ func TestHash_Clone(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// We don't define an interface for the Clone method to avoid other
+			// packages from depending on it. Use type assertion to call it.
 			h2, err := h.(interface{ Clone() (hash.Hash, error) }).Clone()
 			if err != nil {
 				t.Fatal(err)

--- a/hash_test.go
+++ b/hash_test.go
@@ -39,22 +39,23 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 	return nil
 }
 
+var hashes = [...]crypto.Hash{
+	crypto.MD4,
+	crypto.MD5,
+	crypto.SHA1,
+	crypto.SHA224,
+	crypto.SHA256,
+	crypto.SHA384,
+	crypto.SHA512,
+	crypto.SHA3_224,
+	crypto.SHA3_256,
+	crypto.SHA3_384,
+	crypto.SHA3_512,
+}
+
 func TestHash(t *testing.T) {
 	msg := []byte("testing")
-	var tests = []crypto.Hash{
-		crypto.MD4,
-		crypto.MD5,
-		crypto.SHA1,
-		crypto.SHA224,
-		crypto.SHA256,
-		crypto.SHA384,
-		crypto.SHA512,
-		crypto.SHA3_224,
-		crypto.SHA3_256,
-		crypto.SHA3_384,
-		crypto.SHA3_512,
-	}
-	for _, ch := range tests {
+	for _, ch := range hashes {
 		ch := ch
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
@@ -77,38 +78,115 @@ func TestHash(t *testing.T) {
 			if bytes.Equal(sum, initSum) {
 				t.Error("Write didn't change internal hash state")
 			}
-			if _, ok := h.(encoding.BinaryMarshaler); ok {
-				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
-				if err != nil {
-					t.Errorf("could not marshal: %v", err)
-				}
-				h2 := cryptoToHash(ch)()
-				if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
-					t.Errorf("could not unmarshal: %v", err)
-				}
-				if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-					t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
-				}
-			}
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}
+		})
+	}
+}
 
+func TestHash_BinaryMarshaler(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			if _, ok := h.(encoding.BinaryMarshaler); !ok {
+				t.Skip("skipping: not supported")
+			}
+			_, err := h.Write(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+			if err != nil {
+				t.Errorf("could not marshal: %v", err)
+			}
+			h2 := cryptoToHash(ch)()
+			if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
+				t.Errorf("could not unmarshal: %v", err)
+			}
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
+			}
+		})
+	}
+}
+
+func TestHash_Clone(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			if _, ok := h.(encoding.BinaryMarshaler); !ok {
+				t.Skip("skipping: not supported")
+			}
+			_, err := h.Write(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			h2, err := h.(interface{ Clone() (hash.Hash, error) }).Clone()
+			if err != nil {
+				t.Fatal(err)
+			}
+			h.Write(msg)
+			h2.Write(msg)
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", ch.String(), msg, actual, actual2)
+			}
+		})
+	}
+}
+
+func TestHash_ByteWriter(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			initSum := h.Sum(nil)
 			bw := h.(io.ByteWriter)
 			for i := 0; i < len(msg); i++ {
 				bw.WriteByte(msg[i])
 			}
 			h.Reset()
-			sum = h.Sum(nil)
+			sum := h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}
+		})
+	}
+}
 
+func TestHash_StringWriter(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			initSum := h.Sum(nil)
 			h.(io.StringWriter).WriteString(string(msg))
 			h.Reset()
-			sum = h.Sum(nil)
+			sum := h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
 			}

--- a/shims.h
+++ b/shims.h
@@ -200,6 +200,7 @@ DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
+DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 DEFINEFUNC(int, EVP_Digest, (const void *data, size_t count, unsigned char *md, unsigned int *size, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (data, count, md, size, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \


### PR DESCRIPTION
In #161 I refactored our hash implementations to only implement the `encoding.BinaryMarshaler` interface when using the built-in providers. This raises a new problem, as the standard library uses that interface to clone a hash when doing a TLS 1.3 handshake: https://github.com/golang/go/blob/2707d42966f8985a6663c93e943b9a44b9399fca/src/crypto/tls/handshake_server_tls13.go#L436.

The issue can be fixed by providing a `Clone` method that is not provider-dependent and patch the standard library to use that instead. In fact, we are already following this approach with the Windows CNG backend in the Microsoft Go fork: https://github.com/microsoft/go/blob/294feac5a41d50e2ef261d6acca9feb017f873d0/patches/0005-Add-CNG-crypto-backend.patch#L1061-L1069. I plan to also use this new `Clone` method for the OpenSSL backend.

While here, refactor the hash tests so they are a bit more atomic.