### PR TITLE
Implement openssl.Provider

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,4 +2,6 @@ package openssl
 
 var ErrOpen = errOpen
 
-var MajorVersion = vMajor
+func MajorVersion() uint {
+	return vMajor
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,12 +1,5 @@
 package openssl
 
-import "sync"
-
 var ErrOpen = errOpen
 
-var SymCryptProviderAvailable = sync.OnceValue(func() bool {
-	if vMajor == 1 {
-		return false
-	}
-	return isProviderAvailable("symcryptprovider")
-})
+var MajorVersion = vMajor

--- a/hash.go
+++ b/hash.go
@@ -182,6 +182,10 @@ func (h *evpHash) finalize() {
 	C.go_openssl_EVP_MD_CTX_free(h.ctx2)
 }
 
+func (h *evpHash) provider() C.GO_OSSL_PROVIDER_PTR {
+	return C.go_openssl_EVP_MD_get0_provider(C.go_openssl_EVP_MD_CTX_get0_md(h.ctx))
+}
+
 func (h *evpHash) Reset() {
 	// There is no need to reset h.ctx2 because it is always reset after
 	// use in evpHash.sum.

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -78,3 +78,33 @@ func TestCheckVersion(t *testing.T) {
 		t.Fatalf("FIPS mismatch: want %v, got %v", want, fips)
 	}
 }
+
+func TestProvider(t *testing.T) {
+	if openssl.MajorVersion == 1 {
+		t.Skip("Provider is not supported in OpenSSL 1")
+	}
+	tests := []struct {
+		name string
+		fn   func() any
+	}{
+		{"sha256", func() any { return openssl.NewSHA256() }},
+		{"rsaPub", func() any {
+			_, pub := newRSAKey(t, 1024)
+			return pub
+		}},
+		{"rsaPriv", func() any {
+			priv, _ := newRSAKey(t, 1024)
+			return priv
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			md := openssl.NewSHA256()
+			name, _, _ := openssl.Provider(md)
+			if name == "" {
+				t.Fatal("Provider: empty name")
+			}
+		})
+	}
+}

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -80,7 +80,7 @@ func TestCheckVersion(t *testing.T) {
 }
 
 func TestProvider(t *testing.T) {
-	if openssl.MajorVersion == 1 {
+	if openssl.MajorVersion() == 1 {
 		t.Skip("Provider is not supported in OpenSSL 1")
 	}
 	tests := []struct {

--- a/rsa.go
+++ b/rsa.go
@@ -140,6 +140,14 @@ func (k *PublicKeyRSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
 	return f(k._pkey)
 }
 
+func (k *PublicKeyRSA) provider() (prov C.GO_OSSL_PROVIDER_PTR) {
+	k.withKey(func(pkey C.GO_EVP_PKEY_PTR) C.int {
+		prov = C.go_openssl_EVP_PKEY_get0_provider(pkey)
+		return 1
+	})
+	return prov
+}
+
 type PrivateKeyRSA struct {
 	// _pkey MUST NOT be accessed directly. Instead, use the withKey method.
 	_pkey C.GO_EVP_PKEY_PTR
@@ -199,6 +207,14 @@ func (k *PrivateKeyRSA) withKey(f func(C.GO_EVP_PKEY_PTR) C.int) C.int {
 	// collected (and finalized) before the cgo call returns.
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
+}
+
+func (k *PrivateKeyRSA) provider() (prov C.GO_OSSL_PROVIDER_PTR) {
+	k.withKey(func(pkey C.GO_EVP_PKEY_PTR) C.int {
+		prov = C.go_openssl_EVP_PKEY_get0_provider(pkey)
+		return 1
+	})
+	return prov
 }
 
 func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -150,7 +150,8 @@ func TestRSAEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
 }
 
 func TestRSAEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
-	if openssl.SymCryptProviderAvailable() {
+	priv, pub := newRSAKey(t, 2048)
+	if provName, _, _ := openssl.Provider(priv); provName == "symcryptprovider" {
 		t.Skip("SymCrypt provider does not support MGF1 hash")
 	}
 
@@ -158,7 +159,6 @@ func TestRSAEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	label := []byte("ho!")
-	priv, pub := newRSAKey(t, 2048)
 	enc, err := openssl.EncryptRSAOAEP(sha256, sha1, pub, msg, label)
 	if err != nil {
 		t.Fatal(err)
@@ -221,12 +221,12 @@ func TestRSASignVerifyPKCS1v15(t *testing.T) {
 }
 
 func TestRSASignVerifyPKCS1v15_Unhashed(t *testing.T) {
-	if openssl.SymCryptProviderAvailable() {
+	priv, pub := newRSAKey(t, 2048)
+	if provName, _, _ := openssl.Provider(priv); provName == "symcryptprovider" {
 		t.Skip("SymCrypt provider does not support unhashed PKCS1v15")
 	}
 
 	msg := []byte("hi!")
-	priv, pub := newRSAKey(t, 2048)
 	signed, err := openssl.SignRSAPKCS1v15(priv, 0, msg)
 	if err != nil {
 		t.Fatal(err)

--- a/shims.h
+++ b/shims.h
@@ -99,7 +99,6 @@ typedef void* GO_BN_CTX_PTR;
 typedef void* GO_EVP_MAC_PTR;
 typedef void* GO_EVP_MAC_CTX_PTR;
 typedef void* GO_OSSL_PARAM_BLD_PTR;
-typedef void* GO_OSSL_PARAM_PTR;
 typedef void* GO_CRYPTO_THREADID_PTR;
 typedef void* GO_EVP_SIGNATURE_PTR;
 
@@ -108,6 +107,21 @@ typedef void* GO_MD5_CTX_PTR;
 
 // #include <openssl/sha.h>
 typedef void* GO_SHA_CTX_PTR;
+
+// #include <openssl/code.h>
+typedef struct ossl_param_st GO_OSSL_PARAM;
+typedef struct ossl_param_st* GO_OSSL_PARAM_PTR;
+struct ossl_param_st {
+    const char *key;             /* the name of the parameter */
+    unsigned char data_type;     /* declare what kind of content is in data */
+    void *data;                  /* value being passed in or out */
+    size_t data_size;            /* data size */
+    size_t return_size;          /* returned size */
+};
+
+enum {
+    GO_OSSL_PARAM_UTF8 = 6
+};
 
 // FOR_ALL_OPENSSL_FUNCTIONS is the list of all functions from libcrypto that are used in this package.
 // Forgetting to add a function here results in build failure with message reporting the function
@@ -191,6 +205,7 @@ DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (GO_OSSL_LIB_CTX_PTR lib
 DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(const char *, OSSL_PROVIDER_get0_name, (const GO_OSSL_PROVIDER_PTR prov), (prov)) \
+DEFINEFUNC_3_0(int, OSSL_PROVIDER_get_params, (GO_OSSL_PROVIDER_PTR prov, GO_OSSL_PARAM_PTR param), (prov, param)) \
 DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
@@ -199,6 +214,7 @@ DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_block_size, EVP_MD_block_size, (const GO_
 DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC_3_0(const GO_EVP_MD_PTR, EVP_MD_CTX_get0_md, (const GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy_ex, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
 DEFINEFUNC(int, EVP_Digest, (const void *data, size_t count, unsigned char *md, unsigned int *size, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (data, count, md, size, type, impl)) \
@@ -272,6 +288,7 @@ DEFINEFUNC(int, EVP_CIPHER_CTX_set_key_length, (GO_EVP_CIPHER_CTX_PTR x, int key
 DEFINEFUNC(void, EVP_CIPHER_CTX_free, (GO_EVP_CIPHER_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, EVP_CIPHER_CTX_ctrl, (GO_EVP_CIPHER_CTX_PTR ctx, int type, int arg, void *ptr), (ctx, type, arg, ptr)) \
 DEFINEFUNC(GO_EVP_PKEY_PTR, EVP_PKEY_new, (void), ()) \
+DEFINEFUNC_3_0(const GO_OSSL_PROVIDER_PTR, EVP_PKEY_get0_provider, (const GO_EVP_PKEY_PTR ctx), (ctx)) \
 DEFINEFUNC_1_1_1(GO_EVP_PKEY_PTR, EVP_PKEY_new_raw_private_key, (int type, GO_ENGINE_PTR e, const unsigned char *key, size_t keylen), (type, e, key, keylen)) \
 DEFINEFUNC_1_1_1(GO_EVP_PKEY_PTR, EVP_PKEY_new_raw_public_key, (int type, GO_ENGINE_PTR e, const unsigned char *key, size_t keylen), (type, e, key, keylen)) \
 /* EVP_PKEY_size and EVP_PKEY_get_bits pkey parameter is const since OpenSSL 1.1.1. */ \

--- a/shims.h
+++ b/shims.h
@@ -99,6 +99,7 @@ typedef void* GO_BN_CTX_PTR;
 typedef void* GO_EVP_MAC_PTR;
 typedef void* GO_EVP_MAC_CTX_PTR;
 typedef void* GO_OSSL_PARAM_BLD_PTR;
+typedef void* GO_OSSL_PARAM_PTR;
 typedef void* GO_CRYPTO_THREADID_PTR;
 typedef void* GO_EVP_SIGNATURE_PTR;
 
@@ -110,7 +111,6 @@ typedef void* GO_SHA_CTX_PTR;
 
 // #include <openssl/core.h>
 typedef struct ossl_param_st GO_OSSL_PARAM;
-typedef struct ossl_param_st* GO_OSSL_PARAM_PTR;
 struct ossl_param_st {
     const char *key;             /* the name of the parameter */
     unsigned char data_type;     /* declare what kind of content is in data */

--- a/shims.h
+++ b/shims.h
@@ -109,7 +109,9 @@ typedef void* GO_MD5_CTX_PTR;
 // #include <openssl/sha.h>
 typedef void* GO_SHA_CTX_PTR;
 
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 // #include <openssl/core.h>
+// #endif
 typedef struct ossl_param_st GO_OSSL_PARAM;
 struct ossl_param_st {
     const char *key;             /* the name of the parameter */

--- a/shims.h
+++ b/shims.h
@@ -99,7 +99,6 @@ typedef void* GO_BN_CTX_PTR;
 typedef void* GO_EVP_MAC_PTR;
 typedef void* GO_EVP_MAC_CTX_PTR;
 typedef void* GO_OSSL_PARAM_BLD_PTR;
-typedef void* GO_OSSL_PARAM_PTR;
 typedef void* GO_CRYPTO_THREADID_PTR;
 typedef void* GO_EVP_SIGNATURE_PTR;
 
@@ -112,14 +111,13 @@ typedef void* GO_SHA_CTX_PTR;
 // #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 // #include <openssl/core.h>
 // #endif
-typedef struct ossl_param_st GO_OSSL_PARAM;
-struct ossl_param_st {
+typedef struct ossl_param_st {
     const char *key;             /* the name of the parameter */
     unsigned char data_type;     /* declare what kind of content is in data */
     void *data;                  /* value being passed in or out */
     size_t data_size;            /* data size */
     size_t return_size;          /* returned size */
-};
+} GO_OSSL_PARAM, *GO_OSSL_PARAM_PTR;
 
 enum {
     GO_OSSL_PARAM_UTF8 = 6

--- a/shims.h
+++ b/shims.h
@@ -108,7 +108,7 @@ typedef void* GO_MD5_CTX_PTR;
 // #include <openssl/sha.h>
 typedef void* GO_SHA_CTX_PTR;
 
-// #include <openssl/code.h>
+// #include <openssl/core.h>
 typedef struct ossl_param_st GO_OSSL_PARAM;
 typedef struct ossl_param_st* GO_OSSL_PARAM_PTR;
 struct ossl_param_st {


### PR DESCRIPTION
This PR adds the following top level function:

```go
// Provider returns the name, version and build info of the provider of the given object.
// The returned values are empty if using OpenSSL 1 or if the object doesn't
// implement the provider method.
func Provider(obj any) (name, version, buildinfo string)
```

It will be used in the Microsoft Go fork to fall back to standard library algorithms for those operations not supported by the SymCrypt provider, such as RSA PKCS1.5 with unhashed messages and specifying the OAEP MGF1 hash.

It is intended to be used as follows:

```go
h := openssl.NewSHA256()
name, _, _ := openssl.Provider(h)
return name == "symcryptprovider"
```

The provider version number and build information, as they might be useful to detect is a given operation is supported or not.

While here, remove the `SymCryptProviderAvailable` test helper in favor of the new `Provider` function.