### PR TITLE
Improve FIPS() logic to support SymCrypt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,5 +87,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Prove FIPS
+      run: |
+        go test -v -count 0 . | grep -q "FIPS enabled: true"
     - name: Run Test
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,19 @@ jobs:
     - name: Check headers
       working-directory: ./cmd/checkheader
       run: go run . --ossl-include /usr/local/src/openssl-${{ matrix.openssl-version }}/include -shim ../../shims.h
-    - name: Set OpenSSL config and prove FIPS
-      run: |
-        sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
-        go test -v -count 0 . | grep -q "FIPS enabled: true"
+    - name: Set OpenSSL 3 config
+      run: sudo cp ./scripts/openssl-3.cnf /usr/local/ssl/openssl.cnf
+      # Only do this for OpenSSL 3.0.1 so we test OpenSSL with and without FIPS.
       if: ${{ matrix.openssl-version == '3.0.1' }}
+    - name: Prove FIPS
+      run: GO_OPENSSL_TEST_WANT_FIPS=1 go test -v -run TestFIPS
+      # OpenSSL 1.0.2 is always FIPS enabled.
+      if: ${{ matrix.openssl-version == '1.0.2' || matrix.openssl-version == '3.0.1' }}
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+    - name: Prove no-FIPS
+      run: GO_OPENSSL_TEST_WANT_FIPS=0 go test -v -run TestFIPS
+      if: ${{ matrix.openssl-version != '1.0.2' && matrix.openssl-version != '3.0.1' }}
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
     - name: Run Test
@@ -88,7 +96,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Prove FIPS
+      # Azure Linux 3 has FIPS enabled by default, use this knowledge to run TestFIPS.
       run: |
-        go test -v -count 0 . | grep -q "FIPS enabled: true"
+        GO_OPENSSL_TEST_WANT_FIPS=1 go test -v -run TestFIPS
     - name: Run Test
       run: go test -v ./...

--- a/goopenssl.c
+++ b/goopenssl.c
@@ -35,6 +35,18 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0
 
+// go_openssl_fips_enabled returns 1 if FIPS mode is enabled, 0 otherwise.
+// See openssl.FIPS() for details about its implementation.
+//
+// This function is reimplemented here because openssl.FIPS() assumes that
+// all the OpenSSL bindings are loaded, that is, go_openssl_load_functions has
+// been called. On the other hand, go_openssl_fips_enabled is called from
+// openssl.CheckFIPS(), which is used to check if a given OpenSSL shared library
+// exists and is FIPS compliant, and that shared library might not be the one that
+// was passed to go_openssl_load_functions, or it might not have been called at all.
+//
+// It is written in C because it is not possible to directly call C function pointers
+// retrieved using dlsym from Go.
 int
 go_openssl_fips_enabled(void* handle)
 {
@@ -45,15 +57,37 @@ go_openssl_fips_enabled(void* handle)
         return FIPS_mode();
 
     // For OpenSSL 3.x.
-    int (*EVP_default_properties_is_fips_enabled)(void*);
-    int (*OSSL_PROVIDER_available)(void*, const char*);
-    EVP_default_properties_is_fips_enabled = (int (*)(void*))dlsym(handle, "EVP_default_properties_is_fips_enabled"); 
-    OSSL_PROVIDER_available = (int (*)(void*, const char*))dlsym(handle, "OSSL_PROVIDER_available"); 
-    if (EVP_default_properties_is_fips_enabled != NULL && OSSL_PROVIDER_available != NULL &&
-        EVP_default_properties_is_fips_enabled(NULL) == 1 && OSSL_PROVIDER_available(NULL, "fips") == 1)
-            return 1;
+    int (*EVP_default_properties_is_fips_enabled)(void*) =              (int (*)(void*))                                    dlsym(handle, "EVP_default_properties_is_fips_enabled");
+    int (*OSSL_PROVIDER_available)(void*, const char*) =                (int (*)(void*, const char*))                       dlsym(handle, "OSSL_PROVIDER_available");
+    GO_EVP_MD_PTR (*EVP_MD_fetch)(void*, const char*, const char*) =    (GO_EVP_MD_PTR (*)(void*, const char*, const char*))dlsym(handle, "EVP_MD_fetch");
+    void (*EVP_MD_free)(GO_EVP_MD_PTR) =                                (void (*)(GO_EVP_MD_PTR))                           dlsym(handle, "EVP_MD_free");
+    GO_OSSL_PROVIDER_PTR (*EVP_MD_get0_provider)(GO_EVP_MD_PTR) =       (GO_OSSL_PROVIDER_PTR (*)(GO_EVP_MD_PTR))           dlsym(handle, "EVP_MD_get0_provider");
 
-    return 0;
+    if (EVP_default_properties_is_fips_enabled == NULL || OSSL_PROVIDER_available == NULL || EVP_MD_fetch == NULL || EVP_MD_free == NULL || EVP_MD_get0_provider == NULL)
+        return 0;
+
+    int fipsEnabledByDefault = EVP_default_properties_is_fips_enabled(NULL);
+    if (fipsEnabledByDefault == 1 && OSSL_PROVIDER_available(NULL, "fips") == 1)
+        return 1;
+
+    GO_EVP_MD_PTR mdFIPS = EVP_MD_fetch(NULL, "SHA2-256", "fips=yes");
+    if (mdFIPS == NULL)
+        return 0;
+    
+    GO_EVP_MD_PTR mdDefault = EVP_MD_fetch(NULL, "SHA2-256", NULL);
+    if (mdDefault == NULL)
+    {
+        EVP_MD_free(mdFIPS);
+        return fipsEnabledByDefault;
+    }
+
+    int fipEnabled = 0;
+    if (EVP_MD_get0_provider(mdFIPS) == EVP_MD_get0_provider(mdDefault))
+        fipEnabled = 1;
+
+    EVP_MD_free(mdFIPS);
+    EVP_MD_free(mdDefault);
+    return fipEnabled;
 }
 
 // Load all the functions stored in FOR_ALL_OPENSSL_FUNCTIONS

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -78,3 +78,16 @@ func TestCheckVersion(t *testing.T) {
 		t.Fatalf("FIPS mismatch: want %v, got %v", want, fips)
 	}
 }
+
+func TestFIPS(t *testing.T) {
+	wantFIPS := os.Getenv("GO_OPENSSL_TEST_WANT_FIPS")
+	if wantFIPS == "" {
+		// FIPS mode is platform dependent.
+		// We can't test it if we don't know what to expect.
+		t.Skip("skipping test; GO_OPENSSL_TEST_WANT_FIPS not set")
+	}
+	want := wantFIPS == "1"
+	if got := openssl.FIPS(); got != want {
+		t.Fatalf("FIPS mode mismatch: want %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
The current `openssl.FIPS()` implementation doesn't take into account the SymCrypt provider for OpenSSL case, where the FIPS algorithms are not provided by the built-in FIPS provider, but by the SymCrypt provider.

This PR expands the `openssl.FIPS()` logic to be more robust to different provider configurations while keeping a "happy path" for the common case of using the built-in FIPS provider.