### PR TITLE
Fix SupportsDESCipher and SupportsRC4 on Mariner 2

### DIFF
--- a/des.go
+++ b/des.go
@@ -16,7 +16,7 @@ import (
 func SupportsDESCipher() bool {
 	// True for stock OpenSSL 1 w/o FIPS.
 	// False for stock OpenSSL 3 unless the legacy provider is available.
-	return (versionAtOrAbove(1, 1, 0) || !FIPS()) && loadCipher(cipherDES, cipherModeECB) != nil
+	return (versionAtOrAbove(3, 0, 0) || !FIPS()) && loadCipher(cipherDES, cipherModeECB) != nil
 }
 
 // SupportsTripleDESCipher returns true if NewTripleDESCipher is supported,

--- a/rc4.go
+++ b/rc4.go
@@ -10,7 +10,7 @@ import "runtime"
 func SupportsRC4() bool {
 	// True for stock OpenSSL 1 w/o FIPS.
 	// False for stock OpenSSL 3 unless the legacy provider is available.
-	return (versionAtOrAbove(1, 1, 0) || !FIPS()) && loadCipher(cipherRC4, cipherModeNone) != nil
+	return (versionAtOrAbove(3, 0, 0) || !FIPS()) && loadCipher(cipherRC4, cipherModeNone) != nil
 }
 
 // A RC4Cipher is an instance of RC4 using a particular key.


### PR DESCRIPTION
SupportsDESCipher and SupportsRC4 is returning false positive on OpenSSL 1.1.1 because of wrong hard coded version comparison config, making it fail on Linux distros using OpenSSL 1.1.1 with FIPS mode. This PR fixes function of SupportsDESCipher and SupportsRC4 to return true only for OpenSSL 3.0.0 or higher for supported ciphers.
