### PR TITLE
Prevent RandReader.Read argument from escaping to the heap

### DIFF
--- a/cgo_go124.go
+++ b/cgo_go124.go
@@ -1,6 +1,16 @@
 //go:build go1.24 && !cmd_go_bootstrap
 
 package openssl
+// The following noescape and nocallback directives are used to prevent the Go
+// compiler from allocating function parameters on the heap. See
+// https://github.com/golang/go/blob/0733682e5ff4cd294f5eccb31cbe87a543147bc6/src/cmd/cgo/doc.go#L439-L461
+//
+// If possible, write a C wrapper function to optimize a call rather than using
+// this feature so the optimization will work for all supported Go versions.
+//
+// This is just a performance optimization. Only add functions that have been
+// observed to benefit from these directives, not every function that is merely
+// expected to meet the noescape/nocallback criteria.
 
 // #cgo noescape go_openssl_RAND_bytes
 // #cgo nocallback go_openssl_RAND_bytes

--- a/cgo_go124.go
+++ b/cgo_go124.go
@@ -1,0 +1,7 @@
+//go:build go1.24 && !cmd_go_bootstrap
+
+package openssl
+
+// #cgo noescape go_openssl_RAND_bytes
+// #cgo nocallback go_openssl_RAND_bytes
+import "C"

--- a/cgo_go124.go
+++ b/cgo_go124.go
@@ -1,6 +1,7 @@
 //go:build go1.24 && !cmd_go_bootstrap
 
 package openssl
+
 // The following noescape and nocallback directives are used to prevent the Go
 // compiler from allocating function parameters on the heap. See
 // https://github.com/golang/go/blob/0733682e5ff4cd294f5eccb31cbe87a543147bc6/src/cmd/cgo/doc.go#L439-L461

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -2,13 +2,18 @@ package openssl_test
 
 import (
 	"fmt"
+	"go/version"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang-fips/openssl/v2"
 )
+
+// sink is used to prevent the compiler from optimizing out the allocations.
+var sink uint8
 
 // getVersion returns the OpenSSL version to use for testing.
 func getVersion() string {
@@ -77,4 +82,12 @@ func TestCheckVersion(t *testing.T) {
 	if want := openssl.FIPS(); want != fips {
 		t.Fatalf("FIPS mismatch: want %v, got %v", want, fips)
 	}
+}
+
+// compareCurrentVersion compares v with [runtime.Version].
+// See [go/versions.Compare] for information about
+// v format and comparison rules.
+func compareCurrentVersion(v string) int {
+	ver := strings.TrimPrefix(runtime.Version(), "devel ")
+	return version.Compare(ver, v)
 }

--- a/pbkdf2_test.go
+++ b/pbkdf2_test.go
@@ -166,8 +166,6 @@ func TestWithUnsupportedHash(t *testing.T) {
 	}
 }
 
-var sink uint8
-
 func benchmark(b *testing.B, h func() hash.Hash) {
 	password := make([]byte, h().Size())
 	salt := make([]byte, 8)

--- a/rand_test.go
+++ b/rand_test.go
@@ -1,6 +1,9 @@
 package openssl_test
 
 import (
+	"go/version"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/golang-fips/openssl/v2"
@@ -10,5 +13,21 @@ func TestRand(t *testing.T) {
 	_, err := openssl.RandReader.Read(make([]byte, 5))
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAllocations(t *testing.T) {
+	n := int(testing.AllocsPerRun(10, func() {
+		buf := make([]byte, 32)
+		openssl.RandReader.Read(buf)
+		sink ^= buf[0]
+	}))
+	want := 1
+	ver := strings.TrimPrefix(runtime.Version(), "devel ")
+	if version.Compare(ver, "go1.24") >= 0 {
+		want = 0
+	}
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
 	}
 }

--- a/rand_test.go
+++ b/rand_test.go
@@ -1,9 +1,6 @@
 package openssl_test
 
 import (
-	"go/version"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/golang-fips/openssl/v2"
@@ -23,8 +20,9 @@ func TestAllocations(t *testing.T) {
 		sink ^= buf[0]
 	}))
 	want := 1
-	ver := strings.TrimPrefix(runtime.Version(), "devel ")
-	if version.Compare(ver, "go1.24") >= 0 {
+	if compareCurrentVersion("go1.24") >= 0 {
+		// The go1.24 compiler is able to optimize the allocation away.
+		// See cgo_go124.go for more information.
 		want = 0
 	}
 	if n > want {


### PR DESCRIPTION
Go 1.24 will bring back `noescape` and `nocallback` cgo directives, this time without the issue that made us revert the previous attempt to use them (see https://github.com/golang-fips/openssl/pull/129).

For now just use the cgo directives for `go_openssl_RAND_bytes`, as there is no other way to avoid the allocation.