### PR TITLE
Check proper initialization for SupportEd25519

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
-      # This line is temporary. We are currently working on a fix to fully support Mariner 2.0. Once the fix is merged, we will remove this line.    
-      continue-on-error: true
       run: go test -v ./...

--- a/ed25519.go
+++ b/ed25519.go
@@ -37,7 +37,7 @@ func SupportsEd25519() bool {
 	onceSupportsEd25519.Do(func() {
 		switch vMajor {
 		case 1:
-			supportsEd25519 = versionAtOrAbove(1, 1, 1) || !FIPS()
+			supportsEd25519 = versionAtOrAbove(1, 1, 1) || FIPS()
 		case 3:
 			name := C.CString("ED25519")
 			defer C.free(unsafe.Pointer(name))

--- a/ed25519.go
+++ b/ed25519.go
@@ -37,7 +37,7 @@ func SupportsEd25519() bool {
 	onceSupportsEd25519.Do(func() {
 		switch vMajor {
 		case 1:
-			supportsEd25519 = versionAtOrAbove(1, 1, 1)
+			supportsEd25519 = versionAtOrAbove(1, 1, 1) || !FIPS()
 		case 3:
 			name := C.CString("ED25519")
 			defer C.free(unsafe.Pointer(name))

--- a/ed25519.go
+++ b/ed25519.go
@@ -37,7 +37,7 @@ func SupportsEd25519() bool {
 	onceSupportsEd25519.Do(func() {
 		switch vMajor {
 		case 1:
-			supportsEd25519 = versionAtOrAbove(1, 1, 1) || FIPS()
+			supportsEd25519 = versionAtOrAbove(1, 1, 1) && C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_ED25519, nil) != nil
 		case 3:
 			name := C.CString("ED25519")
 			defer C.free(unsafe.Pointer(name))

--- a/ed25519.go
+++ b/ed25519.go
@@ -37,12 +37,13 @@ func SupportsEd25519() bool {
 	onceSupportsEd25519.Do(func() {
 		switch vMajor {
 		case 1:
-			ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_ED25519, nil)
-			if ctx != nil {
-				defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+			if versionAtOrAbove(1, 1, 1) {
+				ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_ED25519, nil)
+				if ctx != nil {
+					C.go_openssl_EVP_PKEY_CTX_free(ctx)
+					supportsEd25519 = true
+				}
 			}
-
-			supportsEd25519 = versionAtOrAbove(1, 1, 1) && ctx != nil
 		case 3:
 			name := C.CString("ED25519")
 			defer C.free(unsafe.Pointer(name))

--- a/ed25519.go
+++ b/ed25519.go
@@ -37,7 +37,12 @@ func SupportsEd25519() bool {
 	onceSupportsEd25519.Do(func() {
 		switch vMajor {
 		case 1:
-			supportsEd25519 = versionAtOrAbove(1, 1, 1) && C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_ED25519, nil) != nil
+			ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_ED25519, nil)
+			if ctx != nil {
+				defer C.go_openssl_EVP_PKEY_CTX_free(ctx)
+			}
+
+			supportsEd25519 = versionAtOrAbove(1, 1, 1) && ctx != nil
 		case 3:
 			name := C.CString("ED25519")
 			defer C.free(unsafe.Pointer(name))


### PR DESCRIPTION
This PR checks if Ed25519 is properly initialized in OpenSSL 1. And adds an extra clause for SupportEd25519 to see if initialized structure is nil or not.