### PR TITLE
Use paramBuilder everywhere

### DIFF
--- a/dsa.go
+++ b/dsa.go
@@ -9,14 +9,6 @@ import (
 	"unsafe"
 )
 
-var (
-	OSSL_PKEY_PARAM_FFC_PBITS = C.CString("pbits")
-	OSSL_PKEY_PARAM_FFC_QBITS = C.CString("qbits")
-	OSSL_PKEY_PARAM_FFC_P     = C.CString("p")
-	OSSL_PKEY_PARAM_FFC_Q     = C.CString("q")
-	OSSL_PKEY_PARAM_FFC_G     = C.CString("g")
-)
-
 // SupportsDSA returns true if the OpenSSL library supports DSA.
 func SupportsDSA() bool {
 	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_DSA, nil)
@@ -110,9 +102,9 @@ func GenerateDSAParameters(l, n int) (DSAParameters, error) {
 			C.go_openssl_BN_free(q)
 			C.go_openssl_BN_free(g)
 		}()
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_P, &p) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_Q, &q) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_FFC_G, &g) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_P, &p) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_Q, &q) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G, &g) != 1 {
 			return DSAParameters{}, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 	default:
@@ -174,8 +166,8 @@ func GenerateKeyDSA(params DSAParameters) (*PrivateKeyDSA, error) {
 			C.go_openssl_BN_clear_free(x)
 			C.go_openssl_BN_free(y)
 		}()
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, &y) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &x) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PUB_KEY, &y) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY, &x) != 1 {
 			return nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 	default:
@@ -264,44 +256,28 @@ func newDSA1(params DSAParameters, x, y BigInt) (pkey C.GO_EVP_PKEY_PTR, err err
 func newDSA3(params DSAParameters, x, y BigInt) (C.GO_EVP_PKEY_PTR, error) {
 	checkMajorVersion(3)
 
-	bld := C.go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
-	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	p, q, g := bigToBN(params.P), bigToBN(params.Q), bigToBN(params.G)
-	defer func() {
-		C.go_openssl_BN_free(p)
-		C.go_openssl_BN_free(q)
-		C.go_openssl_BN_free(g)
-	}()
-	if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_P, p) != 1 ||
-		C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_Q, q) != 1 ||
-		C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_FFC_G, g) != 1 {
+	defer bld.finalize()
 
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-	}
+	bld.addBigInt(_OSSL_PKEY_PARAM_FFC_P, params.P, false)
+	bld.addBigInt(_OSSL_PKEY_PARAM_FFC_Q, params.Q, false)
+	bld.addBigInt(_OSSL_PKEY_PARAM_FFC_G, params.G, false)
 	selection := C.int(C.GO_EVP_PKEY_KEYPAIR)
 	if y != nil {
-		pub := bigToBN(y)
-		defer C.go_openssl_BN_free(pub)
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PUB_KEY, pub) != 1 {
-			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-		}
+		bld.addBigInt(_OSSL_PKEY_PARAM_PUB_KEY, y, false)
 		if x == nil {
 			selection = C.int(C.GO_EVP_PKEY_PUBLIC_KEY)
 		}
 	}
 	if x != nil {
-		priv := bigToBN(x)
-		defer C.go_openssl_BN_clear_free(priv)
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1 {
-			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-		}
+		bld.addBigInt(_OSSL_PKEY_PARAM_PRIV_KEY, x, true)
 	}
-	bldparams := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
-	if bldparams == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_to_param")
+	bldparams, err := bld.build()
+	if err != nil {
+		return nil, err
 	}
 	defer C.go_openssl_OSSL_PARAM_free(bldparams)
 	pkey, err := newEvpFromParams(C.GO_EVP_PKEY_DSA, selection, bldparams)

--- a/ec.go
+++ b/ec.go
@@ -5,14 +5,6 @@ package openssl
 // #include "goopenssl.h"
 import "C"
 
-var (
-	OSSL_PKEY_PARAM_PUB_KEY    = C.CString("pub")
-	OSSL_PKEY_PARAM_PRIV_KEY   = C.CString("priv")
-	OSSL_PKEY_PARAM_GROUP_NAME = C.CString("group")
-	OSSL_PKEY_PARAM_EC_PUB_X   = C.CString("qx")
-	OSSL_PKEY_PARAM_EC_PUB_Y   = C.CString("qy")
-)
-
 func curveNID(curve string) (C.int, error) {
 	switch curve {
 	case "P-224":

--- a/ecdh.go
+++ b/ecdh.go
@@ -167,32 +167,24 @@ func newECDHPkey1(nid C.int, bytes []byte, isPrivate bool) (pkey C.GO_EVP_PKEY_P
 func newECDHPkey3(nid C.int, bytes []byte, isPrivate bool) (C.GO_EVP_PKEY_PTR, error) {
 	checkMajorVersion(3)
 
-	bld := C.go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
-	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
+	defer bld.finalize()
+	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
 	var selection C.int
 	if isPrivate {
-		priv := C.go_openssl_BN_bin2bn(base(bytes), C.int(len(bytes)), nil)
-		if priv == nil {
-			return nil, newOpenSSLError("BN_bin2bn")
-		}
-		defer C.go_openssl_BN_clear_free(priv)
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv) != 1 {
-			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-		}
+		bld.addBin(_OSSL_PKEY_PARAM_PRIV_KEY, bytes, true)
 		selection = C.GO_EVP_PKEY_KEYPAIR
 	} else {
-		cbytes := C.CBytes(bytes)
-		defer C.free(cbytes)
-		C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(bytes)))
+		bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, bytes)
 		selection = C.GO_EVP_PKEY_PUBLIC_KEY
 	}
-	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
-	if params == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_to_param")
+
+	params, err := bld.build()
+	if err != nil {
+		return nil, err
 	}
 	defer C.go_openssl_OSSL_PARAM_free(params)
 	return newEvpFromParams(C.GO_EVP_PKEY_EC, selection, params)
@@ -233,7 +225,7 @@ func deriveEcdhPublicKey(pkey C.GO_EVP_PKEY_PTR, curve string) error {
 		}
 	case 3:
 		var priv C.GO_BIGNUM_PTR
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 			return newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(priv)
@@ -298,7 +290,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 			return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
 		}
 	case 3:
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY, &priv) != 1 {
 			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(priv)

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -91,9 +91,9 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 		// Get Z. We don't need to free it, get0 does not increase the reference count.
 		bd = C.go_openssl_EC_KEY_get0_private_key(key)
 	case 3:
-		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_X, &bx) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_EC_PUB_Y, &by) != 1 ||
-			C.go_openssl_EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &bd) != 1 {
+		if C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X, &bx) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_Y, &by) != 1 ||
+			C.go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY, &bd) != 1 {
 			return nil, nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
 		}
 		defer C.go_openssl_BN_clear_free(bd)
@@ -188,27 +188,23 @@ func newECDSAKey3(nid C.int, bx, by, bd C.GO_BIGNUM_PTR) (C.GO_EVP_PKEY_PTR, err
 		return nil, err
 	}
 	// Construct the parameters.
-	bld := C.go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
-	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
-	cbytes := C.CBytes(pubBytes)
-	defer C.free(cbytes)
-	C.go_openssl_OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, cbytes, C.size_t(len(pubBytes)))
+	defer bld.finalize()
+	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, C.go_openssl_OBJ_nid2sn(nid), 0)
+	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubBytes)
 	var selection C.int
 	if bd != nil {
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, bd) != 1 {
-			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-		}
+		bld.addBN(_OSSL_PKEY_PARAM_PRIV_KEY, bd)
 		selection = C.GO_EVP_PKEY_KEYPAIR
 	} else {
 		selection = C.GO_EVP_PKEY_PUBLIC_KEY
 	}
-	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
-	if params == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_to_param")
+	params, err := bld.build()
+	if err != nil {
+		return nil, err
 	}
 	defer C.go_openssl_OSSL_PARAM_free(params)
 	return newEvpFromParams(C.GO_EVP_PKEY_EC, selection, params)

--- a/hmac.go
+++ b/hmac.go
@@ -11,8 +11,6 @@ import (
 	"unsafe"
 )
 
-var OSSL_MAC_PARAM_DIGEST = C.CString("digest")
-
 // NewHMAC returns a new HMAC using OpenSSL.
 // The function h must return a hash implemented by
 // OpenSSL (for example, h could be openssl.NewSHA256).
@@ -99,14 +97,14 @@ var fetchHMAC3 = sync.OnceValue(func() C.GO_EVP_MAC_PTR {
 	return mac
 })
 
-func buildHMAC3Params(digest *C.char) C.GO_OSSL_PARAM_PTR {
-	bld := C.go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		panic(newOpenSSLError("OSSL_PARAM_BLD_new"))
+func buildHMAC3Params(digest *C.char) (C.GO_OSSL_PARAM_PTR, error) {
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
-	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-	C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_MAC_PARAM_DIGEST, digest, 0)
-	return C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
+	defer bld.finalize()
+	bld.addUTF8String(_OSSL_MAC_PARAM_DIGEST, digest, 0)
+	return bld.build()
 }
 
 func isHMAC3DigestSupported(digest string) bool {
@@ -121,9 +119,9 @@ func isHMAC3DigestSupported(digest string) bool {
 
 	cdigest := C.CString(digest)
 	defer C.free(unsafe.Pointer(cdigest))
-	params := buildHMAC3Params(cdigest)
-	if params == nil {
-		panic(newOpenSSLError("OSSL_PARAM_BLD_to_param"))
+	params, err := buildHMAC3Params(cdigest)
+	if err != nil {
+		panic(err)
 	}
 	defer C.go_openssl_OSSL_PARAM_free(params)
 
@@ -141,9 +139,9 @@ func newHMAC3(key []byte, md C.GO_EVP_MD_PTR) hmacCtx3 {
 		// See https://github.com/golang-fips/openssl/issues/153.
 		return hmacCtx3{}
 	}
-	params := buildHMAC3Params(digest)
-	if params == nil {
-		panic(newOpenSSLError("OSSL_PARAM_BLD_to_param"))
+	params, err := buildHMAC3Params(digest)
+	if err != nil {
+		panic(err)
 	}
 	defer C.go_openssl_OSSL_PARAM_free(params)
 

--- a/params.go
+++ b/params.go
@@ -175,7 +175,7 @@ func (b *paramBuilder) addBin(name *C.char, value []byte, private bool) {
 	if !b.check() {
 		return
 	}
-	if value == nil {
+	if len(value) == 0 {
 		// Nothing to do.
 		return
 	}
@@ -196,7 +196,7 @@ func (b *paramBuilder) addBigInt(name *C.char, value BigInt, private bool) {
 	if !b.check() {
 		return
 	}
-	if value == nil {
+	if len(value) == 0 {
 		// Nothing to do.
 		return
 	}

--- a/params.go
+++ b/params.go
@@ -175,6 +175,10 @@ func (b *paramBuilder) addBin(name *C.char, value []byte, private bool) {
 	if !b.check() {
 		return
 	}
+	if value == nil {
+		// Nothing to do.
+		return
+	}
 	bn := C.go_openssl_BN_bin2bn(base(value), C.int(len(value)), nil)
 	if bn == nil {
 		b.err = newOpenSSLError("BN_bin2bn")
@@ -190,6 +194,10 @@ func (b *paramBuilder) addBin(name *C.char, value []byte, private bool) {
 // otherwise it will be freed with BN_free.
 func (b *paramBuilder) addBigInt(name *C.char, value BigInt, private bool) {
 	if !b.check() {
+		return
+	}
+	if value == nil {
+		// Nothing to do.
 		return
 	}
 	bn := bigToBN(value)

--- a/params.go
+++ b/params.go
@@ -157,7 +157,7 @@ func (b *paramBuilder) addInt32(name *C.char, value int32) {
 	}
 }
 
-// addBN adds an GO_BIGNUM_PTR to the builder.
+// addBN adds a GO_BIGNUM_PTR to the builder.
 func (b *paramBuilder) addBN(name *C.char, value C.GO_BIGNUM_PTR) {
 	if !b.check() {
 		return
@@ -185,7 +185,7 @@ func (b *paramBuilder) addBin(name *C.char, value []byte, private bool) {
 }
 
 // addBigInt adds a BigInt to the builder.
-// The BigInt is converted to a BIGNUM using bigToBN and freed when the builder is finalized.
+// The BigInt is converted using bigToBN to a BIGNUM that is freed when the builder is finalized.
 // If private is true, the BIGNUM will be cleared with BN_clear_free,
 // otherwise it will be freed with BN_free.
 func (b *paramBuilder) addBigInt(name *C.char, value BigInt, private bool) {

--- a/params.go
+++ b/params.go
@@ -18,15 +18,44 @@ var (
 	_OSSL_KDF_PARAM_INFO   = C.CString("info")
 	_OSSL_KDF_PARAM_SALT   = C.CString("salt")
 	_OSSL_KDF_PARAM_MODE   = C.CString("mode")
+
+	// PKEY parameters
+	_OSSL_PKEY_PARAM_PUB_KEY          = C.CString("pub")
+	_OSSL_PKEY_PARAM_PRIV_KEY         = C.CString("priv")
+	_OSSL_PKEY_PARAM_GROUP_NAME       = C.CString("group")
+	_OSSL_PKEY_PARAM_EC_PUB_X         = C.CString("qx")
+	_OSSL_PKEY_PARAM_EC_PUB_Y         = C.CString("qy")
+	_OSSL_PKEY_PARAM_FFC_PBITS        = C.CString("pbits")
+	_OSSL_PKEY_PARAM_FFC_QBITS        = C.CString("qbits")
+	_OSSL_PKEY_PARAM_RSA_N            = C.CString("n")
+	_OSSL_PKEY_PARAM_RSA_E            = C.CString("e")
+	_OSSL_PKEY_PARAM_RSA_D            = C.CString("d")
+	_OSSL_PKEY_PARAM_FFC_P            = C.CString("p")
+	_OSSL_PKEY_PARAM_FFC_Q            = C.CString("q")
+	_OSSL_PKEY_PARAM_FFC_G            = C.CString("g")
+	_OSSL_PKEY_PARAM_RSA_FACTOR1      = C.CString("rsa-factor1")
+	_OSSL_PKEY_PARAM_RSA_FACTOR2      = C.CString("rsa-factor2")
+	_OSSL_PKEY_PARAM_RSA_EXPONENT1    = C.CString("rsa-exponent1")
+	_OSSL_PKEY_PARAM_RSA_EXPONENT2    = C.CString("rsa-exponent2")
+	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1 = C.CString("rsa-coefficient1")
+
+	// MAC parameters
+	_OSSL_MAC_PARAM_DIGEST = C.CString("digest")
 )
+
+type bnParam struct {
+	value   C.GO_BIGNUM_PTR
+	private bool
+}
 
 // paramBuilder is a helper for building OSSL_PARAMs.
 // If an error occurs when adding a new parameter,
 // subsequent calls to add parameters are ignored
 // and build() will return the error.
 type paramBuilder struct {
-	bld    C.GO_OSSL_PARAM_BLD_PTR
-	pinner runtime.Pinner
+	bld      C.GO_OSSL_PARAM_BLD_PTR
+	pinner   runtime.Pinner
+	bnToFree []bnParam
 
 	err error
 }
@@ -37,7 +66,10 @@ func newParamBuilder() (*paramBuilder, error) {
 	if bld == nil {
 		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
 	}
-	pb := &paramBuilder{bld: bld}
+	pb := &paramBuilder{
+		bld:      bld,
+		bnToFree: make([]bnParam, 0, 8), // the maximum known number of BIGNUMs to free are 8 for RSA
+	}
 	runtime.SetFinalizer(pb, (*paramBuilder).finalize)
 	return pb, nil
 }
@@ -46,6 +78,13 @@ func newParamBuilder() (*paramBuilder, error) {
 func (b *paramBuilder) finalize() {
 	if b.bld != nil {
 		b.pinner.Unpin()
+		for _, bn := range b.bnToFree {
+			if bn.private {
+				C.go_openssl_BN_clear_free(bn.value)
+			} else {
+				C.go_openssl_BN_free(bn.value)
+			}
+		}
 		C.go_openssl_OSSL_PARAM_BLD_free(b.bld)
 		b.bld = nil
 	}
@@ -116,4 +155,48 @@ func (b *paramBuilder) addInt32(name *C.char, value int32) {
 	if C.go_openssl_OSSL_PARAM_BLD_push_int32(b.bld, name, C.int32_t(value)) != 1 {
 		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_int32(" + C.GoString(name) + ")")
 	}
+}
+
+// addBN adds an GO_BIGNUM_PTR to the builder.
+func (b *paramBuilder) addBN(name *C.char, value C.GO_BIGNUM_PTR) {
+	if !b.check() {
+		return
+	}
+	if C.go_openssl_OSSL_PARAM_BLD_push_BN(b.bld, name, value) != 1 {
+		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_BN(" + C.GoString(name) + ")")
+	}
+}
+
+// addBin adds a byte slice to the builder.
+// The slice is converted to a BIGNUM using BN_bin2bn and freed when the builder is finalized.
+// If private is true, the BIGNUM will be cleared with BN_clear_free,
+// otherwise it will be freed with BN_free.
+func (b *paramBuilder) addBin(name *C.char, value []byte, private bool) {
+	if !b.check() {
+		return
+	}
+	bn := C.go_openssl_BN_bin2bn(base(value), C.int(len(value)), nil)
+	if bn == nil {
+		b.err = newOpenSSLError("BN_bin2bn")
+		return
+	}
+	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
+	b.addBN(name, bn)
+}
+
+// addBigInt adds a BigInt to the builder.
+// The BigInt is converted to a BIGNUM using bigToBN and freed when the builder is finalized.
+// If private is true, the BIGNUM will be cleared with BN_clear_free,
+// otherwise it will be freed with BN_free.
+func (b *paramBuilder) addBigInt(name *C.char, value BigInt, private bool) {
+	if !b.check() {
+		return
+	}
+	bn := bigToBN(value)
+	if bn == nil {
+		b.err = newOpenSSLError("bigToBN")
+		return
+	}
+	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
+	b.addBN(name, bn)
 }

--- a/rsa.go
+++ b/rsa.go
@@ -13,17 +13,6 @@ import (
 	"unsafe"
 )
 
-var (
-	OSSL_PKEY_PARAM_RSA_N            = C.CString("n")
-	OSSL_PKEY_PARAM_RSA_E            = C.CString("e")
-	OSSL_PKEY_PARAM_RSA_D            = C.CString("d")
-	OSSL_PKEY_PARAM_RSA_FACTOR1      = C.CString("rsa-factor1")
-	OSSL_PKEY_PARAM_RSA_FACTOR2      = C.CString("rsa-factor2")
-	OSSL_PKEY_PARAM_RSA_EXPONENT1    = C.CString("rsa-exponent1")
-	OSSL_PKEY_PARAM_RSA_EXPONENT2    = C.CString("rsa-exponent2")
-	OSSL_PKEY_PARAM_RSA_COEFFICIENT1 = C.CString("rsa-coefficient1")
-)
-
 func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	bad := func(e error) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		return nil, nil, nil, nil, nil, nil, nil, nil, e
@@ -73,14 +62,14 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 			C.go_openssl_BN_clear(tmp)
 			return true
 		}
-		if !(setBigInt(&N, OSSL_PKEY_PARAM_RSA_N) &&
-			setBigInt(&E, OSSL_PKEY_PARAM_RSA_E) &&
-			setBigInt(&D, OSSL_PKEY_PARAM_RSA_D) &&
-			setBigInt(&P, OSSL_PKEY_PARAM_RSA_FACTOR1) &&
-			setBigInt(&Q, OSSL_PKEY_PARAM_RSA_FACTOR2) &&
-			setBigInt(&Dp, OSSL_PKEY_PARAM_RSA_EXPONENT1) &&
-			setBigInt(&Dq, OSSL_PKEY_PARAM_RSA_EXPONENT2) &&
-			setBigInt(&Qinv, OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
+		if !(setBigInt(&N, _OSSL_PKEY_PARAM_RSA_N) &&
+			setBigInt(&E, _OSSL_PKEY_PARAM_RSA_E) &&
+			setBigInt(&D, _OSSL_PKEY_PARAM_RSA_D) &&
+			setBigInt(&P, _OSSL_PKEY_PARAM_RSA_FACTOR1) &&
+			setBigInt(&Q, _OSSL_PKEY_PARAM_RSA_FACTOR2) &&
+			setBigInt(&Dp, _OSSL_PKEY_PARAM_RSA_EXPONENT1) &&
+			setBigInt(&Dq, _OSSL_PKEY_PARAM_RSA_EXPONENT2) &&
+			setBigInt(&Qinv, _OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 			return bad(err)
 		}
 	default:
@@ -377,22 +366,16 @@ func rsaSetCRTParams(key C.GO_RSA_PTR, dmp1, dmq1, iqmp BigInt) bool {
 	return C.go_openssl_RSA_set0_crt_params(key, bigToBN(dmp1), bigToBN(dmq1), bigToBN(iqmp)) == 1
 }
 func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_PTR, error) {
-	// Construct the parameters.
-	bld := C.go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
-	}
-	defer C.go_openssl_OSSL_PARAM_BLD_free(bld)
-
 	type bigIntParam struct {
-		name *C.char
-		num  BigInt
+		name    *C.char
+		num     BigInt
+		private bool
 	}
 
 	comps := make([]bigIntParam, 0, 8)
 
 	required := [...]bigIntParam{
-		{OSSL_PKEY_PARAM_RSA_N, n}, {OSSL_PKEY_PARAM_RSA_E, e}, {OSSL_PKEY_PARAM_RSA_D, d},
+		{_OSSL_PKEY_PARAM_RSA_N, n, false}, {_OSSL_PKEY_PARAM_RSA_E, e, false}, {_OSSL_PKEY_PARAM_RSA_D, d, false},
 	}
 	comps = append(comps, required[:]...)
 
@@ -405,34 +388,32 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
 		// value is missing. See https://github.com/openssl/openssl/pull/22334
 		if vMinor >= 2 || allPrecomputedExists {
-			comps = append(comps, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR2, q})
+			comps = append(comps, bigIntParam{_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true}, bigIntParam{_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true})
 		}
 		if allPrecomputedExists {
 			comps = append(comps,
-				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp},
-				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT2, dq},
-				bigIntParam{OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv},
+				bigIntParam{_OSSL_PKEY_PARAM_RSA_EXPONENT1, dp, true},
+				bigIntParam{_OSSL_PKEY_PARAM_RSA_EXPONENT2, dq, true},
+				bigIntParam{_OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv, true},
 			)
 		}
 	}
+
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
+	}
+	defer bld.finalize()
 
 	for _, comp := range comps {
 		if comp.num == nil {
 			continue
 		}
-		b := bigToBN(comp.num)
-		if b == nil {
-			return nil, newOpenSSLError("BN_lebin2bn failed")
-		}
-		// b must remain valid until OSSL_PARAM_BLD_to_param has been called.
-		defer C.go_openssl_BN_clear_free(b)
-		if C.go_openssl_OSSL_PARAM_BLD_push_BN(bld, comp.name, b) != 1 {
-			return nil, newOpenSSLError("OSSL_PARAM_BLD_push_BN")
-		}
+		bld.addBigInt(comp.name, comp.num, comp.private)
 	}
-	params := C.go_openssl_OSSL_PARAM_BLD_to_param(bld)
-	if params == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_to_param")
+	params, err := bld.build()
+	if err != nil {
+		return nil, err
 	}
 	defer C.go_openssl_OSSL_PARAM_free(params)
 	selection := C.GO_EVP_PKEY_PUBLIC_KEY

--- a/rsa.go
+++ b/rsa.go
@@ -366,18 +366,15 @@ func rsaSetCRTParams(key C.GO_RSA_PTR, dmp1, dmq1, iqmp BigInt) bool {
 	return C.go_openssl_RSA_set0_crt_params(key, bigToBN(dmp1), bigToBN(dmq1), bigToBN(iqmp)) == 1
 }
 func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_PTR, error) {
-	type bigIntParam struct {
-		name    *C.char
-		num     BigInt
-		private bool
+	bld, err := newParamBuilder()
+	if err != nil {
+		return nil, err
 	}
+	defer bld.finalize()
 
-	comps := make([]bigIntParam, 0, 8)
-
-	required := [...]bigIntParam{
-		{_OSSL_PKEY_PARAM_RSA_N, n, false}, {_OSSL_PKEY_PARAM_RSA_E, e, false}, {_OSSL_PKEY_PARAM_RSA_D, d, false},
-	}
-	comps = append(comps, required[:]...)
+	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_N, n, false)
+	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_E, e, false)
+	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_D, d, false)
 
 	if p != nil && q != nil {
 		allPrecomputedExists := dp != nil && dq != nil && qinv != nil
@@ -388,29 +385,16 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
 		// value is missing. See https://github.com/openssl/openssl/pull/22334
 		if vMinor >= 2 || allPrecomputedExists {
-			comps = append(comps, bigIntParam{_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true}, bigIntParam{_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true})
+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true)
+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true)
 		}
 		if allPrecomputedExists {
-			comps = append(comps,
-				bigIntParam{_OSSL_PKEY_PARAM_RSA_EXPONENT1, dp, true},
-				bigIntParam{_OSSL_PKEY_PARAM_RSA_EXPONENT2, dq, true},
-				bigIntParam{_OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv, true},
-			)
+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT1, dp, true)
+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_EXPONENT2, dq, true)
+			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv, true)
 		}
 	}
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
-	defer bld.finalize()
-
-	for _, comp := range comps {
-		if comp.num == nil {
-			continue
-		}
-		bld.addBigInt(comp.name, comp.num, comp.private)
-	}
 	params, err := bld.build()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Building parameters using the OpenSSL C API is tedious and error-prone. Better use the `paramBuilder` abstraction, which knows how and when to free memory and doesn't miss any error check.

While here, move all parameter definitions to `params.go` and make sure they are not part of the public API by prepending them with an underscore.