### PR TITLE
Add cgolessbuild test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,18 @@ jobs:
     - name: Run Test
       run: go test -v ./...
 
-  # The module isn't useful without cgo, but it still needs to successfully build. Broad cgo-less
-  # builds should succeed if they import this module but don't refer to anything requiring cgo. This
-  # may be necessary to build a Go toolset fork, depending on how it's implemented.
+  # Verify that golang-fips/openssl builds successfully without cgo enabled.
+  #
+  # A project can avoid attempting to build the openssl package by only
+  # importing it from Go files with a cgo build tag. However, this isn't always
+  # reasonable. In that case, we can help by making sure the openssl package
+  # builds successfully even without cgo.
+  #
+  # For example, the Microsoft Go toolset fork builds this module without cgo
+  # for a cross-platform build.
+  #
+  # The golang-fips/openssl module can't do any crypto when built without cgo,
+  # but it exports a few simple functions and types.
   cgolessbuild:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,3 +97,14 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
       run: go test -v ./...
+
+  # The module isn't useful without cgo, but it still needs to successfully build. Broad cgo-less
+  # builds should succeed if they import this module but don't refer to anything requiring cgo. This
+  # may be necessary to build a Go toolset fork, depending on how it's implemented.
+  cgolessbuild:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Run Build
+      run: CGO_ENABLED=0 go build ./...


### PR DESCRIPTION
* To check for regressions like https://github.com/golang-fips/openssl/pull/209

I'm not totally positive why our fork depends on this. I would have expected that there are no `import`s if cgo isn't enabled because we wouldn't try to use the openssl backend. However, I don't think it would be bad to keep this working even if we figure out and remove the dependency.