### PR TITLE
Implement HasFIPSProvider

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -10,7 +10,3 @@ var SymCryptProviderAvailable = sync.OnceValue(func() bool {
 	}
 	return isProviderAvailable("symcryptprovider")
 })
-
-func MajorVersion() int {
-	return int(vMajor)
-}

--- a/export_test.go
+++ b/export_test.go
@@ -10,3 +10,7 @@ var SymCryptProviderAvailable = sync.OnceValue(func() bool {
 	}
 	return isProviderAvailable("symcryptprovider")
 })
+
+func MajorVersion() int {
+	return int(vMajor)
+}

--- a/openssl.go
+++ b/openssl.go
@@ -141,12 +141,12 @@ func FIPS() bool {
 
 // FIPSProvider returns true if the provider used by the default matches the `fips=yes` query.
 // Note that this function can return true even if [FIPS] returns false, because [FIPS] checks
-// whether the default properties contain `fips=1`.
-// It will always return true for OpenSSL 3 if [FIPS] returns true.
-// It will always returns false for OpenSSL 1.
+// whether the default properties contain `fips=1`. It will always return true for OpenSSL 3 if
+// [FIPS] returns true.
+// When using OpenSSL 1, this function always returns the same value as [FIPS].
 func FIPSProvider() bool {
 	if vMajor == 1 {
-		return false
+		return FIPS()
 	}
 	provFn := func(props *C.char) C.GO_OSSL_PROVIDER_PTR {
 		md := C.go_openssl_EVP_MD_fetch(nil, algorithmSHA256, props)

--- a/openssl.go
+++ b/openssl.go
@@ -141,7 +141,7 @@ func FIPS() bool {
 
 // HasFIPSProvider returns true if the provider used by the default matches the `fips=yes` query.
 // Note that this function can return true even if [FIPS] returns false, because [FIPS] checks
-// whether the default properties contain `fips=1`. It will always return true for OpenSSL 3 if
+// whether the default properties contain `fips=yes`. It will always return true for OpenSSL 3 if
 // [FIPS] returns true.
 // When using OpenSSL 1, this function always returns the same value as [FIPS].
 func HasFIPSProvider() bool {

--- a/openssl.go
+++ b/openssl.go
@@ -129,6 +129,7 @@ func FIPS() bool {
 		// used by the caller application, but that is also unlikely because the FIPS provider should provide all common algorithms.
 		md := C.go_openssl_EVP_MD_fetch(nil, algorithmSHA256, nil)
 		if md == nil {
+			C.go_openssl_ERR_clear_error()
 			return false
 		}
 		C.go_openssl_EVP_MD_free(md)
@@ -136,6 +137,31 @@ func FIPS() bool {
 	default:
 		panic(errUnsupportedVersion())
 	}
+}
+
+// FIPSProvider returns true if the provider used by the default matches the `fips=yes` query.
+// Note that this function can return true even if [FIPS] returns false, because [FIPS] checks
+// whether the default properties contain `fips=1`.
+// It will always return true for OpenSSL 3 if [FIPS] returns true.
+// It will always returns false for OpenSSL 1.
+func FIPSProvider() bool {
+	if vMajor == 1 {
+		return false
+	}
+	provFn := func(props *C.char) C.GO_OSSL_PROVIDER_PTR {
+		md := C.go_openssl_EVP_MD_fetch(nil, algorithmSHA256, props)
+		if md == nil {
+			C.go_openssl_ERR_clear_error()
+			return nil
+		}
+		C.go_openssl_EVP_MD_free(md)
+		return C.go_openssl_EVP_MD_get0_provider(md)
+	}
+	// Load the provider with and without the `fips=yes` query.
+	// If the providers are the same, then the default provider is FIPS-capable.
+	provFIPS := provFn(propFIPS)
+	provDefault := provFn(nil)
+	return provFIPS != nil && provFIPS == provDefault
 }
 
 // isProviderAvailable checks if the provider with the given name is available.

--- a/openssl.go
+++ b/openssl.go
@@ -160,8 +160,11 @@ func FIPSProvider() bool {
 	// Load the provider with and without the `fips=yes` query.
 	// If the providers are the same, then the default provider is FIPS-capable.
 	provFIPS := provFn(propFIPS)
+	if provFIPS == nil {
+		return false
+	}
 	provDefault := provFn(nil)
-	return provFIPS != nil && provFIPS == provDefault
+	return provFIPS == provDefault
 }
 
 // isProviderAvailable checks if the provider with the given name is available.

--- a/openssl.go
+++ b/openssl.go
@@ -139,32 +139,36 @@ func FIPS() bool {
 	}
 }
 
-// FIPSProvider returns true if the provider used by the default matches the `fips=yes` query.
+// HasFIPSProvider returns true if the provider used by the default matches the `fips=yes` query.
 // Note that this function can return true even if [FIPS] returns false, because [FIPS] checks
 // whether the default properties contain `fips=1`. It will always return true for OpenSSL 3 if
 // [FIPS] returns true.
 // When using OpenSSL 1, this function always returns the same value as [FIPS].
-func FIPSProvider() bool {
-	if vMajor == 1 {
+func HasFIPSProvider() bool {
+	switch vMajor {
+	case 1:
 		return FIPS()
-	}
-	provFn := func(props *C.char) C.GO_OSSL_PROVIDER_PTR {
-		md := C.go_openssl_EVP_MD_fetch(nil, algorithmSHA256, props)
-		if md == nil {
-			C.go_openssl_ERR_clear_error()
-			return nil
+	case 3:
+		provFn := func(props *C.char) C.GO_OSSL_PROVIDER_PTR {
+			md := C.go_openssl_EVP_MD_fetch(nil, algorithmSHA256, props)
+			if md == nil {
+				C.go_openssl_ERR_clear_error()
+				return nil
+			}
+			C.go_openssl_EVP_MD_free(md)
+			return C.go_openssl_EVP_MD_get0_provider(md)
 		}
-		C.go_openssl_EVP_MD_free(md)
-		return C.go_openssl_EVP_MD_get0_provider(md)
+		// Load the provider with and without the `fips=yes` query.
+		// If the providers are the same, then the default provider is FIPS-capable.
+		provFIPS := provFn(propFIPS)
+		if provFIPS == nil {
+			return false
+		}
+		provDefault := provFn(nil)
+		return provFIPS == provDefault
+	default:
+		panic(errUnsupportedVersion())
 	}
-	// Load the provider with and without the `fips=yes` query.
-	// If the providers are the same, then the default provider is FIPS-capable.
-	provFIPS := provFn(propFIPS)
-	if provFIPS == nil {
-		return false
-	}
-	provDefault := provFn(nil)
-	return provFIPS == provDefault
 }
 
 // isProviderAvailable checks if the provider with the given name is available.

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -96,8 +96,9 @@ func compareCurrentVersion(v string) int {
 func TestFIPSProvider(t *testing.T) {
 	fipsProv := openssl.FIPSProvider()
 	if openssl.MajorVersion() == 1 {
-		if fipsProv {
-			t.Fatal("FIPSProvider should be false for OpenSSL 1")
+		want := openssl.FIPS()
+		if fipsProv != want {
+			t.Fatalf("FIPSProvider mismatch: want %v, got %v", want, fipsProv)
 		}
 		return
 	}

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -62,6 +62,7 @@ func TestMain(m *testing.M) {
 	_ = openssl.SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
 	fmt.Println("OpenSSL version:", openssl.VersionText())
 	fmt.Println("FIPS enabled:", openssl.FIPS())
+	fmt.Println("FIPS capable:", openssl.FIPSProvider())
 	status := m.Run()
 	for range 5 {
 		// Run GC a few times to avoid false positives in leak detection.
@@ -90,4 +91,24 @@ func TestCheckVersion(t *testing.T) {
 func compareCurrentVersion(v string) int {
 	ver := strings.TrimPrefix(runtime.Version(), "devel ")
 	return version.Compare(ver, v)
+}
+
+func TestFIPSProvider(t *testing.T) {
+	fipsProv := openssl.FIPSProvider()
+	if openssl.MajorVersion() == 1 {
+		if fipsProv {
+			t.Fatal("FIPSProvider should be false for OpenSSL 1")
+		}
+		return
+	}
+
+	if openssl.FIPS() {
+		if !fipsProv {
+			t.Fatal("FIPSProvider should be true when FIPS is enabled")
+		}
+	} else if openssl.SymCryptProviderAvailable() {
+		if !fipsProv {
+			t.Fatal("FIPSProvider should be true when SymCrypt is available")
+		}
+	}
 }

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	_ = openssl.SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
 	fmt.Println("OpenSSL version:", openssl.VersionText())
 	fmt.Println("FIPS enabled:", openssl.FIPS())
-	fmt.Println("FIPS capable:", openssl.FIPSProvider())
+	fmt.Println("FIPS provider:", openssl.HasFIPSProvider())
 	status := m.Run()
 	for range 5 {
 		// Run GC a few times to avoid false positives in leak detection.
@@ -93,23 +93,14 @@ func compareCurrentVersion(v string) int {
 	return version.Compare(ver, v)
 }
 
-func TestFIPSProvider(t *testing.T) {
-	fipsProv := openssl.FIPSProvider()
-	if openssl.MajorVersion() == 1 {
-		want := openssl.FIPS()
-		if fipsProv != want {
-			t.Fatalf("FIPSProvider mismatch: want %v, got %v", want, fipsProv)
-		}
-		return
+func TestHasFIPSProvider(t *testing.T) {
+	got := openssl.HasFIPSProvider()
+	want := openssl.FIPS()
+	if !want && openssl.SymCryptProviderAvailable() {
+		// The SymCrypt provider is FIPS-capable.
+		want = true
 	}
-
-	if openssl.FIPS() {
-		if !fipsProv {
-			t.Fatal("FIPSProvider should be true when FIPS is enabled")
-		}
-	} else if openssl.SymCryptProviderAvailable() {
-		if !fipsProv {
-			t.Fatal("FIPSProvider should be true when SymCrypt is available")
-		}
+	if got != want {
+		t.Fatalf("HasFIPSProvider mismatch: want %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
`FIPS()` will return false if the `fips=yes` property is not set in the default properties. This is working as intended, but it is not sufficient to determine if the provider used by default is FIPS-capable. Some distros (e.g. Azure Linux 3, see https://github.com/microsoft/azurelinux/issues/10433) don't set the `-fips=yes` property when operating in FIPS mode, but instead set a FIPS-capable provider (e.g. SymCrypt) as default provider by setting the `provider` property in the default properties (e.g. `?provider=symcryptprovider`).

This PR adds a new function, `HasFIPSProvider()`, which checks if the provider used by the default matches the `fips=yes` query.