### PR TITLE
Upgrade CI runner from macos-12 to macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         go-version: [1.22.x, 1.23.x]
         openssl-version: [libcrypto.3.dylib]
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [libcrypto.3.dylib]
+        openssl-version: [libcrypto.dylib]
     runs-on: macos-13
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [libcrypto.3.dylib]
-    runs-on: macos-15
+        openssl-version: [libcrypto.1.1.dylib]
+    runs-on: macos-14
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         go-version: [1.22.x, 1.23.x]
         openssl-version: [libcrypto.3.dylib]
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [libcrypto.1.1.dylib]
+        openssl-version: [libcrypto.3.dylib]
     runs-on: macos-14
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [libcrypto.dylib]
-    runs-on: macos-13
+        openssl-version: [libcrypto.3.dylib]
+    runs-on: macos-14
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,11 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [/opt/homebrew/opt/openssl@1.1/lib/libcrypto.1.1.dylib]
+        openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib]
     runs-on: macos-13
     steps:
+    - name: Install OpenSSL@3
+      run: brew install openssl@3
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,8 @@ jobs:
         openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib]
     runs-on: macos-13
     steps:
-    - name: Install OpenSSL
-      run: brew install openssl@3
     - name: List OpenSSL
-      run: ls /opt/homebrew/opt
+      run: brew --prefix openssl@3
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib]
+        openssl-version: [/usr/local/opt/openssl@3/lib/libcrypto.3.dylib]
     runs-on: macos-13
     steps:
-    - name: List OpenSSL
-      run: brew --prefix openssl@3
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         go-version: [1.22.x, 1.23.x]
         openssl-version: [libcrypto.3.dylib]
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [libcrypto.3.dylib]
     runs-on: macos-13
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,10 @@ jobs:
         openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib]
     runs-on: macos-13
     steps:
+    - name: Install OpenSSL
+      run: brew install openssl@3
     - name: List OpenSSL
-      run: ls /opt/homebrew/opt/openssl@3/lib/
+      run: ls /opt/homebrew/opt
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
+        openssl-version: [/opt/homebrew/opt/openssl@1.1/lib/libcrypto.1.1.dylib]
     runs-on: macos-13
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,11 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib]
+        openssl-version: [/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib]
     runs-on: macos-13
     steps:
-    - name: Install OpenSSL@3
-      run: brew install openssl@3
+    - name: List OpenSSL
+      run: ls /opt/homebrew/opt/openssl@3/lib/
     - name: Install Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
MacOS CI runners are deprecated and will be removed soon: https://github.com/actions/runner-images/issues/10721.

In fact, macOS already entered the burnout period.