### PR TITLE
Update RSA invalid salt length error message

### DIFF
--- a/rsa.go
+++ b/rsa.go
@@ -238,7 +238,7 @@ func saltLength(saltLen int, sign bool) (C.int, error) {
 	// A salt length of -2 is valid in OpenSSL, but not in crypto/rsa, so reject
 	// it, and lengths < -2, before we convert to the OpenSSL sentinel values.
 	if saltLen <= -2 {
-		return 0, errors.New("crypto/rsa: PSSOptions.SaltLength cannot be negative")
+		return 0, errors.New("crypto/rsa: invalid PSS salt length")
 	}
 	// OpenSSL uses sentinel salt length values like Go crypto does,
 	// but the values don't fully match for rsa.PSSSaltLengthAuto (0).


### PR DESCRIPTION
Upstream just reworded the error message displayed when an invalid salt length is provided for RSA PSS ([source](https://github.com/golang/go/commit/93fcd8fb1882b55b3456aa753d32a2cf3d369b1c#diff-5add5ff057b0d06bb595f45e3e074652af0565974e8b2bb8022b27583295ae81L255)). That error message is used in an upstream test, so we need to follow suite.