### PR TITLE
fix: typo in Ed25519 functions

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -90,7 +90,7 @@ func (k *PrivateKeyEd25519) Public() (*PublicKeyEd25519, error) {
 	if err := extractPKEYPubEd25519(k._pkey, pub); err != nil {
 		return nil, err
 	}
-	pubk, err := NewPublicKeyEd25119(pub)
+	pubk, err := NewPublicKeyEd25519(pub)
 	if err != nil {
 		return nil, err
 	}
@@ -108,14 +108,14 @@ func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 	return priv, nil
 }
 
-func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
+func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 	if len(priv) != privateKeySizeEd25519 {
 		panic("ed25519: bad private key length: " + strconv.Itoa(len(priv)))
 	}
 	return NewPrivateKeyEd25519FromSeed(priv[:seedSizeEd25519])
 }
 
-func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
+func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
 	if len(pub) != publicKeySizeEd25519 {
 		panic("ed25519: bad public key length: " + strconv.Itoa(len(pub)))
 	}

--- a/ed25519.go
+++ b/ed25519.go
@@ -108,11 +108,21 @@ func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 	return priv, nil
 }
 
+// Deprecated: NewPrivateKeyEd25119 has been deprecated in favor of NewPrivateKeyEd25519.
+func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
+	return NewPrivateKeyEd25519(priv)
+}
+
 func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 	if len(priv) != privateKeySizeEd25519 {
 		panic("ed25519: bad private key length: " + strconv.Itoa(len(priv)))
 	}
 	return NewPrivateKeyEd25519FromSeed(priv[:seedSizeEd25519])
+}
+
+// Deprecated: NewPublicKeyEd25119 has been deprecated in favor of NewPublicKeyEd25519.
+func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
+	return NewPublicKeyEd25519(pub)
 }
 
 func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {

--- a/ed25519.go
+++ b/ed25519.go
@@ -108,7 +108,7 @@ func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
 	return priv, nil
 }
 
-// Deprecated: NewPrivateKeyEd25119 has been deprecated in favor of NewPrivateKeyEd25519.
+// Deprecated: use NewPrivateKeyEd25519 instead.
 func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {
 	return NewPrivateKeyEd25519(priv)
 }
@@ -120,7 +120,7 @@ func NewPrivateKeyEd25519(priv []byte) (*PrivateKeyEd25519, error) {
 	return NewPrivateKeyEd25519FromSeed(priv[:seedSizeEd25519])
 }
 
-// Deprecated: NewPublicKeyEd25119 has been deprecated in favor of NewPublicKeyEd25519.
+// Deprecated: use NewPublicKeyEd25519 instead.
 func NewPublicKeyEd25119(pub []byte) (*PublicKeyEd25519, error) {
 	return NewPublicKeyEd25519(pub)
 }

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -82,7 +82,7 @@ func TestEd25519Malleability(t *testing.T) {
 		0xb1, 0x08, 0xc3, 0xbd, 0xae, 0x36, 0x9e, 0xf5, 0x49, 0xfa,
 	}
 
-	pub, err := openssl.NewPublicKeyEd25119(publicKey)
+	pub, err := openssl.NewPublicKeyEd25519(publicKey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
when reviewing the code recently I discovered the typo in the function names