### PR TITLE
Fix:add sha512's 224 and 256 byte truncated versions

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -81,6 +81,20 @@ func SHA512(p []byte) (sum [64]byte) {
 	return
 }
 
+func SHA512_224(p []byte) (sum [28]byte) {
+	if !hashOneShot(crypto.SHA512_224, p, sum[:]) {
+		panic("openssl: SHA512 failed")
+	}
+	return
+}
+
+func SHA512_256(p []byte) (sum [32]byte) {
+	if !hashOneShot(crypto.SHA512_256, p, sum[:]) {
+		panic("openssl: SHA512_256 failed")
+	}
+	return
+}
+
 // cacheHashSupported is a cache of crypto.Hash support.
 var cacheHashSupported sync.Map
 
@@ -169,6 +183,16 @@ func NewSHA384() hash.Hash {
 // NewSHA512 returns a new SHA512 hash.
 func NewSHA512() hash.Hash {
 	return newEvpHash(crypto.SHA512)
+}
+
+// NewSHA512_224 returns a new SHA512_224 hash.
+func NewSHA512_224() hash.Hash {
+	return newEvpHash(crypto.SHA512_224)
+}
+
+// NewSHA512_256 returns a new SHA512_256 hash.
+func NewSHA512_256() hash.Hash {
+	return newEvpHash(crypto.SHA512_256)
 }
 
 // NewSHA3_224 returns a new SHA3-224 hash.
@@ -383,6 +407,10 @@ func (d *evpHash) AppendBinary(buf []byte) ([]byte, error) {
 		appender = (*sha512State)(state)
 	case crypto.SHA512:
 		appender = (*sha512State)(state)
+	case crypto.SHA512_224:
+		appender = (*sha512State)(state)
+	case crypto.SHA512_256:
+		appender = (*sha512State)(state)
 	default:
 		panic("openssl: unsupported hash function: " + strconv.Itoa(int(d.alg.ch)))
 	}
@@ -420,6 +448,10 @@ func (d *evpHash) UnmarshalBinary(b []byte) error {
 	case crypto.SHA384:
 		unmarshaler = (*sha512State)(state)
 	case crypto.SHA512:
+		unmarshaler = (*sha512State)(state)
+	case crypto.SHA512_224:
+		unmarshaler = (*sha512State)(state)
+	case crypto.SHA512_256:
 		unmarshaler = (*sha512State)(state)
 	default:
 		panic("openssl: unsupported hash function: " + strconv.Itoa(int(d.alg.ch)))

--- a/hash_test.go
+++ b/hash_test.go
@@ -28,6 +28,10 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 		return openssl.NewSHA384
 	case crypto.SHA512:
 		return openssl.NewSHA512
+	case crypto.SHA512_224:
+		return openssl.NewSHA512_224
+	case crypto.SHA512_256:
+		return openssl.NewSHA512_256
 	case crypto.SHA3_224:
 		return openssl.NewSHA3_224
 	case crypto.SHA3_256:
@@ -48,6 +52,8 @@ var hashes = [...]crypto.Hash{
 	crypto.SHA256,
 	crypto.SHA384,
 	crypto.SHA512,
+	crypto.SHA512_224,
+	crypto.SHA512_256,
 	crypto.SHA3_224,
 	crypto.SHA3_256,
 	crypto.SHA3_384,
@@ -292,6 +298,14 @@ func TestHash_OneShot(t *testing.T) {
 		}},
 		{crypto.SHA512, func(p []byte) []byte {
 			b := openssl.SHA512(p)
+			return b[:]
+		}},
+		{crypto.SHA512_224, func(p []byte) []byte {
+			b := openssl.SHA512_224(p)
+			return b[:]
+		}},
+		{crypto.SHA512_256, func(p []byte) []byte {
+			b := openssl.SHA512_256(p)
 			return b[:]
 		}},
 		{crypto.SHA3_224, func(p []byte) []byte {

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -18,6 +18,8 @@ func TestHMAC(t *testing.T) {
 		{"sha256", openssl.NewSHA256},
 		{"sha384", openssl.NewSHA384},
 		{"sha512", openssl.NewSHA512},
+		{"sha512_224", openssl.NewSHA512_224},
+		{"sha512_256", openssl.NewSHA512_256},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR covers OpenSSL repo stage for https://github.com/microsoft/go/issues/1456 . Implementing SHA512_224 and SHA_256 hashes functions and one shot versions.