### PR TITLE
Adjust branding for Microsoft build of Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,8 @@ jobs:
   # reasonable. In that case, we can help by making sure the openssl package
   # builds successfully even without cgo.
   #
-  # For example, the Microsoft Go toolset fork builds this module without cgo
-  # for a cross-platform build.
+  # For example, the Microsoft build of Go compiles this module without cgo when
+  # running a cross-platform build.
   #
   # The golang-fips/openssl module can't do any crypto when built without cgo,
   # but it exports a few simple functions and types.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `openssl` package has support for multiple OpenSSL versions, namely 1.0.2, 1
 All supported OpenSSL versions pass a small set of automatic tests that ensure they can be built and that there are no major regressions.
 These tests do not validate the cryptographic correctness of the `openssl` package.
 
-On top of that, the [golang-fips Go fork](https://github.com/golang-fips/go) -maintained by Red Hat- and the [Microsoft Go fork](https://github.com/microsoft/go), tests a subset of the supported OpenSSL versions when integrated with the Go `crypto` package.
+On top of that, the [golang-fips Go fork](https://github.com/golang-fips/go) (maintained by Red Hat) and the [Microsoft build of Go](https://github.com/microsoft/go) test a subset of the supported OpenSSL versions when integrated with the Go `crypto` package.
 These tests are much more exhaustive and validate a specific OpenSSL version can produce working applications.
 
 ### Building without OpenSSL headers


### PR DESCRIPTION
Adjust some references to the Microsoft build of Go to align with https://go.dev/brand, and improve some nearby text.

Touches the readme and a comment in a workflow.