### PR TITLE
Don't set caller information in CRYPTO_[malloc,free]

### DIFF
--- a/openssl.go
+++ b/openssl.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"math/bits"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -313,25 +312,6 @@ func newOpenSSLError(msg string) error {
 	return errors.New(b.String())
 }
 
-var unknownFile = "<go code>\000"
-
-// caller reports file and line number information about function invocations on
-// the calling goroutine's stack, in a form suitable for passing to C code.
-// The argument skip is the number of stack frames to ascend, with 0 identifying
-// the caller of caller. The return values report the file name and line number
-// within the file of the corresponding call. The returned file is a C string
-// with static storage duration.
-func caller(skip int) (file *C.char, line C.int) {
-	_, f, l, ok := runtime.Caller(skip + 1)
-	if !ok {
-		f = unknownFile
-	}
-	// The underlying bytes of the file string are null-terminated rodata with
-	// static lifetimes, so can be safely passed to C without worrying about
-	// leaking memory or use-after-free.
-	return (*C.char)(noescape(unsafe.Pointer(unsafe.StringData(f)))), C.int(l)
-}
-
 // cryptoMalloc allocates n bytes of memory on the OpenSSL heap, which may be
 // different from the heap which C.malloc allocates on. The allocated object
 // must be freed using cryptoFree. cryptoMalloc is equivalent to the
@@ -344,8 +324,7 @@ func caller(skip int) (file *C.char, line C.int) {
 // freed by OPENSSL_free / CRYPTO_free) need to be allocated on the OpenSSL
 // heap.
 func cryptoMalloc(n int) unsafe.Pointer {
-	file, line := caller(1)
-	p := C.go_openssl_CRYPTO_malloc(C.size_t(n), file, line)
+	p := C.go_openssl_CRYPTO_malloc(C.size_t(n), nil, 0)
 	if p == nil {
 		// Un-recover()-ably crash the program in the same manner as the
 		// C.malloc() wrapper function.
@@ -358,8 +337,7 @@ func cryptoMalloc(n int) unsafe.Pointer {
 // different from the heap which C.malloc allocates on. cryptoFree is equivalent
 // to the OPENSSL_free macro.
 func cryptoFree(p unsafe.Pointer) {
-	file, line := caller(1)
-	C.go_openssl_CRYPTO_free(p, file, line)
+	C.go_openssl_CRYPTO_free(p, nil, 0)
 }
 
 const wordBytes = bits.UintSize / 8


### PR DESCRIPTION
The `CRYPTO_malloc` and `CRYPTO_free` file and line parameters were used in OpenSSL 1 to report memory leaks when calling [CRYPTO_mem_leaks](https://docs.openssl.org/3.0/man3/CRYPTO_mem_leaks).

OpenSSL 3 removed support for the built-in memory leak detections, making `CRYPTO_mem_leaks` no-op. The recommended way of detecting memory leaks is using LLVM address sanitizers or Valgrind.

We have never used `CRYPTO_mem_leaks`, and alrady use the recommended way when testing OpenSSL 1, so there is no need to fill the file and line info when calling OpenSSL memory functions. This avoids a call to [runtime.Caller](https://pkg.go.dev/runtime#Caller), which is strange to see in the middle of a cryptographic function.