### PR TITLE
Implement GCM Seal and Open in Go

### DIFF
--- a/cgo_go124.go
+++ b/cgo_go124.go
@@ -18,6 +18,10 @@ package openssl
 #cgo nocallback go_openssl_RAND_bytes
 #cgo noescape go_openssl_EVP_EncryptUpdate
 #cgo nocallback go_openssl_EVP_EncryptUpdate
+#cgo noescape go_openssl_EVP_EncryptFinal_ex
+#cgo nocallback go_openssl_EVP_EncryptFinal_ex
+#cgo noescape go_openssl_EVP_DecryptFinal_ex
+#cgo nocallback go_openssl_EVP_DecryptFinal_ex
 #cgo noescape go_openssl_EVP_DecryptUpdate
 #cgo nocallback go_openssl_EVP_DecryptUpdate
 #cgo noescape go_openssl_EVP_CipherUpdate

--- a/cipher.go
+++ b/cipher.go
@@ -381,7 +381,7 @@ func (g *cipherGCM) Overhead() int {
 	return gcmTagSize
 }
 
-func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+func (g *cipherGCM) Seal(dst, nonce, plaintext, aad []byte) []byte {
 	if len(nonce) != gcmStandardNonceSize {
 		panic("cipher: incorrect nonce length given to GCM")
 	}
@@ -392,9 +392,9 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 		panic("cipher: message too large for buffer")
 	}
 	if g.tls != cipherGCMTLSNone {
-		if g.tls == cipherGCMTLS12 && len(additionalData) != gcmTls12AddSize {
+		if g.tls == cipherGCMTLS12 && len(aad) != gcmTls12AddSize {
 			panic("cipher: incorrect additional data length given to GCM TLS 1.2")
-		} else if g.tls == cipherGCMTLS13 && len(additionalData) != gcmTls13AddSize {
+		} else if g.tls == cipherGCMTLS13 && len(aad) != gcmTls13AddSize {
 			panic("cipher: incorrect additional data length given to GCM TLS 1.3")
 		}
 		counter := binary.BigEndian.Uint64(nonce[gcmTlsFixedNonceSize:])
@@ -460,18 +460,18 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	if C.go_openssl_EVP_EncryptInit_ex(ctx, nil, nil, nil, base(nonce)) != 1 {
 		panic(newOpenSSLError("EVP_EncryptInit_ex"))
 	}
-	var out_len, discard_len C.int
-	if C.go_openssl_EVP_EncryptUpdate(ctx, nil, &discard_len, baseNeverEmpty(additionalData), C.int(len(additionalData))) != 1 ||
-		C.go_openssl_EVP_EncryptUpdate(ctx, base(out), &out_len, baseNeverEmpty(plaintext), C.int(len(plaintext))) != 1 {
+	var outl, discard C.int
+	if C.go_openssl_EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), C.int(len(aad))) != 1 ||
+		C.go_openssl_EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), C.int(len(plaintext))) != 1 {
 		panic(newOpenSSLError("EVP_EncryptUpdate"))
 	}
-	if len(plaintext) != int(out_len) {
+	if len(plaintext) != int(outl) {
 		panic("cipher: incorrect length returned from GCM EncryptUpdate")
 	}
-	if C.go_openssl_EVP_EncryptFinal_ex(ctx, base(out[out_len:]), &discard_len) != 1 {
+	if C.go_openssl_EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard) != 1 {
 		panic(newOpenSSLError("EVP_EncryptFinal_ex"))
 	}
-	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[out_len:]))) != 1 {
+	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))) != 1 {
 		panic(newOpenSSLError("EVP_CIPHER_CTX_ctrl"))
 	}
 	runtime.KeepAlive(g)
@@ -480,7 +480,7 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 
 var errOpen = errors.New("cipher: message authentication failed")
 
-func (g *cipherGCM) Open(dst, nonce, ciphertext, additionalData []byte) (_ []byte, err error) {
+func (g *cipherGCM) Open(dst, nonce, ciphertext, aad []byte) (_ []byte, err error) {
 	if len(nonce) != gcmStandardNonceSize {
 		panic("cipher: incorrect nonce length given to GCM")
 	}
@@ -523,15 +523,15 @@ func (g *cipherGCM) Open(dst, nonce, ciphertext, additionalData []byte) (_ []byt
 	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(base(tag))) != 1 {
 		return nil, errOpen
 	}
-	var out_len, discard_len C.int
-	if C.go_openssl_EVP_DecryptUpdate(ctx, nil, &discard_len, baseNeverEmpty(additionalData), C.int(len(additionalData))) != 1 ||
-		C.go_openssl_EVP_DecryptUpdate(ctx, base(out), &out_len, baseNeverEmpty(ciphertext), C.int(len(ciphertext))) != 1 {
+	var outl, discard C.int
+	if C.go_openssl_EVP_DecryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), C.int(len(aad))) != 1 ||
+		C.go_openssl_EVP_DecryptUpdate(ctx, base(out), &outl, baseNeverEmpty(ciphertext), C.int(len(ciphertext))) != 1 {
 		return nil, errOpen
 	}
-	if len(ciphertext) != int(out_len) {
+	if len(ciphertext) != int(outl) {
 		return nil, errOpen
 	}
-	if C.go_openssl_EVP_DecryptFinal_ex(ctx, base(out[out_len:]), &discard_len) != 1 {
+	if C.go_openssl_EVP_DecryptFinal_ex(ctx, base(out[outl:]), &discard) != 1 {
 		return nil, errOpen
 	}
 	runtime.KeepAlive(g)

--- a/cipher.go
+++ b/cipher.go
@@ -457,11 +457,22 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	// relying in the explicit nonce being securely set externally,
 	// and it also gives some interesting speed gains.
 	// Unfortunately we can't use it because Go expects AEAD.Seal to honor the provided nonce.
-	if C.go_openssl_EVP_CIPHER_CTX_seal_wrapper(ctx, base(out), base(nonce),
-		base(plaintext), C.int(len(plaintext)),
-		base(additionalData), C.int(len(additionalData))) != 1 {
-
-		panic(fail("EVP_CIPHER_CTX_seal"))
+	if C.go_openssl_EVP_EncryptInit_ex(ctx, nil, nil, nil, base(nonce)) != 1 {
+		panic(newOpenSSLError("EVP_EncryptInit_ex"))
+	}
+	var out_len, discard_len C.int
+	if C.go_openssl_EVP_EncryptUpdate(ctx, nil, &discard_len, baseNeverEmpty(additionalData), C.int(len(additionalData))) != 1 ||
+		C.go_openssl_EVP_EncryptUpdate(ctx, base(out), &out_len, baseNeverEmpty(plaintext), C.int(len(plaintext))) != 1 {
+		panic(newOpenSSLError("EVP_EncryptUpdate"))
+	}
+	if len(plaintext) != int(out_len) {
+		panic("cipher: incorrect length returned from GCM EncryptUpdate")
+	}
+	if C.go_openssl_EVP_EncryptFinal_ex(ctx, base(out[out_len:]), &discard_len) != 1 {
+		panic(newOpenSSLError("EVP_EncryptFinal_ex"))
+	}
+	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[out_len:]))) != 1 {
+		panic(newOpenSSLError("EVP_CIPHER_CTX_ctrl"))
 	}
 	runtime.KeepAlive(g)
 	return ret
@@ -469,7 +480,7 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 
 var errOpen = errors.New("cipher: message authentication failed")
 
-func (g *cipherGCM) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+func (g *cipherGCM) Open(dst, nonce, ciphertext, additionalData []byte) (_ []byte, err error) {
 	if len(nonce) != gcmStandardNonceSize {
 		panic("cipher: incorrect nonce length given to GCM")
 	}
@@ -497,18 +508,33 @@ func (g *cipherGCM) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte,
 		return nil, err
 	}
 	defer C.go_openssl_EVP_CIPHER_CTX_free(ctx)
-	ok := C.go_openssl_EVP_CIPHER_CTX_open_wrapper(
-		ctx, base(out), base(nonce),
-		base(ciphertext), C.int(len(ciphertext)),
-		base(additionalData), C.int(len(additionalData)), base(tag))
-	runtime.KeepAlive(g)
-	if ok == 0 {
-		// Zero output buffer on error.
-		for i := range out {
-			out[i] = 0
+
+	defer func() {
+		if err != nil {
+			// Zero output buffer on error.
+			for i := range out {
+				out[i] = 0
+			}
 		}
+	}()
+	if C.go_openssl_EVP_DecryptInit_ex(ctx, nil, nil, nil, base(nonce)) != 1 {
 		return nil, errOpen
 	}
+	if C.go_openssl_EVP_CIPHER_CTX_ctrl(ctx, C.GO_EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(base(tag))) != 1 {
+		return nil, errOpen
+	}
+	var out_len, discard_len C.int
+	if C.go_openssl_EVP_DecryptUpdate(ctx, nil, &discard_len, baseNeverEmpty(additionalData), C.int(len(additionalData))) != 1 ||
+		C.go_openssl_EVP_DecryptUpdate(ctx, base(out), &out_len, baseNeverEmpty(ciphertext), C.int(len(ciphertext))) != 1 {
+		return nil, errOpen
+	}
+	if len(ciphertext) != int(out_len) {
+		return nil, errOpen
+	}
+	if C.go_openssl_EVP_DecryptFinal_ex(ctx, base(out[out_len:]), &discard_len) != 1 {
+		return nil, errOpen
+	}
+	runtime.KeepAlive(g)
 	return ret, nil
 }
 

--- a/goopenssl.h
+++ b/goopenssl.h
@@ -1,7 +1,5 @@
 // This header file describes the OpenSSL ABI as built for use in Go.
 
-#include <stdlib.h> // size_t
-
 #include "shims.h"
 
 // Suppress warnings about unused parameters.
@@ -74,85 +72,4 @@ go_hash_sum(GO_EVP_MD_CTX_PTR ctx, GO_EVP_MD_CTX_PTR ctx2, unsigned char *out)
     // TODO: use EVP_DigestFinal_ex once we know why it leaks
     // memory on OpenSSL 1.0.2.
     return go_openssl_EVP_DigestFinal(ctx2, out, NULL);
-}
-
-// These wrappers allocate out_len on the C stack, and check that it matches the expected
-// value, to avoid having to pass a pointer from Go, which would escape to the heap.
-
-static inline int
-go_openssl_EVP_CIPHER_CTX_seal_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
-                                       unsigned char *out,
-                                       const unsigned char *nonce,
-                                       const unsigned char *in, int in_len,
-                                       const unsigned char *aad, int aad_len)
-{
-    if (in_len == 0) in = (const unsigned char *)"";
-    if (aad_len == 0) aad = (const unsigned char *)"";
-
-    if (go_openssl_EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, nonce) != 1)
-        return 0;
-
-    int discard_len, out_len;
-    if (go_openssl_EVP_EncryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
-        || go_openssl_EVP_EncryptUpdate(ctx, out, &out_len, in, in_len) != 1
-        || go_openssl_EVP_EncryptFinal_ex(ctx, out + out_len, &discard_len) != 1)
-    {
-        return 0;
-    }
-
-    if (in_len != out_len)
-        return 0;
-
-    return go_openssl_EVP_CIPHER_CTX_ctrl(ctx, GO_EVP_CTRL_GCM_GET_TAG, 16, out + out_len);
-}
-
-static inline int
-go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
-                                       unsigned char *out,
-                                       const unsigned char *nonce,
-                                       const unsigned char *in, int in_len,
-                                       const unsigned char *aad, int aad_len,
-                                       const unsigned char *tag)
-{
-    if (in_len == 0) {
-        in = (const unsigned char *)"";
-        // OpenSSL 1.0.2 in FIPS mode contains a bug: it will fail to verify
-        // unless EVP_DecryptUpdate is called at least once with a non-NULL
-        // output buffer.  OpenSSL will not dereference the output buffer when
-        // the input length is zero, so set it to an arbitrary non-NULL pointer
-        // to satisfy OpenSSL when the caller only has authenticated additional
-        // data (AAD) to verify. While a stack-allocated buffer could be used,
-        // that would risk a stack-corrupting buffer overflow if OpenSSL
-        // unexpectedly dereferenced it. Instead pass a value which would
-        // segfault if dereferenced on any modern platform where a NULL-pointer
-        // dereference would also segfault.
-        if (out == NULL) out = (unsigned char *)1;
-    }
-    if (aad_len == 0) aad = (const unsigned char *)"";
-
-    if (go_openssl_EVP_DecryptInit_ex(ctx, NULL, NULL, NULL, nonce) != 1)
-        return 0;
-
-    // OpenSSL 1.0.x FIPS Object Module 2.0 versions below 2.0.5 require that
-    // the tag be set before the ciphertext, otherwise EVP_DecryptUpdate returns
-    // an error. At least one extant commercially-supported, FIPS validated
-    // build of OpenSSL 1.0.2 uses FIPS module version 2.0.1. Set the tag first
-    // to maximize compatibility with all OpenSSL version combinations.
-    if (go_openssl_EVP_CIPHER_CTX_ctrl(ctx, GO_EVP_CTRL_GCM_SET_TAG, 16, (unsigned char *)(tag)) != 1)
-        return 0;
-
-    int discard_len, out_len;
-    if (go_openssl_EVP_DecryptUpdate(ctx, NULL, &discard_len, aad, aad_len) != 1
-        || go_openssl_EVP_DecryptUpdate(ctx, out, &out_len, in, in_len) != 1)
-    {
-        return 0;
-    }
-
-    if (go_openssl_EVP_DecryptFinal_ex(ctx, out + out_len, &discard_len) != 1)
-        return 0;
-
-    if (out_len != in_len)
-        return 0;
-
-    return 1;
 }

--- a/openssl.go
+++ b/openssl.go
@@ -258,6 +258,15 @@ func addr(p []byte) *byte {
 	return (*byte)(noescape(unsafe.Pointer(&p[0])))
 }
 
+// baseNeverEmpty returns the address of the underlying array in b.
+// If b has zero length, it returns a pointer to a zero byte.
+func baseNeverEmpty(b []byte) *C.uchar {
+	if len(b) == 0 {
+		return (*C.uchar)(unsafe.Pointer(&zero))
+	}
+	return (*C.uchar)(unsafe.Pointer(&b[0]))
+}
+
 // base returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 func base(b []byte) *C.uchar {


### PR DESCRIPTION
The less C code we have, the better. This PR moves the GCM Seal/Open implementation from C to Go. It was previously written in C to avoid allocations, but that's no longer need thanks to the `noescape` and `nocallback` directive.

Note that I haven't ported some special-casing for OpenSSL 1.0.2, as it is no longer supported.

These benchmark run demonstrates that there is not performance regression:

```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
              │   old.txt    │               new.txt               │
              │    sec/op    │    sec/op     vs base               │
AESGCM_Open-4   1.708µ ± 17%   1.814µ ±  6%       ~ (p=0.190 n=10)
AESGCM_Seal-4   1.876µ ± 21%   1.771µ ± 15%       ~ (p=0.224 n=10)
geomean         1.790µ         1.792µ        +0.13%

              │    old.txt    │               new.txt                │
              │      B/s      │      B/s       vs base               │
AESGCM_Open-4   35.74Mi ± 14%   33.65Mi ±  5%       ~ (p=0.190 n=10)
AESGCM_Seal-4   32.57Mi ± 17%   34.47Mi ± 13%       ~ (p=0.224 n=10)
geomean         34.12Mi         34.06Mi        -0.18%

              │   old.txt    │               new.txt               │
              │     B/op     │    B/op     vs base                 │
AESGCM_Open-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
AESGCM_Seal-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

              │   old.txt    │               new.txt               │
              │  allocs/op   │ allocs/op   vs base                 │
AESGCM_Open-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
AESGCM_Seal-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                    ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```