### PR TITLE
Use EVP_DigestFinal_ex instead of EVP_DigestFinal

### DIFF
--- a/goopenssl.h
+++ b/goopenssl.h
@@ -60,7 +60,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_RENAMED_3_0
 #undef DEFINEFUNC_VARIADIC_3_0
 
-// go_hash_sum copies ctx into ctx2 and calls EVP_DigestFinal using ctx2.
+// go_hash_sum copies ctx into ctx2 and calls EVP_DigestFinal_ex using ctx2.
 // This is necessary because Go hash.Hash mandates that Sum has no effect
 // on the underlying stream. In particular it is OK to Sum, then Write more,
 // then Sum again, and the second Sum acts as if the first didn't happen.
@@ -71,9 +71,7 @@ go_hash_sum(GO_EVP_MD_CTX_PTR ctx, GO_EVP_MD_CTX_PTR ctx2, unsigned char *out)
 {
     if (go_openssl_EVP_MD_CTX_copy(ctx2, ctx) != 1)
         return 0;
-    // TODO: use EVP_DigestFinal_ex once we know why it leaks
-    // memory on OpenSSL 1.0.2.
-    return go_openssl_EVP_DigestFinal(ctx2, out, NULL);
+    return go_openssl_EVP_DigestFinal_ex(ctx2, out, NULL);
 }
 
 // These wrappers allocate out_len on the C stack, and check that it matches the expected

--- a/shims.h
+++ b/shims.h
@@ -207,7 +207,7 @@ DEFINEFUNC(int, EVP_Digest, (const void *data, size_t count, unsigned char *md, 
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
-DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
+DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC_1_1_1(int, EVP_DigestSign, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen), (ctx, sigret, siglen, tbs, tbslen)) \
 DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \


### PR DESCRIPTION
We can switch to `EVP_DigestFinal_ex` now that we no longer support OpenSSL 1.0.2. Note that `EVP_DigestFinal_ex` is slightly better than `EVP_DigestFinal` because the former doesn't reset the context, which is not necessary in our case.