### PR TITLE
Remove hash hacks

### DIFF
--- a/cgo_go124.go
+++ b/cgo_go124.go
@@ -34,5 +34,9 @@ package openssl
 #cgo nocallback go_openssl_EVP_PKEY_get_raw_private_key
 #cgo noescape go_openssl_EVP_DigestSign
 #cgo nocallback go_openssl_EVP_DigestSign
+#cgo noescape go_openssl_EVP_Digest
+#cgo nocallback go_openssl_EVP_Digest
+#cgo noescape go_openssl_EVP_DigestUpdate
+#cgo nocallback go_openssl_EVP_DigestUpdate
 */
 import "C"

--- a/hash.go
+++ b/hash.go
@@ -17,19 +17,13 @@ import (
 // maxHashSize is the size of SHA52 and SHA3_512, the largest hashes we support.
 const maxHashSize = 64
 
-// NOTE: Implementation ported from https://go-review.googlesource.com/c/go/+/404295.
-// The cgo calls in this file are arranged to avoid marking the parameters as escaping.
-// To do that, we call noescape (including via addr).
-// We must also make sure that the data pointer arguments have the form unsafe.Pointer(&...)
-// so that cgo does not annotate them with cgoCheckPointer calls. If it did that, it might look
-// beyond the byte slice and find Go pointers in unprocessed parts of a larger allocation.
-// To do both of these simultaneously, the idiom is unsafe.Pointer(&*addr(p)),
-// where addr returns the base pointer of p, substituting a non-nil pointer for nil,
-// and applying a noescape along the way.
-// This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
-
 func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
-	return C.go_openssl_EVP_Digest(unsafe.Pointer(&*addr(p)), C.size_t(len(p)), (*C.uchar)(unsafe.Pointer(&*addr(sum))), nil, loadHash(ch).md, nil) != 0
+	if len(p) > 0 {
+		var pinner runtime.Pinner
+		defer pinner.Unpin()
+		pinner.Pin(&p[0])
+	}
+	return C.go_openssl_EVP_Digest(pbase(p), C.size_t(len(p)), base(sum), nil, loadHash(ch).md, nil) != 0
 }
 
 func MD4(p []byte) (sum [16]byte) {
@@ -256,7 +250,8 @@ type evpHash struct {
 	// ctx2 is used in evpHash.sum to avoid changing
 	// the state of ctx. Having it here allows reusing the
 	// same allocated object multiple times.
-	ctx2 C.GO_EVP_MD_CTX_PTR
+	ctx2   C.GO_EVP_MD_CTX_PTR
+	pinner runtime.Pinner
 }
 
 func newEvpHash(ch crypto.Hash) *evpHash {
@@ -312,8 +307,10 @@ func (h *evpHash) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+	defer h.pinner.Unpin()
+	h.pinner.Pin(&p[0])
 	h.init()
-	if C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&*addr(p)), C.size_t(len(p))) != 1 {
+	if C.go_openssl_EVP_DigestUpdate(h.ctx, pbase(p), C.size_t(len(p))) != 1 {
 		panic(newOpenSSLError("EVP_DigestUpdate"))
 	}
 	runtime.KeepAlive(h)

--- a/hash_test.go
+++ b/hash_test.go
@@ -360,7 +360,7 @@ func TestCgo(t *testing.T) {
 	openssl.SHA256(d.Data[:])
 }
 
-func BenchmarkHash8Bytes(b *testing.B) {
+func BenchmarkSHA256(b *testing.B) {
 	b.StopTimer()
 	h := openssl.NewSHA256()
 	sum := make([]byte, h.Size())
@@ -376,7 +376,7 @@ func BenchmarkHash8Bytes(b *testing.B) {
 	}
 }
 
-func BenchmarkSHA256(b *testing.B) {
+func BenchmarkSHA256OneShot(b *testing.B) {
 	b.StopTimer()
 	size := 8
 	buf := make([]byte, size)

--- a/openssl.go
+++ b/openssl.go
@@ -232,31 +232,7 @@ func proveSHA256(props cString) bool {
 	return sha256Provider(props) != nil
 }
 
-// noescape hides a pointer from escape analysis. noescape is
-// the identity function but escape analysis doesn't think the
-// output depends on the input. noescape is inlined and currently
-// compiles down to zero instructions.
-// USE CAREFULLY!
-//
-//go:nosplit
-func noescape(p unsafe.Pointer) unsafe.Pointer {
-	x := uintptr(p)
-	return unsafe.Pointer(x ^ 0)
-}
-
 var zero byte
-
-// addr converts p to its base addr, including a noescape along the way.
-// If p is nil, addr returns a non-nil pointer, so that the result can always
-// be dereferenced.
-//
-//go:nosplit
-func addr(p []byte) *byte {
-	if len(p) == 0 {
-		return &zero
-	}
-	return (*byte)(noescape(unsafe.Pointer(&p[0])))
-}
 
 // baseNeverEmpty returns the address of the underlying array in b.
 // If b has zero length, it returns a pointer to a zero byte.
@@ -267,20 +243,22 @@ func baseNeverEmpty(b []byte) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(&b[0]))
 }
 
+// pbase returns the address of the underlying array in b.
+func pbase(b []byte) unsafe.Pointer {
+	if len(b) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(&b[0])
+}
+
 // base returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 func base(b []byte) *C.uchar {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.uchar)(unsafe.Pointer(&b[0]))
+	return (*C.uchar)(pbase(b))
 }
 
 func sbase(b []byte) *C.char {
-	if len(b) == 0 {
-		return nil
-	}
-	return (*C.char)(unsafe.Pointer(&b[0]))
+	return (*C.char)(pbase(b))
 }
 
 func newOpenSSLError(msg string) error {

--- a/openssl.go
+++ b/openssl.go
@@ -243,7 +243,8 @@ func baseNeverEmpty(b []byte) *C.uchar {
 	return (*C.uchar)(unsafe.Pointer(&b[0]))
 }
 
-// pbase returns the address of the underlying array in b.
+// pbase returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
 func pbase(b []byte) unsafe.Pointer {
 	if len(b) == 0 {
 		return nil

--- a/openssl.go
+++ b/openssl.go
@@ -258,6 +258,8 @@ func base(b []byte) *C.uchar {
 	return (*C.uchar)(pbase(b))
 }
 
+// sbase returns the address of the underlying array in b,
+// being careful not to panic when b has zero length.
 func sbase(b []byte) *C.char {
 	return (*C.char)(pbase(b))
 }


### PR DESCRIPTION
We can use a `runtime.Pinner` and the `noescape`/`nocallback` directives to replace some hacky logic that we implemented in the several hash functions to avoid allocations and to workaround a `cgoCheckPointer` false positive (tested in `TestCgo`).

Performance is not affected:

```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
                │   old.txt    │              new.txt               │
                │    sec/op    │   sec/op     vs base               │
SHA256-4          814.0n ±  3%   792.2n ± 6%       ~ (p=0.105 n=10)
SHA256OneShot-4   585.8n ± 15%   607.1n ± 4%       ~ (p=0.089 n=10)
geomean           690.5n         693.5n       +0.42%

                │    old.txt    │               new.txt               │
                │      B/s      │     B/s       vs base               │
SHA256-4          9.370Mi ±  2%   9.632Mi ± 6%       ~ (p=0.093 n=10)
SHA256OneShot-4   13.02Mi ± 18%   12.56Mi ± 4%       ~ (p=0.089 n=10)
geomean           11.05Mi         11.00Mi       -0.41%

                │   old.txt    │               new.txt               │
                │     B/op     │    B/op     vs base                 │
SHA256-4          64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=10) ¹
SHA256OneShot-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                      ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                │   old.txt    │               new.txt               │
                │  allocs/op   │ allocs/op   vs base                 │
SHA256-4          1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
SHA256OneShot-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                      ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```