### PR TITLE
hkdf: Replace nil salt with a slice of a preallocated all zeros buffer

### DIFF
--- a/hkdf.go
+++ b/hkdf.go
@@ -109,9 +109,14 @@ func (c *hkdf1) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF()
-var hkdfAllZerosSalt [64]byte
+// hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF().
+// The size should be kept larger than the output length of any hash algorithm
+// used with HKDF.
+var hkdfAllZerosSalt [512]byte
 
+// ExtractHDKF implements the HDKF extract step.
+// If salt is nil, then this function replaces it internally with a buffer of
+// zeros whose length equals the output length of the specified hash algorithm.
 func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	if !SupportsHKDF() {
 		return nil, errUnsupportedVersion()
@@ -126,10 +131,10 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	// zeros, as specified in RFC 5896 and as OpenSSL EVP_KDF-HKDF documentation
 	// instructs. Take a slice of a preallocated buffer to avoid allocating new
 	// buffer per call.
-	if len(salt) == 0 {
+	if salt == nil {
 		hlen := h().Size()
 		if hlen > len(hkdfAllZerosSalt) {
-			return nil, errors.New("nil salt is not supported for the specified hash algorithm")
+			return nil, errors.New("nil salt is not supported: hash output length exceeds internal buffer size")
 		}
 		salt = hkdfAllZerosSalt[:hlen]
 	}

--- a/hkdf.go
+++ b/hkdf.go
@@ -110,9 +110,9 @@ func (c *hkdf1) Read(p []byte) (int, error) {
 }
 
 // hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF().
-// The size should be kept larger than the output length of any hash algorithm
+// The size should be kept as large as the output length of any hash algorithm
 // used with HKDF.
-var hkdfAllZerosSalt [512]byte
+var hkdfAllZerosSalt [64]byte
 
 // ExtractHDKF implements the HDKF extract step.
 // If salt is nil, then this function replaces it internally with a buffer of
@@ -130,13 +130,15 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	// If calling code specifies nil salt, replace it with a buffer of hashLen
 	// zeros, as specified in RFC 5896 and as OpenSSL EVP_KDF-HKDF documentation
 	// instructs. Take a slice of a preallocated buffer to avoid allocating new
-	// buffer per call.
+	// buffer per call, but fall back to allocating a buffer if preallocated
+	// buffer is not large enough.
 	if salt == nil {
 		hlen := h().Size()
 		if hlen > len(hkdfAllZerosSalt) {
-			return nil, errors.New("nil salt is not supported: hash output length exceeds internal buffer size")
+			salt = make([]byte, hlen)
+		} else {
+			salt = hkdfAllZerosSalt[:hlen]
 		}
-		salt = hkdfAllZerosSalt[:hlen]
 	}
 
 	switch vMajor {

--- a/hkdf.go
+++ b/hkdf.go
@@ -109,6 +109,12 @@ func (c *hkdf1) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// maxHKDFHashLength is maximum output length of any hash used with HKDF
+const maxHKDFHashLength = 64
+
+// hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF()
+var hkdfAllZerosSalt = make([]byte, maxHKDFHashLength)
+
 func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	if !SupportsHKDF() {
 		return nil, errUnsupportedVersion()
@@ -117,6 +123,18 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	md, err := hashFuncToMD(h)
 	if err != nil {
 		return nil, err
+	}
+
+	// If calling code specifies nil salt, replace it with a buffer of hashLen
+	// zeros, as specified in RFC 5896 and as OpenSSL EVP_KDF-HKDF documentation
+	// instructs. Take a slice of a preallocated buffer to avoid allocating new
+	// buffer per call.
+	if salt == nil {
+		hlen := h().Size()
+		if hlen > maxHKDFHashLength {
+			return nil, errors.New("nil salt is not supported for the specified hash algorithm")
+		}
+		salt = hkdfAllZerosSalt[:hlen]
 	}
 
 	switch vMajor {

--- a/hkdf.go
+++ b/hkdf.go
@@ -109,11 +109,8 @@ func (c *hkdf1) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// maxHKDFHashLength is maximum output length of any hash used with HKDF
-const maxHKDFHashLength = 64
-
 // hkdfAllZerosSalt is a preallocated buffer of zeros used in ExtractHKDF()
-var hkdfAllZerosSalt = make([]byte, maxHKDFHashLength)
+var hkdfAllZerosSalt [64]byte
 
 func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	if !SupportsHKDF() {
@@ -129,9 +126,9 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 	// zeros, as specified in RFC 5896 and as OpenSSL EVP_KDF-HKDF documentation
 	// instructs. Take a slice of a preallocated buffer to avoid allocating new
 	// buffer per call.
-	if salt == nil {
+	if len(salt) == 0 {
 		hlen := h().Size()
-		if hlen > maxHKDFHashLength {
+		if hlen > len(hkdfAllZerosSalt) {
 			return nil, errors.New("nil salt is not supported for the specified hash algorithm")
 		}
 		salt = hkdfAllZerosSalt[:hlen]


### PR DESCRIPTION
hkdf: Replace nil salt with a slice of a preallocated all zeros buffer. This fixes HKDF when using KeyPair FIPS Provider for OpenSSL 3

Fixes golang-fips/openssl#253