### PR TITLE
Move error handling to the autogenerated Go code

### DIFF
--- a/cipher.go
+++ b/cipher.go
@@ -84,7 +84,7 @@ func loadCipher(k cipherKind, mode cipherMode) (cipher _EVP_CIPHER_PTR) {
 			// not created by EVP_CIPHER has negative performance
 			// implications, as cipher operations will have
 			// to fetch it on every call. Better to just fetch it once here.
-			cipher = go_openssl_EVP_CIPHER_fetch(nil, go_openssl_EVP_CIPHER_get0_name(cipher), nil)
+			cipher, _ = go_openssl_EVP_CIPHER_fetch(nil, go_openssl_EVP_CIPHER_get0_name(cipher), nil)
 		}
 		cacheCipher.Store(cacheCipherKey{k, mode}, cipher)
 	}()
@@ -178,8 +178,8 @@ func (c *evpCipher) encrypt(dst, src []byte) error {
 	defer go_openssl_EVP_CIPHER_CTX_free(enc_ctx)
 
 	var outl int32
-	if go_openssl_EVP_EncryptUpdate(enc_ctx, base(dst), &outl, base(src), int32(c.blockSize)) != 1 {
-		return errors.New("EncryptUpdate failed")
+	if _, err := go_openssl_EVP_EncryptUpdate(enc_ctx, base(dst), &outl, base(src), int32(c.blockSize)); err != nil {
+		return err
 	}
 	runtime.KeepAlive(c)
 	return nil
@@ -203,8 +203,8 @@ func (c *evpCipher) decrypt(dst, src []byte) error {
 	}
 	defer go_openssl_EVP_CIPHER_CTX_free(dec_ctx)
 
-	if go_openssl_EVP_CIPHER_CTX_set_padding(dec_ctx, 0) != 1 {
-		return errors.New("could not disable cipher padding")
+	if _, err := go_openssl_EVP_CIPHER_CTX_set_padding(dec_ctx, 0); err != nil {
+		return err
 	}
 
 	var outl int32
@@ -236,8 +236,8 @@ func (x *cipherCBC) CryptBlocks(dst, src []byte) {
 	}
 	if len(src) > 0 {
 		var outl int32
-		if go_openssl_EVP_CipherUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))) != 1 {
-			panic("crypto/cipher: CipherUpdate failed")
+		if _, err := go_openssl_EVP_CipherUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))); err != nil {
+			panic("crypto/cipher: " + err.Error())
 		}
 		runtime.KeepAlive(x)
 	}
@@ -245,10 +245,10 @@ func (x *cipherCBC) CryptBlocks(dst, src []byte) {
 
 func (x *cipherCBC) SetIV(iv []byte) {
 	if len(iv) != x.blockSize {
-		panic("cipher: incorrect length IV")
+		panic("crypto/cipher: incorrect length IV")
 	}
-	if go_openssl_EVP_CipherInit_ex(x.ctx, nil, nil, nil, base(iv), int32(cipherOpNone)) != 1 {
-		panic("cipher: unable to initialize EVP cipher ctx")
+	if _, err := go_openssl_EVP_CipherInit_ex(x.ctx, nil, nil, nil, base(iv), int32(cipherOpNone)); err != nil {
+		panic("crypto/cipher: " + err.Error())
 	}
 }
 
@@ -259,8 +259,8 @@ func (c *evpCipher) newCBC(iv []byte, op cipherOp) cipher.BlockMode {
 	}
 	x := &cipherCBC{ctx: ctx, blockSize: c.blockSize}
 	runtime.SetFinalizer(x, (*cipherCBC).finalize)
-	if go_openssl_EVP_CIPHER_CTX_set_padding(x.ctx, 0) != 1 {
-		panic("cipher: unable to set padding")
+	if _, err := go_openssl_EVP_CIPHER_CTX_set_padding(x.ctx, 0); err != nil {
+		panic("crypto/cipher: " + err.Error())
 	}
 	return x
 }
@@ -280,8 +280,8 @@ func (x *cipherCTR) XORKeyStream(dst, src []byte) {
 		return
 	}
 	var outl int32
-	if go_openssl_EVP_EncryptUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))) != 1 {
-		panic("crypto/cipher: EncryptUpdate failed")
+	if _, err := go_openssl_EVP_EncryptUpdate(x.ctx, base(dst), &outl, base(src), int32(len(src))); err != nil {
+		panic("crypto/cipher: " + err.Error())
 	}
 	runtime.KeepAlive(x)
 }
@@ -455,22 +455,24 @@ func (g *cipherGCM) Seal(dst, nonce, plaintext, aad []byte) []byte {
 	// relying in the explicit nonce being securely set externally,
 	// and it also gives some interesting speed gains.
 	// Unfortunately we can't use it because Go expects AEAD.Seal to honor the provided nonce.
-	if go_openssl_EVP_EncryptInit_ex(ctx, nil, nil, nil, base(nonce)) != 1 {
-		panic(newOpenSSLError("EVP_EncryptInit_ex"))
+	if _, err := go_openssl_EVP_EncryptInit_ex(ctx, nil, nil, nil, base(nonce)); err != nil {
+		panic(err)
 	}
 	var outl, discard int32
-	if go_openssl_EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))) != 1 ||
-		go_openssl_EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), int32(len(plaintext))) != 1 {
-		panic(newOpenSSLError("EVP_EncryptUpdate"))
+	if _, err := go_openssl_EVP_EncryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
+		panic(err)
+	}
+	if _, err := go_openssl_EVP_EncryptUpdate(ctx, base(out), &outl, baseNeverEmpty(plaintext), int32(len(plaintext))); err != nil {
+		panic(err)
 	}
 	if len(plaintext) != int(outl) {
 		panic("cipher: incorrect length returned from GCM EncryptUpdate")
 	}
-	if go_openssl_EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard) != 1 {
-		panic(newOpenSSLError("EVP_EncryptFinal_ex"))
+	if _, err := go_openssl_EVP_EncryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
+		panic(err)
 	}
-	if go_openssl_EVP_CIPHER_CTX_ctrl(ctx, _EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))) != 1 {
-		panic(newOpenSSLError("EVP_CIPHER_CTX_ctrl"))
+	if _, err := go_openssl_EVP_CIPHER_CTX_ctrl(ctx, _EVP_CTRL_GCM_GET_TAG, 16, unsafe.Pointer(base(out[outl:]))); err != nil {
+		panic(err)
 	}
 	runtime.KeepAlive(g)
 	return ret
@@ -515,21 +517,23 @@ func (g *cipherGCM) Open(dst, nonce, ciphertext, aad []byte) (_ []byte, err erro
 			}
 		}
 	}()
-	if go_openssl_EVP_DecryptInit_ex(ctx, nil, nil, nil, base(nonce)) != 1 {
+	if _, err := go_openssl_EVP_DecryptInit_ex(ctx, nil, nil, nil, base(nonce)); err != nil {
 		return nil, errOpen
 	}
-	if go_openssl_EVP_CIPHER_CTX_ctrl(ctx, _EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(base(tag))) != 1 {
+	if _, err := go_openssl_EVP_CIPHER_CTX_ctrl(ctx, _EVP_CTRL_GCM_SET_TAG, 16, unsafe.Pointer(base(tag))); err != nil {
 		return nil, errOpen
 	}
 	var outl, discard int32
-	if go_openssl_EVP_DecryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))) != 1 ||
-		go_openssl_EVP_DecryptUpdate(ctx, base(out), &outl, baseNeverEmpty(ciphertext), int32(len(ciphertext))) != 1 {
+	if _, err := go_openssl_EVP_DecryptUpdate(ctx, nil, &discard, baseNeverEmpty(aad), int32(len(aad))); err != nil {
+		return nil, errOpen
+	}
+	if _, err := go_openssl_EVP_DecryptUpdate(ctx, base(out), &outl, baseNeverEmpty(ciphertext), int32(len(ciphertext))); err != nil {
 		return nil, errOpen
 	}
 	if len(ciphertext) != int(outl) {
 		return nil, errOpen
 	}
-	if go_openssl_EVP_DecryptFinal_ex(ctx, base(out[outl:]), &discard) != 1 {
+	if _, err := go_openssl_EVP_DecryptFinal_ex(ctx, base(out[outl:]), &discard); err != nil {
 		return nil, errOpen
 	}
 	runtime.KeepAlive(g)
@@ -553,9 +557,9 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 	if cipher == nil {
 		panic("crypto/cipher: unsupported cipher: " + kind.String())
 	}
-	ctx := go_openssl_EVP_CIPHER_CTX_new()
-	if ctx == nil {
-		return nil, fail("unable to create EVP cipher ctx")
+	ctx, err := go_openssl_EVP_CIPHER_CTX_new()
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -566,17 +570,17 @@ func newCipherCtx(kind cipherKind, mode cipherMode, encrypt cipherOp, key, iv []
 		// RC4 cipher supports a variable key length.
 		// We need to set the key length before setting the key,
 		// and to do so we need to have an initialized cipher ctx.
-		if go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, nil, nil, int32(encrypt)) != 1 {
-			return nil, newOpenSSLError("EVP_CipherInit_ex")
+		if _, err := go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, nil, nil, int32(encrypt)); err != nil {
+			return nil, err
 		}
-		if go_openssl_EVP_CIPHER_CTX_set_key_length(ctx, int32(len(key))) != 1 {
-			return nil, newOpenSSLError("EVP_CIPHER_CTX_set_key_length")
+		if _, err := go_openssl_EVP_CIPHER_CTX_set_key_length(ctx, int32(len(key))); err != nil {
+			return nil, err
 		}
 		// Pass nil to the next call to EVP_CipherInit_ex to avoid resetting ctx's cipher.
 		cipher = nil
 	}
-	if go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)) != 1 {
-		return nil, newOpenSSLError("unable to initialize EVP cipher ctx")
+	if _, err := go_openssl_EVP_CipherInit_ex(ctx, cipher, nil, base(key), base(iv), int32(encrypt)); err != nil {
+		return nil, err
 	}
 	return ctx, nil
 }

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -54,6 +54,11 @@ func generateGo(src *mkcgo.Source, w io.Writer) {
 		fmt.Fprintf(w, "}\n\n")
 	}
 
+	typedefs := make(map[string]string, len(src.TypeDefs))
+	for _, def := range src.TypeDefs {
+		typedefs[def.Name] = def.Type
+	}
+
 	// Generate function wrappers.
 	for _, fn := range src.Funcs {
 		if fn.Variadic() {
@@ -66,7 +71,7 @@ func generateGo(src *mkcgo.Source, w io.Writer) {
 			fmt.Fprintf(w, "\treturn C.%s_Available() != 0\n", fn.ImportName)
 			fmt.Fprintf(w, "}\n\n")
 		}
-		generateGoFn(fn, w)
+		generateGoFn(typedefs, fn, w)
 	}
 }
 
@@ -226,31 +231,75 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 }
 
 // generateGoFn generates Go function f.
-func generateGoFn(fn *mkcgo.Func, w io.Writer) {
+func generateGoFn(typedefs map[string]string, fn *mkcgo.Func, w io.Writer) {
+	fnCall := fmt.Sprintf("C.%s(%s)", fn.CName, fnToGoArgs(fn))
+	// Function definition
 	fmt.Fprintf(w, "func %s(%s)", fn.GoName, fnToGoParams(fn))
-	if !retIsVoid(fn.Ret) {
-		fmt.Fprintf(w, " %s ", cTypeToGo(fn.Ret.Type, false))
+	if retIsVoid(fn.Ret) {
+		// Easy path, just call the C function. No need to write the return types,
+		// nor do error handling, nor cast the return value.
+		fmt.Fprintf(w, "{\n")
+		fmt.Fprintf(w, "\t%s\n", fnCall)
+		fmt.Fprintf(w, "}\n\n")
+		return
+	}
+	typ, _ := cTypeToGo(fn.Ret.Type, false)
+	if fn.NoError {
+		fmt.Fprintf(w, " %s ", typ)
+	} else {
+		fmt.Fprintf(w, " (%s, error) ", typ)
 	}
 	fmt.Fprintf(w, "{\n")
-	fmt.Fprintf(w, "\t")
-	var closePar int
-	if !retIsVoid(fn.Ret) {
-		fmt.Fprintf(w, "return ")
-		goType := cTypeToGo(fn.Ret.Type, false)
-		if goType != "" && goType != fn.Ret.Type {
-			closePar++
-			if goType[0] == '*' {
-				goType = fmt.Sprintf("(%s)(unsafe.Pointer", goType)
-				closePar++
+
+	// Function call
+	var needUnsafeCast bool
+	goType, needCast := cTypeToGo(fn.Ret.Type, false)
+	if needCast && goType[0] == '*' {
+		goType = fmt.Sprintf("(%s)(unsafe.Pointer", goType)
+		needUnsafeCast = true
+	}
+	if fn.NoError {
+		// No error handling, just cast the return value if necessary.
+		fmt.Fprintf(w, "\treturn ")
+		if needCast {
+			fmt.Fprintf(w, "%s(%s)", goType, fnCall)
+			if needUnsafeCast {
+				fmt.Fprintf(w, ")")
 			}
-			fmt.Fprintf(w, "%s(", goType)
+		} else {
+			fmt.Fprintf(w, "%s", fnCall)
 		}
+		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "}\n\n")
+		return
 	}
-	fmt.Fprintf(w, "C.%s(%s)", fn.CName, fnToGoArgs(fn))
-	if closePar > 0 {
-		fmt.Fprint(w, strings.Repeat(")", closePar))
+	fmt.Fprintf(w, "\t_ret := C.%s(%s)\n", fn.CName, fnToGoArgs(fn))
+
+	// Error handling
+	errCond := "<= 0"
+	if fn.ErrCond != "" {
+		errCond = fn.ErrCond
+	} else if strings.Contains(goType, "unsafe.Pointer") {
+		errCond = "== nil"
+	} else if typ, ok := typedefs[goType]; ok && typ == "void*" {
+		errCond = "== nil"
 	}
-	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "\tvar _err error\n")
+	fmt.Fprintf(w, "\tif _ret %s {\n", errCond)
+	fmt.Fprintf(w, "\t\t_err = newOpenSSLError(\"%s\")\n", fn.CName)
+	fmt.Fprintf(w, "\t}\n")
+
+	// Return the value
+	fmt.Fprintf(w, "\treturn ")
+	if needCast {
+		fmt.Fprintf(w, "%s(_ret)", goType)
+		if needUnsafeCast {
+			fmt.Fprintf(w, ")")
+		}
+	} else {
+		fmt.Fprintf(w, "_ret")
+	}
+	fmt.Fprintf(w, ", _err\n")
 	fmt.Fprintf(w, "}\n\n")
 }
 
@@ -265,7 +314,10 @@ func generateCFn(fn *mkcgo.Func, w io.Writer) {
 
 // paramToGo converts C parameter p to Go parameter.
 func paramToGo(p *mkcgo.Param) string {
-	goType := cTypeToGo(p.Type, true)
+	goType, needCast := cTypeToGo(p.Type, true)
+	if !needCast {
+		return p.Name
+	}
 	switch {
 	case goType == "unsafe.Pointer" || goType == "":
 		return p.Name
@@ -318,13 +370,17 @@ var cstdTypesToCgo = map[string]string{
 }
 
 // cTypeToGo converts C type t to a Go type.
-func cTypeToGo(t string, cgo bool) string {
+// If cgo is true, it returns the type that can be
+// passed to a cgo function call.
+// It returns the Go type and a boolean that reports whether
+// the type needs to be casted to goType or not.
+func cTypeToGo(t string, cgo bool) (string, bool) {
 	t, _ = strings.CutPrefix(t, "const ")
 	if t == "void" {
-		return ""
+		return "", true
 	}
 	if strings.HasPrefix(t, "void*") {
-		return "unsafe.Pointer"
+		return "unsafe.Pointer", false
 	}
 	if strings.HasSuffix(t, "*") {
 		// Remove all trailing '*' characters.
@@ -335,29 +391,25 @@ func cTypeToGo(t string, cgo bool) string {
 			}
 			n++
 		}
-		s := cTypeToGo(t[:i+1], cgo)
+		s, std := cTypeToGo(t[:i+1], cgo)
 		if s != "" {
 			s = strings.Repeat("*", n) + s
 		}
-		return s
+		return s, std
 	}
 	if !isStdType(t) {
-		if cgo {
-			// Non-standard C types are aliased so C.<type> so they don't need to be converted.
-			return ""
-		}
-		return t
+		return t, false
 	}
 	if cgo {
 		if s, ok := cstdTypesToCgo[t]; ok {
 			t = s
 		}
-		return "C." + t
+		return "C." + t, true
 	}
 	if t, ok := cstdTypesToGo[t]; ok {
-		return t
+		return t, true
 	}
-	return t
+	return t, true
 }
 
 // paramToC returns C source code of parameter p.
@@ -382,7 +434,8 @@ func retIsVoid(r *mkcgo.Return) bool {
 // fnToGoParams returns source code for function f parameters.
 func fnToGoParams(fn *mkcgo.Func) string {
 	return join(fn.Params, func(_ int, p *mkcgo.Param) string {
-		return p.Name + " " + cTypeToGo(p.Type, false)
+		typ, _ := cTypeToGo(p.Type, false)
+		return p.Name + " " + typ
 	}, ", ")
 }
 

--- a/dsa.go
+++ b/dsa.go
@@ -36,7 +36,7 @@ func (k *PrivateKeyDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PrivateKeyDSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -54,7 +54,7 @@ func (k *PublicKeyDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PublicKeyDSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }

--- a/dsa.go
+++ b/dsa.go
@@ -10,8 +10,8 @@ import (
 
 // SupportsDSA returns true if the OpenSSL library supports DSA.
 func SupportsDSA() bool {
-	ctx := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_DSA, nil)
-	if ctx == nil {
+	ctx, err := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_DSA, nil)
+	if err != nil {
 		return false
 	}
 	go_openssl_EVP_PKEY_CTX_free(ctx)
@@ -36,7 +36,7 @@ func (k *PrivateKeyDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyDSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PrivateKeyDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -54,7 +54,7 @@ func (k *PublicKeyDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyDSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PublicKeyDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -65,23 +65,23 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 	// extracting the domain parameters from it.
 
 	// Generate a new DSA key context and set the known parameters.
-	ctx := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_DSA, nil)
-	if ctx == nil {
-		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_new_id failed")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_DSA, nil)
+	if err != nil {
+		return DSAParameters{}, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	if go_openssl_EVP_PKEY_paramgen_init(ctx) != 1 {
-		return DSAParameters{}, newOpenSSLError("EVP_PKEY_paramgen_init failed")
+	if _, err := go_openssl_EVP_PKEY_paramgen_init(ctx); err != nil {
+		return DSAParameters{}, err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_DSA, -1, _EVP_PKEY_CTRL_DSA_PARAMGEN_BITS, int32(l), nil) != 1 {
-		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_DSA, -1, _EVP_PKEY_CTRL_DSA_PARAMGEN_BITS, int32(l), nil); err != nil {
+		return DSAParameters{}, err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_DSA, -1, _EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, int32(n), nil) != 1 {
-		return DSAParameters{}, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_DSA, -1, _EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, int32(n), nil); err != nil {
+		return DSAParameters{}, err
 	}
 	var pkey _EVP_PKEY_PTR
-	if go_openssl_EVP_PKEY_paramgen(ctx, &pkey) != 1 {
-		return DSAParameters{}, newOpenSSLError("EVP_PKEY_paramgen failed")
+	if _, err := go_openssl_EVP_PKEY_paramgen(ctx, &pkey); err != nil {
+		return DSAParameters{}, err
 	}
 	defer go_openssl_EVP_PKEY_free(pkey)
 
@@ -97,10 +97,14 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 			go_openssl_BN_free(q)
 			go_openssl_BN_free(g)
 		}()
-		if go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_P.ptr(), &p) != 1 ||
-			go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_Q.ptr(), &q) != 1 ||
-			go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G.ptr(), &g) != 1 {
-			return DSAParameters{}, newOpenSSLError("EVP_PKEY_get_bn_param")
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_P.ptr(), &p); err != nil {
+			return DSAParameters{}, err
+		}
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_Q.ptr(), &q); err != nil {
+			return DSAParameters{}, err
+		}
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G.ptr(), &g); err != nil {
+			return DSAParameters{}, err
 		}
 	default:
 		panic(errUnsupportedVersion())
@@ -158,9 +162,11 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 			go_openssl_BN_clear_free(bx)
 			go_openssl_BN_free(by)
 		}()
-		if go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PUB_KEY.ptr(), &by) != 1 ||
-			go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bx) != 1 {
-			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PUB_KEY.ptr(), &by); err != nil {
+			return nil, nil, err
+		}
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bx); err != nil {
+			return nil, nil, err
 		}
 	default:
 		panic(errUnsupportedVersion())
@@ -192,44 +198,46 @@ func newDSA(params DSAParameters, x, y BigInt) (_EVP_PKEY_PTR, error) {
 func newDSA1(params DSAParameters, x, y BigInt) (pkey _EVP_PKEY_PTR, err error) {
 	checkMajorVersion(1)
 
-	dsa := go_openssl_DSA_new()
-	if dsa == nil {
-		return nil, newOpenSSLError("DSA_new failed")
+	dsa, err := go_openssl_DSA_new()
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if pkey == nil {
 			go_openssl_DSA_free(dsa)
 		}
 	}()
-
-	p, q, g := bigToBN(params.P), bigToBN(params.Q), bigToBN(params.G)
-	ret := go_openssl_DSA_set0_pqg(dsa, p, q, g)
-	if ret != 1 {
+	// No need to check for errors here, DSA_set0_* functions will fail
+	// if the BNs are NULL and we will free non-NULL BNs in the error handling.
+	p, _ := bigToBN(params.P)
+	q, _ := bigToBN(params.Q)
+	g, _ := bigToBN(params.G)
+	if _, err := go_openssl_DSA_set0_pqg(dsa, p, q, g); err != nil {
 		go_openssl_BN_free(p)
 		go_openssl_BN_free(q)
 		go_openssl_BN_free(g)
-		return nil, newOpenSSLError("DSA_set0_pqg failed")
+		return nil, err
 	}
 	if y != nil {
-		pub, priv := bigToBN(y), bigToBN(x)
-		ret = go_openssl_DSA_set0_key(dsa, pub, priv)
-		if ret != 1 {
+		pub, _ := bigToBN(y)
+		priv, _ := bigToBN(x)
+		if _, err := go_openssl_DSA_set0_key(dsa, pub, priv); err != nil {
 			go_openssl_BN_free(pub)
 			go_openssl_BN_clear_free(priv)
-			return nil, newOpenSSLError("DSA_set0_key failed")
+			return nil, err
 		}
 	} else {
-		if go_openssl_DSA_generate_key(dsa) != 1 {
-			return nil, newOpenSSLError("DSA_generate_key failed")
+		if _, err := go_openssl_DSA_generate_key(dsa); err != nil {
+			return nil, err
 		}
 	}
-	pkey = go_openssl_EVP_PKEY_new()
-	if pkey == nil {
-		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	pkey, err = go_openssl_EVP_PKEY_new()
+	if err != nil {
+		return nil, err
 	}
-	if go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_DSA, unsafe.Pointer(dsa)) != 1 {
+	if _, err := go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_DSA, unsafe.Pointer(dsa)); err != nil {
 		go_openssl_EVP_PKEY_free(pkey)
-		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+		return nil, err
 	}
 	return pkey, nil
 }
@@ -272,17 +280,17 @@ func newDSA3(params DSAParameters, x, y BigInt) (_EVP_PKEY_PTR, error) {
 	// expects it to be always there. Generate a new key using pkey as domain
 	// parameters placeholder.
 	defer go_openssl_EVP_PKEY_free(pkey)
-	ctx := go_openssl_EVP_PKEY_CTX_new_from_pkey(nil, pkey, nil)
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_PKEY_CTX_new_from_pkey")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new_from_pkey(nil, pkey, nil)
+	if err != nil {
+		return nil, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	if go_openssl_EVP_PKEY_keygen_init(ctx) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_keygen_init")
+	if _, err := go_openssl_EVP_PKEY_keygen_init(ctx); err != nil {
+		return nil, err
 	}
 	var gkey _EVP_PKEY_PTR
-	if go_openssl_EVP_PKEY_keygen(ctx, &gkey) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_keygen")
+	if _, err := go_openssl_EVP_PKEY_keygen(ctx, &gkey); err != nil {
+		return nil, err
 	}
 	return gkey, nil
 }
@@ -291,9 +299,9 @@ func newDSA3(params DSAParameters, x, y BigInt) (_EVP_PKEY_PTR, error) {
 // If pkey does not contain an DSA it panics.
 // The returned key should not be freed.
 func getDSA(pkey _EVP_PKEY_PTR) _DSA_PTR {
-	key := go_openssl_EVP_PKEY_get0_DSA(pkey)
-	if key == nil {
-		panic("pkey does not contain an DSA")
+	key, err := go_openssl_EVP_PKEY_get0_DSA(pkey)
+	if err != nil {
+		panic(err)
 	}
 	return key
 }

--- a/ec.go
+++ b/ec.go
@@ -38,24 +38,23 @@ func curveSize(curve string) int {
 // encodeEcPoint encodes pt.
 func encodeEcPoint(group _EC_GROUP_PTR, pt _EC_POINT_PTR) ([]byte, error) {
 	// Get encoded point size.
-	n := go_openssl_EC_POINT_point2oct(group, pt, _POINT_CONVERSION_UNCOMPRESSED, nil, 0, nil)
-	if n == 0 {
-		return nil, newOpenSSLError("EC_POINT_point2oct")
+	n, err := go_openssl_EC_POINT_point2oct(group, pt, _POINT_CONVERSION_UNCOMPRESSED, nil, 0, nil)
+	if err != nil {
+		return nil, err
 	}
 	// Encode point into bytes.
 	bytes := make([]byte, n)
-	n = go_openssl_EC_POINT_point2oct(group, pt, _POINT_CONVERSION_UNCOMPRESSED, base(bytes), n, nil)
-	if n == 0 {
-		return nil, newOpenSSLError("EC_POINT_point2oct")
+	if _, err = go_openssl_EC_POINT_point2oct(group, pt, _POINT_CONVERSION_UNCOMPRESSED, base(bytes), n, nil); err != nil {
+		return nil, err
 	}
 	return bytes, nil
 }
 
 // generateAndEncodeEcPublicKey calls newPubKeyPointFn to generate a public key point and then encodes it.
 func generateAndEncodeEcPublicKey(nid int32, newPubKeyPointFn func(group _EC_GROUP_PTR) (_EC_POINT_PTR, error)) ([]byte, error) {
-	group := go_openssl_EC_GROUP_new_by_curve_name(nid)
-	if group == nil {
-		return nil, newOpenSSLError("EC_GROUP_new_by_curve_name")
+	group, err := go_openssl_EC_GROUP_new_by_curve_name(nid)
+	if err != nil {
+		return nil, err
 	}
 	defer go_openssl_EC_GROUP_free(group)
 	pt, err := newPubKeyPointFn(group)

--- a/ecdh.go
+++ b/ecdh.go
@@ -184,7 +184,7 @@ func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (_EVP_PKEY_PTR, error
 	if isPrivate {
 		priv, err := go_openssl_BN_bin2bn(base(bytes), int32(len(bytes)), nil)
 		if err != nil {
-			return nil, nil
+			return nil, err
 		}
 		defer go_openssl_BN_clear_free(priv)
 		pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group _EC_GROUP_PTR) (_EC_POINT_PTR, error) {

--- a/ecdh.go
+++ b/ecdh.go
@@ -66,34 +66,33 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 	var bytes []byte
 	switch vMajor {
 	case 1:
-		pkey = go_openssl_EVP_PKEY_new()
-		if pkey == nil {
-			return nil, newOpenSSLError("EVP_PKEY_new")
+		var err error
+		pkey, err = go_openssl_EVP_PKEY_new()
+		if err != nil {
+			return nil, err
 		}
 		key := getECKey(k._pkey)
-		if go_openssl_EVP_PKEY_set1_EC_KEY(pkey, key) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_set1_EC_KEY")
+		if _, err := go_openssl_EVP_PKEY_set1_EC_KEY(pkey, key); err != nil {
+			return nil, err
 		}
 		pt := go_openssl_EC_KEY_get0_public_key(key)
 		if pt == nil {
-			return nil, newOpenSSLError("EC_KEY_get0_public_key")
+			return nil, fail("missing ECDH public key")
 		}
 		group := go_openssl_EC_KEY_get0_group(key)
-		var err error
-		bytes, err = encodeEcPoint(group, pt)
-		if err != nil {
+		if bytes, err = encodeEcPoint(group, pt); err != nil {
 			return nil, err
 		}
 	case 3:
 		pkey = k._pkey
-		if go_openssl_EVP_PKEY_up_ref(pkey) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_up_ref")
+		if _, err := go_openssl_EVP_PKEY_up_ref(pkey); err != nil {
+			return nil, err
 		}
 
 		var cbytes *byte
-		n := go_openssl_EVP_PKEY_get1_encoded_public_key(k._pkey, &cbytes)
-		if n == 0 {
-			return nil, newOpenSSLError("EVP_PKEY_get_octet_string_param")
+		n, err := go_openssl_EVP_PKEY_get1_encoded_public_key(k._pkey, &cbytes)
+		if err != nil {
+			return nil, err
 		}
 		bytes = C.GoBytes(unsafe.Pointer(cbytes), C.int(n))
 		cryptoFree(unsafe.Pointer(cbytes))
@@ -121,9 +120,9 @@ func newECDHPkey(curve string, bytes []byte, isPrivate bool) (_EVP_PKEY_PTR, err
 func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey _EVP_PKEY_PTR, err error) {
 	checkMajorVersion(1)
 
-	key := go_openssl_EC_KEY_new_by_curve_name(nid)
-	if key == nil {
-		return nil, newOpenSSLError("EC_KEY_new_by_curve_name")
+	key, err := go_openssl_EC_KEY_new_by_curve_name(nid)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if pkey == nil {
@@ -132,36 +131,36 @@ func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey _EVP_PKEY_PTR, 
 	}()
 	group := go_openssl_EC_KEY_get0_group(key)
 	if isPrivate {
-		priv := go_openssl_BN_bin2bn(base(bytes), int32(len(bytes)), nil)
-		if priv == nil {
-			return nil, newOpenSSLError("BN_bin2bn")
+		priv, err := go_openssl_BN_bin2bn(base(bytes), int32(len(bytes)), nil)
+		if err != nil {
+			return nil, err
 		}
 		defer go_openssl_BN_clear_free(priv)
-		if go_openssl_EC_KEY_set_private_key(key, priv) != 1 {
-			return nil, newOpenSSLError("EC_KEY_set_private_key")
+		if _, err := go_openssl_EC_KEY_set_private_key(key, priv); err != nil {
+			return nil, err
 		}
 		pub, err := pointMult(group, priv)
 		if err != nil {
 			return nil, err
 		}
 		defer go_openssl_EC_POINT_free(pub)
-		if go_openssl_EC_KEY_set_public_key(key, pub) != 1 {
-			return nil, newOpenSSLError("EC_KEY_set_public_key")
+		if _, err := go_openssl_EC_KEY_set_public_key(key, pub); err != nil {
+			return nil, err
 		}
 	} else {
-		pub := go_openssl_EC_POINT_new(group)
-		if pub == nil {
-			return nil, newOpenSSLError("EC_POINT_new")
+		pub, err := go_openssl_EC_POINT_new(group)
+		if err != nil {
+			return nil, err
 		}
 		defer go_openssl_EC_POINT_free(pub)
-		if go_openssl_EC_POINT_oct2point(group, pub, base(bytes), len(bytes), nil) != 1 {
-			return nil, errors.New("point not on curve")
+		if _, err := go_openssl_EC_POINT_oct2point(group, pub, base(bytes), len(bytes), nil); err != nil {
+			return nil, err
 		}
-		if go_openssl_EC_KEY_set_public_key(key, pub) != 1 {
-			return nil, newOpenSSLError("EC_KEY_set_public_key")
+		if _, err := go_openssl_EC_KEY_set_public_key(key, pub); err != nil {
+			return nil, err
 		}
 	}
-	if go_openssl_EC_KEY_check_key(key) != 1 {
+	if _, err := go_openssl_EC_KEY_check_key(key); err != nil {
 		// Match upstream error message.
 		if isPrivate {
 			return nil, errors.New("crypto/ecdh: invalid private key")
@@ -183,9 +182,9 @@ func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (_EVP_PKEY_PTR, error
 	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, go_openssl_OBJ_nid2sn(nid), 0)
 	var selection int32
 	if isPrivate {
-		priv := go_openssl_BN_bin2bn(base(bytes), int32(len(bytes)), nil)
-		if priv == nil {
-			return nil, newOpenSSLError("BN_bin2bn")
+		priv, err := go_openssl_BN_bin2bn(base(bytes), int32(len(bytes)), nil)
+		if err != nil {
+			return nil, nil
 		}
 		defer go_openssl_BN_clear_free(priv)
 		pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group _EC_GROUP_PTR) (_EC_POINT_PTR, error) {
@@ -223,13 +222,13 @@ func pointMult(group _EC_GROUP_PTR, priv _BIGNUM_PTR) (_EC_POINT_PTR, error) {
 	// OpenSSL does not expose any method to generate the public
 	// key from the private key [1], so we have to calculate it here.
 	// [1] https://github.com/openssl/openssl/issues/18437#issuecomment-1144717206
-	pt := go_openssl_EC_POINT_new(group)
-	if pt == nil {
-		return nil, newOpenSSLError("EC_POINT_new")
+	pt, err := go_openssl_EC_POINT_new(group)
+	if err != nil {
+		return nil, err
 	}
-	if go_openssl_EC_POINT_mul(group, pt, priv, nil, nil, nil) == 0 {
+	if _, err := go_openssl_EC_POINT_mul(group, pt, priv, nil, nil, nil); err != nil {
 		go_openssl_EC_POINT_free(pt)
-		return nil, newOpenSSLError("EC_POINT_mul")
+		return nil, err
 	}
 	return pt, nil
 }
@@ -237,24 +236,24 @@ func pointMult(group _EC_GROUP_PTR, priv _BIGNUM_PTR) (_EC_POINT_PTR, error) {
 func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
 	defer runtime.KeepAlive(priv)
 	defer runtime.KeepAlive(pub)
-	ctx := go_openssl_EVP_PKEY_CTX_new(priv._pkey, nil)
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_PKEY_CTX_new")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new(priv._pkey, nil)
+	if err != nil {
+		return nil, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	if go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_derive_init")
+	if _, err := go_openssl_EVP_PKEY_derive_init(ctx); err != nil {
+		return nil, err
 	}
-	if go_openssl_EVP_PKEY_derive_set_peer(ctx, pub._pkey) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_derive_set_peer")
+	if _, err := go_openssl_EVP_PKEY_derive_set_peer(ctx, pub._pkey); err != nil {
+		return nil, err
 	}
 	var keylen int
-	if go_openssl_EVP_PKEY_derive(ctx, nil, &keylen) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_derive")
+	if _, err := go_openssl_EVP_PKEY_derive(ctx, nil, &keylen); err != nil {
+		return nil, err
 	}
 	out := make([]byte, keylen)
-	if go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_derive")
+	if _, err := go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -276,11 +275,11 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 		key := getECKey(pkey)
 		priv = go_openssl_EC_KEY_get0_private_key(key)
 		if priv == nil {
-			return nil, nil, newOpenSSLError("EC_KEY_get0_private_key")
+			return nil, nil, fail("missing ECDH private key")
 		}
 	case 3:
-		if go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &priv) != 1 {
-			return nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &priv); err != nil {
+			return nil, nil, err
 		}
 		defer go_openssl_BN_clear_free(priv)
 	default:
@@ -291,7 +290,10 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	// The fixed length is the order of the large prime subgroup of the curve,
 	// returned by EVP_PKEY_get_bits, which is generally the upper bound for
 	// generating a private ECDH key.
-	bits := go_openssl_EVP_PKEY_get_bits(pkey)
+	bits, err := go_openssl_EVP_PKEY_get_bits(pkey)
+	if err != nil {
+		return nil, nil, err
+	}
 	bytes := make([]byte, (bits+7)/8)
 	if err := bnToBinPad(priv, bytes); err != nil {
 		return nil, nil, err

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -18,7 +18,7 @@ func (k *PrivateKeyECDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyECDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PrivateKeyECDSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -32,7 +32,7 @@ func (k *PublicKeyECDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyECDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PublicKeyECDSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -18,7 +18,7 @@ func (k *PrivateKeyECDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyECDSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PrivateKeyECDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -32,7 +32,7 @@ func (k *PublicKeyECDSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyECDSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PublicKeyECDSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	defer runtime.KeepAlive(k)
 	return f(k._pkey)
 }
@@ -79,21 +79,29 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 		group := go_openssl_EC_KEY_get0_group(key)
 		pt := go_openssl_EC_KEY_get0_public_key(key)
 		// Allocate two big numbers to store the X and Y coordinates.
-		bx, by = go_openssl_BN_new(), go_openssl_BN_new()
-		if bx == nil || by == nil {
-			return nil, nil, nil, newOpenSSLError("BN_new failed")
+		bx, err = go_openssl_BN_new()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		by, err = go_openssl_BN_new()
+		if err != nil {
+			return nil, nil, nil, err
 		}
 		// Get X and Y.
-		if go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, bx, by, nil) == 0 {
-			return nil, nil, nil, newOpenSSLError("EC_POINT_get_affine_coordinates_GFp failed")
+		if _, err := go_openssl_EC_POINT_get_affine_coordinates_GFp(group, pt, bx, by, nil); err != nil {
+			return nil, nil, nil, err
 		}
 		// Get Z. We don't need to free it, get0 does not increase the reference count.
 		bd = go_openssl_EC_KEY_get0_private_key(key)
 	case 3:
-		if go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X.ptr(), &bx) != 1 ||
-			go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_Y.ptr(), &by) != 1 ||
-			go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bd) != 1 {
-			return nil, nil, nil, newOpenSSLError("EVP_PKEY_get_bn_param")
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X.ptr(), &bx); err != nil {
+			return nil, nil, nil, err
+		}
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_Y.ptr(), &by); err != nil {
+			return nil, nil, nil, err
+		}
+		if _, err := go_openssl_EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bd); err != nil {
+			return nil, nil, nil, err
 		}
 		defer go_openssl_BN_clear_free(bd)
 	default:
@@ -122,17 +130,23 @@ func HashVerifyECDSA(pub *PublicKeyECDSA, h crypto.Hash, msg, sig []byte) bool {
 
 func newECDSAKey(curve string, x, y, d BigInt) (_EVP_PKEY_PTR, error) {
 	nid := curveNID(curve)
-	var bx, by, bd _BIGNUM_PTR
-	defer func() {
-		go_openssl_BN_free(bx)
-		go_openssl_BN_free(by)
-		go_openssl_BN_clear_free(bd)
-	}()
-	bx = bigToBN(x)
-	by = bigToBN(y)
-	bd = bigToBN(d)
-	if bx == nil || by == nil || (d != nil && bd == nil) {
-		return nil, newOpenSSLError("BN_lebin2bn failed")
+	bx, err := bigToBN(x)
+	if err != nil {
+		return nil, err
+	}
+	defer go_openssl_BN_free(bx)
+	by, err := bigToBN(y)
+	if err != nil {
+		return nil, err
+	}
+	defer go_openssl_BN_free(by)
+	var bd _BIGNUM_PTR
+	if d != nil {
+		bd, err = bigToBN(d)
+		if err != nil {
+			return nil, err
+		}
+		defer go_openssl_BN_clear_free(bd)
 	}
 	switch vMajor {
 	case 1:
@@ -147,21 +161,24 @@ func newECDSAKey(curve string, x, y, d BigInt) (_EVP_PKEY_PTR, error) {
 func newECDSAKey1(nid int32, bx, by, bd _BIGNUM_PTR) (pkey _EVP_PKEY_PTR, err error) {
 	checkMajorVersion(1)
 
-	key := go_openssl_EC_KEY_new_by_curve_name(nid)
-	if key == nil {
-		return nil, newOpenSSLError("EC_KEY_new_by_curve_name failed")
+	key, err := go_openssl_EC_KEY_new_by_curve_name(nid)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if pkey == nil {
 			defer go_openssl_EC_KEY_free(key)
 		}
 	}()
-	if go_openssl_EC_KEY_set_public_key_affine_coordinates(key, bx, by) != 1 {
-		return nil, newOpenSSLError("EC_KEY_set_public_key_affine_coordinates failed")
+	if _, err := go_openssl_EC_KEY_set_public_key_affine_coordinates(key, bx, by); err != nil {
+		return nil, err
 	}
-	if bd != nil && go_openssl_EC_KEY_set_private_key(key, bd) != 1 {
-		return nil, newOpenSSLError("EC_KEY_set_private_key failed")
+	if bd != nil {
+		if _, err := go_openssl_EC_KEY_set_private_key(key, bd); err != nil {
+			return nil, err
+		}
 	}
+
 	return newEVPPKEY(key)
 }
 
@@ -170,13 +187,13 @@ func newECDSAKey3(nid int32, bx, by, bd _BIGNUM_PTR) (_EVP_PKEY_PTR, error) {
 
 	// Create the encoded public key public key from bx and by.
 	pubBytes, err := generateAndEncodeEcPublicKey(nid, func(group _EC_GROUP_PTR) (_EC_POINT_PTR, error) {
-		pt := go_openssl_EC_POINT_new(group)
-		if pt == nil {
-			return nil, newOpenSSLError("EC_POINT_new")
+		pt, err := go_openssl_EC_POINT_new(group)
+		if err != nil {
+			return nil, err
 		}
-		if go_openssl_EC_POINT_set_affine_coordinates(group, pt, bx, by, nil) != 1 {
+		if _, err := go_openssl_EC_POINT_set_affine_coordinates(group, pt, bx, by, nil); err != nil {
 			go_openssl_EC_POINT_free(pt)
-			return nil, newOpenSSLError("EC_POINT_set_affine_coordinates")
+			return nil, err
 		}
 		return pt, nil
 	})

--- a/ed25519.go
+++ b/ed25519.go
@@ -28,14 +28,14 @@ var supportsEd25519 = sync.OnceValue(func() bool {
 	switch vMajor {
 	case 1:
 		if versionAtOrAbove(1, 1, 1) {
-			ctx := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_ED25519, nil)
+			ctx, _ := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_ED25519, nil)
 			if ctx != nil {
 				go_openssl_EVP_PKEY_CTX_free(ctx)
 				return true
 			}
 		}
 	case 3:
-		sig := go_openssl_EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)
+		sig, _ := go_openssl_EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)
 		if sig != nil {
 			go_openssl_EVP_SIGNATURE_free(sig)
 			return true
@@ -128,9 +128,9 @@ func NewPublicKeyEd25519(pub []byte) (*PublicKeyEd25519, error) {
 	if len(pub) != publicKeySizeEd25519 {
 		panic("ed25519: bad public key length: " + strconv.Itoa(len(pub)))
 	}
-	pkey := go_openssl_EVP_PKEY_new_raw_public_key(_EVP_PKEY_ED25519, nil, base(pub), len(pub))
-	if pkey == nil {
-		return nil, newOpenSSLError("EVP_PKEY_new_raw_public_key")
+	pkey, err := go_openssl_EVP_PKEY_new_raw_public_key(_EVP_PKEY_ED25519, nil, base(pub), len(pub))
+	if err != nil {
+		return nil, err
 	}
 	pubk := &PublicKeyEd25519{_pkey: pkey}
 	runtime.SetFinalizer(pubk, (*PublicKeyEd25519).finalize)
@@ -144,9 +144,9 @@ func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
 	if len(seed) != seedSizeEd25519 {
 		panic("ed25519: bad seed length: " + strconv.Itoa(len(seed)))
 	}
-	pkey := go_openssl_EVP_PKEY_new_raw_private_key(_EVP_PKEY_ED25519, nil, base(seed), len(seed))
-	if pkey == nil {
-		return nil, newOpenSSLError("EVP_PKEY_new_raw_private_key")
+	pkey, err := go_openssl_EVP_PKEY_new_raw_private_key(_EVP_PKEY_ED25519, nil, base(seed), len(seed))
+	if err != nil {
+		return nil, err
 	}
 	priv := &PrivateKeyEd25519{_pkey: pkey}
 	runtime.SetFinalizer(priv, (*PrivateKeyEd25519).finalize)
@@ -155,8 +155,8 @@ func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
 
 func extractPKEYPubEd25519(pkey _EVP_PKEY_PTR, pub []byte) error {
 	keylen := publicKeySizeEd25519
-	if go_openssl_EVP_PKEY_get_raw_public_key(pkey, base(pub), &keylen) != 1 {
-		return newOpenSSLError("EVP_PKEY_get_raw_public_key")
+	if _, err := go_openssl_EVP_PKEY_get_raw_public_key(pkey, base(pub), &keylen); err != nil {
+		return err
 	}
 	if keylen != publicKeySizeEd25519 {
 		return errors.New("ed25519: bad public key length: " + strconv.Itoa(keylen))
@@ -169,8 +169,8 @@ func extractPKEYPrivEd25519(pkey _EVP_PKEY_PTR, priv []byte) error {
 		return err
 	}
 	keylen := seedSizeEd25519
-	if go_openssl_EVP_PKEY_get_raw_private_key(pkey, base(priv), &keylen) != 1 {
-		return newOpenSSLError("EVP_PKEY_get_raw_private_key")
+	if _, err := go_openssl_EVP_PKEY_get_raw_private_key(pkey, base(priv), &keylen); err != nil {
+		return err
 	}
 	if keylen != seedSizeEd25519 {
 		return errors.New("ed25519: bad private key length: " + strconv.Itoa(keylen))
@@ -191,17 +191,17 @@ func SignEd25519(priv *PrivateKeyEd25519, message []byte) (sig []byte, err error
 
 func signEd25519(priv *PrivateKeyEd25519, sig, message []byte) error {
 	defer runtime.KeepAlive(priv)
-	ctx := go_openssl_EVP_MD_CTX_new()
-	if ctx == nil {
-		return newOpenSSLError("EVP_MD_CTX_new")
+	ctx, err := go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		return err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if go_openssl_EVP_DigestSignInit(ctx, nil, nil, nil, priv._pkey) != 1 {
-		return newOpenSSLError("EVP_DigestSignInit")
+	if _, err := go_openssl_EVP_DigestSignInit(ctx, nil, nil, nil, priv._pkey); err != nil {
+		return err
 	}
 	siglen := signatureSizeEd25519
-	if go_openssl_EVP_DigestSign(ctx, base(sig), &siglen, base(message), len(message)) != 1 {
-		return newOpenSSLError("EVP_DigestSign")
+	if _, err := go_openssl_EVP_DigestSign(ctx, base(sig), &siglen, base(message), len(message)); err != nil {
+		return err
 	}
 	if siglen != signatureSizeEd25519 {
 		return errors.New("ed25519: bad signature length: " + strconv.Itoa(siglen))
@@ -212,15 +212,15 @@ func signEd25519(priv *PrivateKeyEd25519, sig, message []byte) error {
 // VerifyEd25519 reports whether sig is a valid signature of message by pub.
 func VerifyEd25519(pub *PublicKeyEd25519, message, sig []byte) error {
 	defer runtime.KeepAlive(pub)
-	ctx := go_openssl_EVP_MD_CTX_new()
-	if ctx == nil {
-		return newOpenSSLError("EVP_MD_CTX_new")
+	ctx, err := go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		return err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if go_openssl_EVP_DigestVerifyInit(ctx, nil, nil, nil, pub._pkey) != 1 {
-		return newOpenSSLError("EVP_DigestVerifyInit")
+	if _, err := go_openssl_EVP_DigestVerifyInit(ctx, nil, nil, nil, pub._pkey); err != nil {
+		return err
 	}
-	if go_openssl_EVP_DigestVerify(ctx, base(sig), len(sig), base(message), len(message)) != 1 {
+	if _, err := go_openssl_EVP_DigestVerify(ctx, base(sig), len(sig), base(message), len(message)); err != nil {
 		return errors.New("ed25519: invalid signature")
 	}
 	return nil

--- a/evp.go
+++ b/evp.go
@@ -150,7 +150,7 @@ func loadHash(ch crypto.Hash) *hashAlgorithm {
 		// not created by EVP_MD_fetch has negative performance
 		// implications, as digest operations will have
 		// to fetch it on every call. Better to just fetch it once here.
-		md := go_openssl_EVP_MD_fetch(nil, go_openssl_EVP_MD_get0_name(hash.md), nil)
+		md, _ := go_openssl_EVP_MD_fetch(nil, go_openssl_EVP_MD_get0_name(hash.md), nil)
 		// Don't overwrite md in case it can't be fetched, as the md may still be used
 		// outside of EVP_MD_CTX, for example to sign and verify RSA signatures.
 		if md != nil {
@@ -170,40 +170,41 @@ func generateEVPPKey(id, bits int32, curve string) (_EVP_PKEY_PTR, error) {
 	var pkey _EVP_PKEY_PTR
 	switch vMajor {
 	case 1:
-		ctx := go_openssl_EVP_PKEY_CTX_new_id(id, nil)
-		if ctx == nil {
-			return nil, newOpenSSLError("EVP_PKEY_CTX_new_id")
+		ctx, err := go_openssl_EVP_PKEY_CTX_new_id(id, nil)
+		if err != nil {
+			return nil, err
 		}
 		defer go_openssl_EVP_PKEY_CTX_free(ctx)
-		if go_openssl_EVP_PKEY_keygen_init(ctx) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_keygen_init")
+		if _, err := go_openssl_EVP_PKEY_keygen_init(ctx); err != nil {
+			return nil, err
 		}
 		if bits != 0 {
-			if go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, _EVP_PKEY_CTRL_RSA_KEYGEN_BITS, bits, nil) != 1 {
-				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl")
+			if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, _EVP_PKEY_CTRL_RSA_KEYGEN_BITS, bits, nil); err != nil {
+				return nil, err
 			}
 		}
 		if curve != "" {
-			if go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, _EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, curveNID(curve), nil) != 1 {
-				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl")
+			if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, id, -1, _EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, curveNID(curve), nil); err != nil {
+				return nil, err
 			}
 		}
-		if go_openssl_EVP_PKEY_keygen(ctx, &pkey) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_keygen")
+		if _, err := go_openssl_EVP_PKEY_keygen(ctx, &pkey); err != nil {
+			return nil, err
 		}
 	case 3:
+		var err error
 		switch id {
 		case _EVP_PKEY_RSA:
-			pkey = go_openssl_EVP_PKEY_Q_keygen_RSA(nil, nil, _KeyTypeRSA.ptr(), int(bits))
+			pkey, err = go_openssl_EVP_PKEY_Q_keygen_RSA(nil, nil, _KeyTypeRSA.ptr(), int(bits))
 		case _EVP_PKEY_EC:
-			pkey = go_openssl_EVP_PKEY_Q_keygen_EC(nil, nil, _KeyTypeEC.ptr(), go_openssl_OBJ_nid2sn(curveNID(curve)))
+			pkey, err = go_openssl_EVP_PKEY_Q_keygen_EC(nil, nil, _KeyTypeEC.ptr(), go_openssl_OBJ_nid2sn(curveNID(curve)))
 		case _EVP_PKEY_ED25519:
-			pkey = go_openssl_EVP_PKEY_Q_keygen_ED25519(nil, nil, _KeyTypeED25519.ptr())
+			pkey, err = go_openssl_EVP_PKEY_Q_keygen_ED25519(nil, nil, _KeyTypeED25519.ptr())
 		default:
 			panic("unsupported key type '" + strconv.Itoa(int(id)) + "'")
 		}
-		if pkey == nil {
-			return nil, newOpenSSLError("EVP_PKEY_Q_keygen")
+		if err != nil {
+			return nil, err
 		}
 	default:
 		panic(errUnsupportedVersion())
@@ -212,7 +213,7 @@ func generateEVPPKey(id, bits int32, curve string) (_EVP_PKEY_PTR, error) {
 	return pkey, nil
 }
 
-type withKeyFunc func(func(_EVP_PKEY_PTR) int32) int32
+type withKeyFunc func(func(_EVP_PKEY_PTR) (int32, error)) (int32, error)
 type initFunc func(_EVP_PKEY_CTX_PTR) error
 type cryptFunc func(_EVP_PKEY_CTX_PTR, *byte, *int, *byte, int) error
 type verifyFunc func(_EVP_PKEY_CTX_PTR, *byte, int, *byte, int) error
@@ -221,12 +222,11 @@ func setupEVP(withKey withKeyFunc, padding int32,
 	h, mgfHash hash.Hash, label []byte, saltLen int32, ch crypto.Hash,
 	init initFunc) (_ _EVP_PKEY_CTX_PTR, err error) {
 	var ctx _EVP_PKEY_CTX_PTR
-	withKey(func(pkey _EVP_PKEY_PTR) int32 {
-		ctx = go_openssl_EVP_PKEY_CTX_new(pkey, nil)
-		return 1
-	})
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_PKEY_CTX_new failed")
+	if _, err := withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
+		ctx, err = go_openssl_EVP_PKEY_CTX_new(pkey, nil)
+		return 0, err
+	}); err != nil {
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -245,10 +245,8 @@ func setupEVP(withKey withKeyFunc, padding int32,
 	// Each padding type has its own requirements in terms of when to apply the padding,
 	// so it can't be just set at this point.
 	setPadding := func() error {
-		if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_PADDING, padding, nil) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_PADDING, padding, nil)
+		return err
 	}
 	switch padding {
 	case _RSA_PKCS1_OAEP_PADDING:
@@ -268,12 +266,12 @@ func setupEVP(withKey withKeyFunc, padding int32,
 		if err := setPadding(); err != nil {
 			return nil, err
 		}
-		if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_OAEP_MD, 0, unsafe.Pointer(md)); err != nil {
+			return nil, err
 		}
 		if mgfHash != nil {
-			if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_MGF1_MD, 0, unsafe.Pointer(mgfMD)) != 1 {
-				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+			if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_MGF1_MD, 0, unsafe.Pointer(mgfMD)); err != nil {
+				return nil, err
 			}
 		}
 		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
@@ -285,15 +283,9 @@ func setupEVP(withKey withKeyFunc, padding int32,
 			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 			var err error
 			if vMajor == 3 {
-				ret := go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
-				if ret != 1 {
-					err = newOpenSSLError("EVP_PKEY_CTX_set0_rsa_oaep_label failed")
-				}
+				_, err = go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
 			} else {
-				ret := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
-				if ret != 1 {
-					err = newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
-				}
+				_, err = go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
 			}
 			if err != nil {
 				cryptoFree(unsafe.Pointer(clabel))
@@ -305,16 +297,16 @@ func setupEVP(withKey withKeyFunc, padding int32,
 		if alg == nil {
 			return nil, errors.New("crypto/rsa: unsupported hash function")
 		}
-		if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+		if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
+			return nil, err
 		}
 		// setPadding must happen after setting EVP_PKEY_CTRL_MD.
 		if err := setPadding(); err != nil {
 			return nil, err
 		}
 		if saltLen != 0 {
-			if go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil) != 1 {
-				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+			if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, _EVP_PKEY_RSA, -1, _EVP_PKEY_CTRL_RSA_PSS_SALTLEN, saltLen, nil); err != nil {
+				return nil, err
 			}
 		}
 
@@ -325,8 +317,8 @@ func setupEVP(withKey withKeyFunc, padding int32,
 			if alg == nil {
 				return nil, errors.New("crypto/rsa: unsupported hash function")
 			}
-			if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, -1, _EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)) != 1 {
-				return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
+			if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, -1, _EVP_PKEY_CTRL_MD, 0, unsafe.Pointer(alg.md)); err != nil {
+				return nil, err
 			}
 			if err := setPadding(); err != nil {
 				return nil, err
@@ -349,9 +341,12 @@ func cryptEVP(withKey withKeyFunc, padding int32,
 		return nil, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	pkeySize := withKey(func(pkey _EVP_PKEY_PTR) int32 {
+	pkeySize, err := withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
 		return go_openssl_EVP_PKEY_get_size(pkey)
 	})
+	if err != nil {
+		return nil, err
+	}
 	outLen := int(pkeySize)
 	out := make([]byte, pkeySize)
 	if err := crypt(ctx, base(out), &outLen, base(in), len(in)); err != nil {
@@ -377,14 +372,12 @@ func verifyEVP(withKey withKeyFunc, padding int32,
 
 func evpEncrypt(withKey withKeyFunc, padding int32, h, mgfHash hash.Hash, label, msg []byte) ([]byte, error) {
 	encryptInit := func(ctx _EVP_PKEY_CTX_PTR) error {
-		if ret := go_openssl_EVP_PKEY_encrypt_init(ctx); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_encrypt_init failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_encrypt_init(ctx)
+		return err
 	}
 	encrypt := func(ctx _EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
-		if ret := go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_encrypt failed")
+		if _, err := go_openssl_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -393,48 +386,36 @@ func evpEncrypt(withKey withKeyFunc, padding int32, h, mgfHash hash.Hash, label,
 
 func evpDecrypt(withKey withKeyFunc, padding int32, h, mgfHash hash.Hash, label, msg []byte) ([]byte, error) {
 	decryptInit := func(ctx _EVP_PKEY_CTX_PTR) error {
-		if ret := go_openssl_EVP_PKEY_decrypt_init(ctx); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_decrypt_init failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_decrypt_init(ctx)
+		return err
 	}
 	decrypt := func(ctx _EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
-		if ret := go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_decrypt failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
+		return err
 	}
 	return cryptEVP(withKey, padding, h, mgfHash, label, 0, 0, decryptInit, decrypt, msg)
 }
 
 func evpSign(withKey withKeyFunc, padding int32, saltLen int32, h crypto.Hash, hashed []byte) ([]byte, error) {
 	signtInit := func(ctx _EVP_PKEY_CTX_PTR) error {
-		if ret := go_openssl_EVP_PKEY_sign_init(ctx); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_sign_init failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_sign_init(ctx)
+		return err
 	}
 	sign := func(ctx _EVP_PKEY_CTX_PTR, out *byte, outLen *int, in *byte, inLen int) error {
-		if ret := go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_sign failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_sign(ctx, out, outLen, in, inLen)
+		return err
 	}
 	return cryptEVP(withKey, padding, nil, nil, nil, saltLen, h, signtInit, sign, hashed)
 }
 
 func evpVerify(withKey withKeyFunc, padding int32, saltLen int32, h crypto.Hash, sig, hashed []byte) error {
 	verifyInit := func(ctx _EVP_PKEY_CTX_PTR) error {
-		if ret := go_openssl_EVP_PKEY_verify_init(ctx); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_verify_init failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_verify_init(ctx)
+		return err
 	}
 	verify := func(ctx _EVP_PKEY_CTX_PTR, out *byte, outLen int, in *byte, inLen int) error {
-		if ret := go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen); ret != 1 {
-			return newOpenSSLError("EVP_PKEY_verify failed")
-		}
-		return nil
+		_, err := go_openssl_EVP_PKEY_verify(ctx, out, outLen, in, inLen)
+		return err
 	}
 	return verifyEVP(withKey, padding, nil, nil, saltLen, h, verifyInit, verify, sig, hashed)
 }
@@ -446,27 +427,27 @@ func evpHashSign(withKey withKeyFunc, h crypto.Hash, msg []byte) ([]byte, error)
 	}
 	var out []byte
 	var outLen int
-	ctx := go_openssl_EVP_MD_CTX_new()
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_MD_CTX_new failed")
+	ctx, err := go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		return nil, err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if withKey(func(key _EVP_PKEY_PTR) int32 {
+	if _, err := withKey(func(key _EVP_PKEY_PTR) (int32, error) {
 		return go_openssl_EVP_DigestSignInit(ctx, nil, alg.md, nil, key)
-	}) != 1 {
-		return nil, newOpenSSLError("EVP_DigestSignInit failed")
+	}); err != nil {
+		return nil, err
 	}
-	if go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), len(msg)) != 1 {
-		return nil, newOpenSSLError("EVP_DigestUpdate failed")
+	if _, err := go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), len(msg)); err != nil {
+		return nil, err
 	}
 	// Obtain the signature length
-	if go_openssl_EVP_DigestSignFinal(ctx, nil, &outLen) != 1 {
-		return nil, newOpenSSLError("EVP_DigestSignFinal failed")
+	if _, err := go_openssl_EVP_DigestSignFinal(ctx, nil, &outLen); err != nil {
+		return nil, err
 	}
 	out = make([]byte, outLen)
 	// Obtain the signature
-	if go_openssl_EVP_DigestSignFinal(ctx, base(out), &outLen) != 1 {
-		return nil, newOpenSSLError("EVP_DigestSignFinal failed")
+	if _, err := go_openssl_EVP_DigestSignFinal(ctx, base(out), &outLen); err != nil {
+		return nil, err
 	}
 	return out[:outLen], nil
 }
@@ -476,33 +457,33 @@ func evpHashVerify(withKey withKeyFunc, h crypto.Hash, msg, sig []byte) error {
 	if alg == nil {
 		return errors.New("unsupported hash function: " + strconv.Itoa(int(h)))
 	}
-	ctx := go_openssl_EVP_MD_CTX_new()
-	if ctx == nil {
-		return newOpenSSLError("EVP_MD_CTX_new failed")
+	ctx, err := go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		return err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if withKey(func(key _EVP_PKEY_PTR) int32 {
+	if _, err := withKey(func(key _EVP_PKEY_PTR) (int32, error) {
 		return go_openssl_EVP_DigestVerifyInit(ctx, nil, alg.md, nil, key)
-	}) != 1 {
-		return newOpenSSLError("EVP_DigestVerifyInit failed")
+	}); err != nil {
+		return err
 	}
-	if go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), len(msg)) != 1 {
-		return newOpenSSLError("EVP_DigestUpdate failed")
+	if _, err := go_openssl_EVP_DigestUpdate(ctx, unsafe.Pointer(base(msg)), len(msg)); err != nil {
+		return err
 	}
-	if go_openssl_EVP_DigestVerifyFinal(ctx, base(sig), len(sig)) != 1 {
-		return newOpenSSLError("EVP_DigestVerifyFinal failed")
+	if _, err := go_openssl_EVP_DigestVerifyFinal(ctx, base(sig), len(sig)); err != nil {
+		return err
 	}
 	return nil
 }
 
 func newEVPPKEY(key _EC_KEY_PTR) (_EVP_PKEY_PTR, error) {
-	pkey := go_openssl_EVP_PKEY_new()
-	if pkey == nil {
-		return nil, newOpenSSLError("EVP_PKEY_new failed")
+	pkey, err := go_openssl_EVP_PKEY_new()
+	if err != nil {
+		return nil, err
 	}
-	if go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_EC, unsafe.Pointer(key)) != 1 {
+	if _, err := go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_EC, unsafe.Pointer(key)); err != nil {
 		go_openssl_EVP_PKEY_free(pkey)
-		return nil, newOpenSSLError("EVP_PKEY_assign failed")
+		return nil, err
 	}
 	return pkey, nil
 }
@@ -511,49 +492,49 @@ func newEVPPKEY(key _EC_KEY_PTR) (_EVP_PKEY_PTR, error) {
 // If pkey does not contain an EC_KEY it panics.
 // The returned key should not be freed.
 func getECKey(pkey _EVP_PKEY_PTR) _EC_KEY_PTR {
-	key := go_openssl_EVP_PKEY_get0_EC_KEY(pkey)
-	if key == nil {
-		panic("pkey does not contain an EC_KEY")
+	key, err := go_openssl_EVP_PKEY_get0_EC_KEY(pkey)
+	if err != nil {
+		panic(err)
 	}
 	return key
 }
 
 func newEvpFromParams(id int32, selection int32, params _OSSL_PARAM_PTR) (_EVP_PKEY_PTR, error) {
-	ctx := go_openssl_EVP_PKEY_CTX_new_id(id, nil)
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_PKEY_CTX_new_id")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new_id(id, nil)
+	if err != nil {
+		return nil, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	if go_openssl_EVP_PKEY_fromdata_init(ctx) != 1 {
-		return nil, newOpenSSLError("EVP_PKEY_fromdata_init")
+	if _, err := go_openssl_EVP_PKEY_fromdata_init(ctx); err != nil {
+		return nil, err
 	}
 	var pkey _EVP_PKEY_PTR
-	if go_openssl_EVP_PKEY_fromdata(ctx, &pkey, selection, params) != 1 {
+	if _, err := go_openssl_EVP_PKEY_fromdata(ctx, &pkey, selection, params); err != nil {
 		if vMajor == 3 && vMinor <= 2 {
 			// OpenSSL 3.0.1 and 3.0.2 have a bug where EVP_PKEY_fromdata
 			// does not free the internally allocated EVP_PKEY on error.
 			// See https://github.com/openssl/openssl/issues/17407.
 			go_openssl_EVP_PKEY_free(pkey)
 		}
-		return nil, newOpenSSLError("EVP_PKEY_fromdata")
+		return nil, err
 	}
 	return pkey, nil
 }
 
 func checkPkey(pkey _EVP_PKEY_PTR, isPrivate bool) error {
-	ctx := go_openssl_EVP_PKEY_CTX_new(pkey, nil)
-	if ctx == nil {
-		return newOpenSSLError("EVP_PKEY_CTX_new")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new(pkey, nil)
+	if err != nil {
+		return err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
 	if isPrivate {
-		if go_openssl_EVP_PKEY_private_check(ctx) != 1 {
+		if _, err := go_openssl_EVP_PKEY_private_check(ctx); err != nil {
 			// Match upstream error message.
 			return errors.New("invalid private key")
 		}
 	} else {
 		// Upstream Go does a partial check here, so do we.
-		if go_openssl_EVP_PKEY_public_check_quick(ctx) != 1 {
+		if _, err := go_openssl_EVP_PKEY_public_check_quick(ctx); err != nil {
 			// Match upstream error message.
 			return errors.New("invalid public key")
 		}

--- a/evp.go
+++ b/evp.go
@@ -213,7 +213,7 @@ func generateEVPPKey(id, bits int32, curve string) (_EVP_PKEY_PTR, error) {
 	return pkey, nil
 }
 
-type withKeyFunc func(func(_EVP_PKEY_PTR) (int32, error)) (int32, error)
+type withKeyFunc func(func(_EVP_PKEY_PTR) error) error
 type initFunc func(_EVP_PKEY_CTX_PTR) error
 type cryptFunc func(_EVP_PKEY_CTX_PTR, *byte, *int, *byte, int) error
 type verifyFunc func(_EVP_PKEY_CTX_PTR, *byte, int, *byte, int) error
@@ -222,9 +222,9 @@ func setupEVP(withKey withKeyFunc, padding int32,
 	h, mgfHash hash.Hash, label []byte, saltLen int32, ch crypto.Hash,
 	init initFunc) (_ _EVP_PKEY_CTX_PTR, err error) {
 	var ctx _EVP_PKEY_CTX_PTR
-	if _, err := withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
+	if err := withKey(func(pkey _EVP_PKEY_PTR) error {
 		ctx, err = go_openssl_EVP_PKEY_CTX_new(pkey, nil)
-		return 0, err
+		return err
 	}); err != nil {
 		return nil, err
 	}
@@ -341,10 +341,11 @@ func cryptEVP(withKey withKeyFunc, padding int32,
 		return nil, err
 	}
 	defer go_openssl_EVP_PKEY_CTX_free(ctx)
-	pkeySize, err := withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
-		return go_openssl_EVP_PKEY_get_size(pkey)
-	})
-	if err != nil {
+	var pkeySize int32
+	if err := withKey(func(pkey _EVP_PKEY_PTR) (err error) {
+		pkeySize, err = go_openssl_EVP_PKEY_get_size(pkey)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	outLen := int(pkeySize)
@@ -432,8 +433,9 @@ func evpHashSign(withKey withKeyFunc, h crypto.Hash, msg []byte) ([]byte, error)
 		return nil, err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if _, err := withKey(func(key _EVP_PKEY_PTR) (int32, error) {
-		return go_openssl_EVP_DigestSignInit(ctx, nil, alg.md, nil, key)
+	if err := withKey(func(key _EVP_PKEY_PTR) error {
+		_, err := go_openssl_EVP_DigestSignInit(ctx, nil, alg.md, nil, key)
+		return err
 	}); err != nil {
 		return nil, err
 	}
@@ -462,8 +464,9 @@ func evpHashVerify(withKey withKeyFunc, h crypto.Hash, msg, sig []byte) error {
 		return err
 	}
 	defer go_openssl_EVP_MD_CTX_free(ctx)
-	if _, err := withKey(func(key _EVP_PKEY_PTR) (int32, error) {
-		return go_openssl_EVP_DigestVerifyInit(ctx, nil, alg.md, nil, key)
+	if err := withKey(func(key _EVP_PKEY_PTR) error {
+		_, err := go_openssl_EVP_DigestVerifyInit(ctx, nil, alg.md, nil, key)
+		return err
 	}); err != nil {
 		return err
 	}

--- a/hash.go
+++ b/hash.go
@@ -38,7 +38,8 @@ func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
 		defer pinner.Unpin()
 		pinner.Pin(&p[0])
 	}
-	return go_openssl_EVP_Digest(pbase(p), len(p), base(sum), nil, loadHash(ch).md, nil) != 0
+	_, err := go_openssl_EVP_Digest(pbase(p), len(p), base(sum), nil, loadHash(ch).md, nil)
+	return err == nil
 }
 
 func MD4(p []byte) (sum [16]byte) {
@@ -121,8 +122,9 @@ func SupportsHash(h crypto.Hash) bool {
 	// in a EVP_MD_CTX, e.g. MD5 in FIPS mode. We need to prove
 	// if they can be used by passing them to a EVP_MD_CTX.
 	var supported bool
-	if ctx := go_openssl_EVP_MD_CTX_new(); ctx != nil {
-		supported = go_openssl_EVP_DigestInit_ex(ctx, alg.md, nil) == 1
+	if ctx, _ := go_openssl_EVP_MD_CTX_new(); ctx != nil {
+		_, err := go_openssl_EVP_DigestInit_ex(ctx, alg.md, nil)
+		supported = err == nil
 		go_openssl_EVP_MD_CTX_free(ctx)
 	}
 	cacheHashSupported.Store(h, supported)
@@ -296,12 +298,20 @@ func (h *evpHash) init() {
 	if h.ctx != nil {
 		return
 	}
-	h.ctx = go_openssl_EVP_MD_CTX_new()
-	if go_openssl_EVP_DigestInit_ex(h.ctx, h.alg.md, nil) != 1 {
-		go_openssl_EVP_MD_CTX_free(h.ctx)
-		panic(newOpenSSLError("EVP_DigestInit_ex"))
+	var err error
+	h.ctx, err = go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		panic(err)
 	}
-	h.ctx2 = go_openssl_EVP_MD_CTX_new()
+	if _, err := go_openssl_EVP_DigestInit_ex(h.ctx, h.alg.md, nil); err != nil {
+		go_openssl_EVP_MD_CTX_free(h.ctx)
+		panic(err)
+	}
+	h.ctx2, err = go_openssl_EVP_MD_CTX_new()
+	if err != nil {
+		go_openssl_EVP_MD_CTX_free(h.ctx)
+		panic(err)
+	}
 	runtime.SetFinalizer(h, (*evpHash).finalize)
 }
 
@@ -312,8 +322,8 @@ func (h *evpHash) Reset() {
 	}
 	// There is no need to reset h.ctx2 because it is always reset after
 	// use in evpHash.sum.
-	if go_openssl_EVP_DigestInit_ex(h.ctx, nil, nil) != 1 {
-		panic(newOpenSSLError("EVP_DigestInit_ex"))
+	if _, err := go_openssl_EVP_DigestInit_ex(h.ctx, nil, nil); err != nil {
+		panic(err)
 	}
 	runtime.KeepAlive(h)
 }
@@ -325,8 +335,8 @@ func (h *evpHash) Write(p []byte) (int, error) {
 	defer h.pinner.Unpin()
 	h.pinner.Pin(&p[0])
 	h.init()
-	if go_openssl_EVP_DigestUpdate(h.ctx, pbase(p), len(p)) != 1 {
-		panic(newOpenSSLError("EVP_DigestUpdate"))
+	if _, err := go_openssl_EVP_DigestUpdate(h.ctx, pbase(p), len(p)); err != nil {
+		panic(err)
 	}
 	runtime.KeepAlive(h)
 	return len(p), nil
@@ -337,8 +347,8 @@ func (h *evpHash) WriteString(s string) (int, error) {
 		return 0, nil
 	}
 	h.init()
-	if go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(unsafe.StringData(s)), len(s)) == 0 {
-		panic("openssl: EVP_DigestUpdate failed")
+	if _, err := go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(unsafe.StringData(s)), len(s)); err != nil {
+		panic(err)
 	}
 	runtime.KeepAlive(h)
 	return len(s), nil
@@ -346,8 +356,8 @@ func (h *evpHash) WriteString(s string) (int, error) {
 
 func (h *evpHash) WriteByte(c byte) error {
 	h.init()
-	if go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1) == 0 {
-		panic("openssl: EVP_DigestUpdate failed")
+	if _, err := go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1); err != nil {
+		panic(err)
 	}
 	runtime.KeepAlive(h)
 	return nil
@@ -377,18 +387,19 @@ func (h *evpHash) Sum(in []byte) []byte {
 func (h *evpHash) Clone() hash.Hash {
 	h2 := &evpHash{alg: h.alg}
 	if h.ctx != nil {
-		h2.ctx = go_openssl_EVP_MD_CTX_new()
-		if h2.ctx == nil {
-			panic(newOpenSSLError("EVP_MD_CTX_new"))
+		var err error
+		h2.ctx, err = go_openssl_EVP_MD_CTX_new()
+		if err != nil {
+			panic(err)
 		}
-		if go_openssl_EVP_MD_CTX_copy_ex(h2.ctx, h.ctx) != 1 {
+		if _, err := go_openssl_EVP_MD_CTX_copy_ex(h2.ctx, h.ctx); err != nil {
 			go_openssl_EVP_MD_CTX_free(h2.ctx)
-			panic(newOpenSSLError("EVP_MD_CTX_copy"))
+			panic(err)
 		}
-		h2.ctx2 = go_openssl_EVP_MD_CTX_new()
-		if h2.ctx2 == nil {
+		h2.ctx2, err = go_openssl_EVP_MD_CTX_new()
+		if err != nil {
 			go_openssl_EVP_MD_CTX_free(h2.ctx)
-			panic(newOpenSSLError("EVP_MD_CTX_new"))
+			panic(err)
 		}
 		runtime.SetFinalizer(h2, (*evpHash).finalize)
 	}

--- a/hkdf.go
+++ b/hkdf.go
@@ -28,9 +28,9 @@ func SupportsHKDF() bool {
 func newHKDFCtx1(md _EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info []byte) (ctx _EVP_PKEY_CTX_PTR, err error) {
 	checkMajorVersion(1)
 
-	ctx = go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_HKDF, nil)
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_PKEY_CTX_new_id")
+	ctx, err = go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_HKDF, nil)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -38,34 +38,32 @@ func newHKDFCtx1(md _EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info
 		}
 	}()
 
-	if go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_derive_init")
+	if _, err := go_openssl_EVP_PKEY_derive_init(ctx); err != nil {
+		return ctx, err
 	}
 
-	ctrlSlice := func(ctrl int32, data []byte) int32 {
-		if len(data) == 0 {
-			return 1 // No data to set.
+	ctrlSlice := func(ctrl int32, data []byte) bool {
+		if err != nil {
+			return false
 		}
-		return go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, ctrl, int32(len(data)), unsafe.Pointer(base(data)))
+		if len(data) == 0 {
+			return true // No data to set.
+		}
+		_, err = go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, ctrl, int32(len(data)), unsafe.Pointer(base(data)))
+		return err == nil
 	}
 
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, _EVP_PKEY_CTRL_HKDF_MODE, mode, nil) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_set_hkdf_mode")
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, _EVP_PKEY_CTRL_HKDF_MODE, mode, nil); err != nil {
+		return ctx, err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, _EVP_PKEY_CTRL_HKDF_MD, 0, unsafe.Pointer(md)) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_set_hkdf_md")
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1, _EVP_PKEY_OP_DERIVE, _EVP_PKEY_CTRL_HKDF_MD, 0, unsafe.Pointer(md)); err != nil {
+		return ctx, err
 	}
-	if ctrlSlice(_EVP_PKEY_CTRL_HKDF_KEY, secret) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_set1_hkdf_key")
-	}
-	if ctrlSlice(_EVP_PKEY_CTRL_HKDF_SALT, salt) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_set1_hkdf_salt")
-	}
-	if ctrlSlice(_EVP_PKEY_CTRL_HKDF_KEY, pseudorandomKey) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_set1_hkdf_key")
-	}
-	if ctrlSlice(_EVP_PKEY_CTRL_HKDF_INFO, info) != 1 {
-		return ctx, newOpenSSLError("EVP_PKEY_CTX_add1_hkdf_info")
+	if ctrlSlice(_EVP_PKEY_CTRL_HKDF_KEY, secret) &&
+		ctrlSlice(_EVP_PKEY_CTRL_HKDF_SALT, salt) &&
+		ctrlSlice(_EVP_PKEY_CTRL_HKDF_KEY, pseudorandomKey) &&
+		ctrlSlice(_EVP_PKEY_CTRL_HKDF_INFO, info) {
+		return ctx, err
 	}
 	return ctx, nil
 }
@@ -101,8 +99,8 @@ func (c *hkdf1) Read(p []byte) (int, error) {
 	}
 	c.buf = append(c.buf, make([]byte, needLen)...)
 	outLen := prevLen + needLen
-	if go_openssl_EVP_PKEY_derive(c.ctx, base(c.buf), &outLen) != 1 {
-		return 0, newOpenSSLError("EVP_PKEY_derive")
+	if _, err := go_openssl_EVP_PKEY_derive(c.ctx, base(c.buf), &outLen); err != nil {
+		return 0, err
 	}
 	n := copy(p, c.buf[prevLen:outLen])
 	return n, nil
@@ -148,12 +146,12 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 		}
 		defer go_openssl_EVP_PKEY_CTX_free(ctx)
 		var keylen int
-		if go_openssl_EVP_PKEY_derive(ctx, nil, &keylen) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_derive_init")
+		if _, err := go_openssl_EVP_PKEY_derive(ctx, nil, &keylen); err != nil {
+			return nil, err
 		}
 		out := make([]byte, keylen)
-		if go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_derive")
+		if _, err := go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
+			return nil, err
 		}
 		return out[:keylen], nil
 	case 3:
@@ -162,9 +160,13 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 			return nil, err
 		}
 		defer go_openssl_EVP_KDF_CTX_free(ctx)
-		out := make([]byte, go_openssl_EVP_KDF_CTX_get_kdf_size(ctx))
-		if go_openssl_EVP_KDF_derive(ctx, base(out), len(out), nil) != 1 {
-			return nil, newOpenSSLError("EVP_KDF_derive")
+		size, err := go_openssl_EVP_KDF_CTX_get_kdf_size(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]byte, size)
+		if _, err := go_openssl_EVP_KDF_derive(ctx, base(out), len(out), nil); err != nil {
+			return nil, err
 		}
 		return out, nil
 	default:
@@ -192,8 +194,8 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 		}
 		defer go_openssl_EVP_PKEY_CTX_free(ctx)
 		keylen := keyLength
-		if go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen) != 1 {
-			return nil, newOpenSSLError("EVP_PKEY_derive")
+		if _, err := go_openssl_EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
+			return nil, err
 		}
 	case 3:
 		ctx, err := newHKDFCtx3(md, _EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
@@ -201,8 +203,8 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 			return nil, err
 		}
 		defer go_openssl_EVP_KDF_CTX_free(ctx)
-		if go_openssl_EVP_KDF_derive(ctx, base(out), keyLength, nil) != 1 {
-			return nil, newOpenSSLError("EVP_KDF_derive")
+		if _, err := go_openssl_EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {
+			return nil, err
 		}
 	default:
 		panic(errUnsupportedVersion())
@@ -263,9 +265,9 @@ func (c *hkdf3) finalize() {
 var fetchHKDF3 = sync.OnceValues(func() (_EVP_KDF_PTR, error) {
 	checkMajorVersion(3)
 
-	kdf := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_HKDF.ptr(), nil)
-	if kdf == nil {
-		return nil, newOpenSSLError("EVP_KDF_fetch")
+	kdf, err := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_HKDF.ptr(), nil)
+	if err != nil {
+		return nil, err
 	}
 	return kdf, nil
 })
@@ -278,9 +280,9 @@ func newHKDFCtx3(md _EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info
 	if err != nil {
 		return nil, err
 	}
-	ctx := go_openssl_EVP_KDF_CTX_new(kdf)
-	if ctx == nil {
-		return nil, newOpenSSLError("EVP_KDF_CTX_new")
+	ctx, err := go_openssl_EVP_KDF_CTX_new(kdf)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -312,8 +314,8 @@ func newHKDFCtx3(md _EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, info
 	}
 	defer go_openssl_OSSL_PARAM_free(params)
 
-	if go_openssl_EVP_KDF_CTX_set_params(ctx, params) != 1 {
-		return ctx, newOpenSSLError("EVP_KDF_CTX_set_params")
+	if _, err := go_openssl_EVP_KDF_CTX_set_params(ctx, params); err != nil {
+		return ctx, err
 	}
 	return ctx, nil
 }
@@ -336,8 +338,8 @@ func (c *hkdf3) Read(p []byte) (int, error) {
 	}
 	c.buf = append(c.buf, make([]byte, needLen)...)
 	outLen := prevLen + needLen
-	if go_openssl_EVP_KDF_derive(c.ctx, base(c.buf), outLen, nil) != 1 {
-		return 0, newOpenSSLError("EVP_KDF_derive")
+	if _, err := go_openssl_EVP_KDF_derive(c.ctx, base(c.buf), outLen, nil); err != nil {
+		return 0, err
 	}
 	n := copy(p, c.buf[prevLen:outLen])
 	return n, nil

--- a/hmac.go
+++ b/hmac.go
@@ -75,21 +75,21 @@ type opensslHMAC struct {
 }
 
 func newHMAC1(key []byte, md _EVP_MD_PTR) hmacCtx1 {
-	ctx := go_openssl_HMAC_CTX_new()
-	if ctx == nil {
-		panic("openssl: EVP_MAC_CTX_new failed")
+	ctx, err := go_openssl_HMAC_CTX_new()
+	if err != nil {
+		panic(err)
 	}
-	if go_openssl_HMAC_Init_ex(ctx, unsafe.Pointer(&key[0]), int32(len(key)), md, nil) == 0 {
-		panic(newOpenSSLError("HMAC_Init_ex failed"))
+	if _, err := go_openssl_HMAC_Init_ex(ctx, unsafe.Pointer(&key[0]), int32(len(key)), md, nil); err != nil {
+		panic(err)
 	}
 	return hmacCtx1{ctx}
 }
 
 var hmacDigestsSupported sync.Map
 var fetchHMAC3 = sync.OnceValue(func() _EVP_MAC_PTR {
-	mac := go_openssl_EVP_MAC_fetch(nil, _OSSL_MAC_NAME_HMAC.ptr(), nil)
-	if mac == nil {
-		panic("openssl: HMAC not supported")
+	mac, err := go_openssl_EVP_MAC_fetch(nil, _OSSL_MAC_NAME_HMAC.ptr(), nil)
+	if err != nil {
+		panic(err)
 	}
 	return mac
 })
@@ -109,9 +109,9 @@ func isHMAC3DigestSupported(md _EVP_MD_PTR) bool {
 	if v, ok := hmacDigestsSupported.Load(nid); ok {
 		return v.(bool)
 	}
-	ctx := go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
-	if ctx == nil {
-		panic(newOpenSSLError("EVP_MAC_CTX_new"))
+	ctx, err := go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
+	if err != nil {
+		panic(err)
 	}
 	defer go_openssl_EVP_MAC_CTX_free(ctx)
 
@@ -121,7 +121,8 @@ func isHMAC3DigestSupported(md _EVP_MD_PTR) bool {
 	}
 	defer go_openssl_OSSL_PARAM_free(params)
 
-	supported := go_openssl_EVP_MAC_CTX_set_params(ctx, params) != 0
+	_, err = go_openssl_EVP_MAC_CTX_set_params(ctx, params)
+	supported := err == nil
 	hmacDigestsSupported.Store(nid, supported)
 	return supported
 }
@@ -140,14 +141,14 @@ func newHMAC3(key []byte, md _EVP_MD_PTR) hmacCtx3 {
 	}
 	defer go_openssl_OSSL_PARAM_free(params)
 
-	ctx := go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
-	if ctx == nil {
-		panic(newOpenSSLError("EVP_MAC_CTX_new"))
+	ctx, err := go_openssl_EVP_MAC_CTX_new(fetchHMAC3())
+	if err != nil {
+		panic(err)
 	}
 
-	if go_openssl_EVP_MAC_init(ctx, base(key), len(key), params) == 0 {
+	if _, err := go_openssl_EVP_MAC_init(ctx, base(key), len(key), params); err != nil {
 		go_openssl_EVP_MAC_CTX_free(ctx)
-		panic(newOpenSSLError("EVP_MAC_init"))
+		panic(err)
 	}
 	var hkey []byte
 	if vMinor == 0 && vPatch <= 2 {
@@ -165,12 +166,12 @@ func newHMAC3(key []byte, md _EVP_MD_PTR) hmacCtx3 {
 func (h *opensslHMAC) Reset() {
 	switch vMajor {
 	case 1:
-		if go_openssl_HMAC_Init_ex(h.ctx1.ctx, nil, 0, nil, nil) == 0 {
-			panic(newOpenSSLError("HMAC_Init_ex failed"))
+		if _, err := go_openssl_HMAC_Init_ex(h.ctx1.ctx, nil, 0, nil, nil); err != nil {
+			panic(err)
 		}
 	case 3:
-		if go_openssl_EVP_MAC_init(h.ctx3.ctx, base(h.ctx3.key), len(h.ctx3.key), nil) == 0 {
-			panic(newOpenSSLError("EVP_MAC_init failed"))
+		if _, err := go_openssl_EVP_MAC_init(h.ctx3.ctx, base(h.ctx3.key), len(h.ctx3.key), nil); err != nil {
+			panic(err)
 		}
 	default:
 		panic(errUnsupportedVersion())
@@ -225,19 +226,19 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	// and the second Sum acts as if the first didn't happen.
 	switch vMajor {
 	case 1:
-		ctx2 := go_openssl_HMAC_CTX_new()
-		if ctx2 == nil {
-			panic("openssl: HMAC_CTX_new failed")
+		ctx2, err := go_openssl_HMAC_CTX_new()
+		if err != nil {
+			panic(err)
 		}
 		defer go_openssl_HMAC_CTX_free(ctx2)
-		if go_openssl_HMAC_CTX_copy(ctx2, h.ctx1.ctx) == 0 {
-			panic("openssl: HMAC_CTX_copy failed")
+		if _, err := go_openssl_HMAC_CTX_copy(ctx2, h.ctx1.ctx); err != nil {
+			panic(err)
 		}
 		go_openssl_HMAC_Final(ctx2, base(h.sum), nil)
 	case 3:
-		ctx2 := go_openssl_EVP_MAC_CTX_dup(h.ctx3.ctx)
-		if ctx2 == nil {
-			panic("openssl: EVP_MAC_CTX_dup failed")
+		ctx2, err := go_openssl_EVP_MAC_CTX_dup(h.ctx3.ctx)
+		if err != nil {
+			panic(err)
 		}
 		defer go_openssl_EVP_MAC_CTX_free(ctx2)
 		go_openssl_EVP_MAC_final(ctx2, base(h.sum), nil, len(h.sum))

--- a/init.go
+++ b/init.go
@@ -27,14 +27,14 @@ func opensslInit(file string) error {
 
 	// Initialize OpenSSL.
 	go_openssl_OPENSSL_init()
-	if go_openssl_OPENSSL_init_crypto(
+	if _, err = go_openssl_OPENSSL_init_crypto(
 		_OPENSSL_INIT_ADD_ALL_CIPHERS|
 			_OPENSSL_INIT_ADD_ALL_DIGESTS|
 			_OPENSSL_INIT_LOAD_CONFIG|
 			_OPENSSL_INIT_LOAD_CRYPTO_STRINGS,
-		nil) != 1 {
+		nil); err != nil {
 		dlclose(handle)
-		return fail("init crypto")
+		return err
 	}
 	osslHandle = handle
 	return nil
@@ -83,14 +83,8 @@ func initForCheckVersion(file string) (func(), error) {
 		dlclose(handle)
 		// Undo all the changes made in this function.
 		mkcgoUnload_version()
-		switch vMajor {
-		case 1:
-			mkcgoUnload_init_1()
-		case 3:
-			mkcgoUnload_init_3()
-		default:
-			panic(errUnsupportedVersion())
-		}
+		mkcgoUnload_init_1()
+		mkcgoUnload_init_3()
 		vMajor, vMinor, vPatch = prevMajor, prevMinor, prevPatch
 		if osslHandle != nil {
 			loadOpenSSLFuncs(osslHandle)

--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -27,14 +27,11 @@ type Enum struct {
 
 // Func describes a function.
 type Func struct {
-	GoName       string
-	CName        string
-	ImportName   string
-	Tags         []TagAttr // if TagAttr.Name is set, it's the import name for the tag
-	Params       []*Param
-	Ret          *Return
-	VariadicInst bool // true if the function is a variadic instantiation
-	Optional     bool
+	FuncAttributes
+	GoName string
+	CName  string
+	Params []*Param
+	Ret    *Return
 }
 
 func (f *Func) Variadic() bool {

--- a/internal/mkcgo/parse.go
+++ b/internal/mkcgo/parse.go
@@ -4,49 +4,77 @@ import (
 	"bufio"
 	"cmp"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
 )
 
-type fnAttributes struct {
-	tags       []TagAttr
-	variadic   bool
-	importName string
-	optional   bool
+type FuncAttributes struct {
+	Tags         []TagAttr
+	VariadicInst bool
+	ImportName   string
+	Optional     bool
+	NoError      bool
+	ErrCond      string
 }
 
 type attribute struct {
 	name        string
 	description string
-	handle      func(*fnAttributes, ...string)
+	handle      func(*FuncAttributes, ...string) error
 }
 
 var attributes = [...]attribute{
 	{
 		name:        "tag",
 		description: "The function will be loaded together with other functions with the same tag. It can contain an optional name, which is the import name for the tag.",
-		handle: func(opts *fnAttributes, s ...string) {
+		handle: func(opts *FuncAttributes, s ...string) error {
 			var name string
 			if len(s) > 1 {
 				name = s[1]
 			}
-			opts.tags = append(opts.tags, TagAttr{Tag: s[0], Name: name})
+			opts.Tags = append(opts.Tags, TagAttr{Tag: s[0], Name: name})
+			return nil
 		},
 	},
 	{
 		name:        "variadic",
 		description: "The function has variadic arguments, and its name is a custom wrapper for the actual C name, defined in this attribute.",
-		handle: func(opts *fnAttributes, s ...string) {
-			opts.variadic = true
-			opts.importName = s[0]
+		handle: func(opts *FuncAttributes, s ...string) error {
+			opts.VariadicInst = true
+			opts.ImportName = s[0]
+			return nil
 		},
 	},
 	{
 		name:        "optional",
 		description: "The function is optional",
-		handle: func(opts *fnAttributes, s ...string) {
-			opts.optional = true
+		handle: func(opts *FuncAttributes, s ...string) error {
+			opts.Optional = true
+			return nil
+		},
+	},
+	{
+		name:        "noerror",
+		description: "The function does not return an error, and the program will panic if the function returns an error.",
+		handle: func(opts *FuncAttributes, s ...string) error {
+			if opts.ErrCond != "" {
+				return errors.New("noerror attribute is not allowed with errcond attribute")
+			}
+			opts.NoError = true
+			return nil
+		},
+	},
+	{
+		name:        "errcond",
+		description: "The function returns an error if the C function returns a value that matches the condition in this attribute.",
+		handle: func(opts *FuncAttributes, s ...string) error {
+			if opts.NoError {
+				return errors.New("errcond attribute is not allowed with noerror attribute")
+			}
+			opts.ErrCond = s[0]
+			return nil
 		},
 	},
 }
@@ -127,7 +155,7 @@ func (src *Source) parseFile(name string) error {
 		}
 
 		// Process attributes.
-		var fnOps fnAttributes
+		var fnOps FuncAttributes
 		line, err = extractFunctionAttributes(line, &fnOps)
 		if err != nil {
 			return err
@@ -180,17 +208,15 @@ func newTypeDef(line string) (*TypeDef, error) {
 }
 
 // newFn parses string s and return created function Fn.
-func newFn(s string, opts fnAttributes) (*Func, error) {
+func newFn(s string, attrs FuncAttributes) (*Func, error) {
 	// function name and args
 	prefix, body, _, found := extractSection(s, "(", ")")
 	if !found || prefix == "" {
 		return nil, errors.New("could not extract function name and parameters from \"" + s + "\"")
 	}
 	fn := &Func{
-		Ret:          &Return{},
-		VariadicInst: opts.variadic,
-		Tags:         opts.tags,
-		Optional:     opts.optional,
+		FuncAttributes: attrs,
+		Ret:            &Return{},
 	}
 	var err error
 	fn.Params, err = extractParams(body)
@@ -204,8 +230,8 @@ func newFn(s string, opts fnAttributes) (*Func, error) {
 	name, typ := prefix[nameIdx+1:], prefix[:nameIdx]
 	name, typ = normalizeParam(name, typ)
 	fn.CName = trim(name)
-	if opts.importName != "" {
-		fn.ImportName = opts.importName
+	if attrs.ImportName != "" {
+		fn.ImportName = attrs.ImportName
 	} else {
 		fn.ImportName = fn.CName
 	}
@@ -309,7 +335,7 @@ func processComments(line string, inBlockComment *bool) (comment, remmaining str
 // extractFunctionAttributes extracts mkcgo attributes from string s.
 // The attributes format follows the GCC __attribute__ syntax as
 // described in https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html.
-func extractFunctionAttributes(s string, fnAttrs *fnAttributes) (string, error) {
+func extractFunctionAttributes(s string, fnAttrs *FuncAttributes) (string, error) {
 	// There can be spaces between __attribute__ and the opening parenthesis.
 	prefix, body, found := strings.Cut(s, "__attribute__")
 	if !found {
@@ -343,7 +369,7 @@ func extractFunctionAttributes(s string, fnAttrs *fnAttributes) (string, error) 
 			name = body[:idxParen]
 			_, args, body, found = extractSection(body[idxParen:], "(", ")")
 			if !found {
-				return "", errors.New("unbalanced parentheses in mkcgo attribute: " + s)
+				return "", errors.New("unbalanced parentheses in line: " + s)
 			}
 			body = strings.TrimPrefix(body, ",")
 		} else if idxComma == -1 && idxParen == -1 {
@@ -361,7 +387,9 @@ func extractFunctionAttributes(s string, fnAttrs *fnAttributes) (string, error) 
 			for i := range vargs {
 				vargs[i] = trim(strings.Trim(vargs[i], `"`))
 			}
-			attr.handle(fnAttrs, vargs...)
+			if err := attr.handle(fnAttrs, vargs...); err != nil {
+				return "", fmt.Errorf("error parsing attribute in line: %v: %w", s, err)
+			}
 			handled = true
 			break
 		}

--- a/openssl.go
+++ b/openssl.go
@@ -195,8 +195,8 @@ func SetFIPS(enable bool) error {
 	}
 	switch vMajor {
 	case 1:
-		if go_openssl_FIPS_mode_set(mode) != 1 {
-			return newOpenSSLError("FIPS_mode_set")
+		if _, err := go_openssl_FIPS_mode_set(mode); err != nil {
+			return err
 		}
 		return nil
 	case 3:
@@ -211,16 +211,14 @@ func SetFIPS(enable bool) error {
 		if !proveSHA256(shaProps) {
 			// There is no provider available that supports the desired FIPS mode.
 			// Try to load the built-in provider associated with the given mode.
-			if go_openssl_OSSL_PROVIDER_try_load(nil, provName.ptr(), 1) == nil {
+			if p, _ := go_openssl_OSSL_PROVIDER_try_load(nil, provName.ptr(), 1); p == nil {
 				// The built-in provider was not loaded successfully, we can't enable FIPS mode.
 				go_openssl_ERR_clear_error()
 				return errors.New("openssl: FIPS mode not supported by any provider")
 			}
 		}
-		if go_openssl_EVP_default_properties_enable_fips(nil, mode) != 1 {
-			return newOpenSSLError("EVP_default_properties_enable_fips")
-		}
-		return nil
+		_, err := go_openssl_EVP_default_properties_enable_fips(nil, mode)
+		return err
 	default:
 		panic(errUnsupportedVersion())
 	}
@@ -229,7 +227,7 @@ func SetFIPS(enable bool) error {
 // sha256Provider returns the provider for the SHA-256 algorithm
 // using the given properties.
 func sha256Provider(props cString) _OSSL_PROVIDER_PTR {
-	md := go_openssl_EVP_MD_fetch(nil, _DigestNameSHA2_256.ptr(), props.ptr())
+	md, _ := go_openssl_EVP_MD_fetch(nil, _DigestNameSHA2_256.ptr(), props.ptr())
 	if md == nil {
 		go_openssl_ERR_clear_error()
 		return nil
@@ -311,7 +309,7 @@ func newOpenSSLError(msg string) error {
 // freed by OPENSSL_free / CRYPTO_free) need to be allocated on the OpenSSL
 // heap.
 func cryptoMalloc(n int) unsafe.Pointer {
-	p := go_openssl_CRYPTO_malloc(n, nil, 0)
+	p, _ := go_openssl_CRYPTO_malloc(n, nil, 0)
 	if p == nil {
 		// Un-recover()-ably crash the program in the same manner as the
 		// C.malloc() wrapper function.
@@ -348,9 +346,9 @@ func wbase(b BigInt) *byte {
 	return (*byte)(unsafe.Pointer(unsafe.SliceData(b)))
 }
 
-func bigToBN(x BigInt) _BIGNUM_PTR {
+func bigToBN(x BigInt) (_BIGNUM_PTR, error) {
 	if len(x) == 0 {
-		return nil
+		return nil, nil
 	}
 	if isBigEndian {
 		z := make(BigInt, len(x))
@@ -360,7 +358,11 @@ func bigToBN(x BigInt) _BIGNUM_PTR {
 	}
 	// Limbs are always ordered in LSB first, so we can safely apply
 	// BN_lebin2bn regardless of host endianness.
-	return go_openssl_BN_lebin2bn(wbase(x), int32(len(x)*wordBytes), nil)
+	bn, err := go_openssl_BN_lebin2bn(wbase(x), int32(len(x)*wordBytes), nil)
+	if err != nil {
+		return nil, err
+	}
+	return bn, nil
 }
 
 func bnToBig(bn _BIGNUM_PTR) BigInt {
@@ -371,8 +373,8 @@ func bnToBig(bn _BIGNUM_PTR) BigInt {
 	// Limbs are always ordered in LSB first, so we can safely apply
 	// BN_bn2lebinpad regardless of host endianness.
 	x := make(BigInt, go_openssl_BN_num_bits(bn))
-	if go_openssl_BN_bn2lebinpad(bn, wbase(x), int32(len(x)*wordBytes)) == 0 {
-		panic("openssl: bignum conversion failed")
+	if _, err := go_openssl_BN_bn2lebinpad(bn, wbase(x), int32(len(x)*wordBytes)); err != nil {
+		panic(err)
 	}
 	if isBigEndian {
 		x.byteSwap()
@@ -384,10 +386,8 @@ func bnToBig(bn _BIGNUM_PTR) BigInt {
 // it at to, padding with zeroes if necessary. If len(to) is not large enough to
 // hold the result, an error is returned.
 func bnToBinPad(bn _BIGNUM_PTR, to []byte) error {
-	if go_openssl_BN_bn2binpad(bn, base(to), int32(len(to))) < 0 {
-		return newOpenSSLError("BN_bn2binpad")
-	}
-	return nil
+	_, err := go_openssl_BN_bn2binpad(bn, base(to), int32(len(to)))
+	return err
 }
 
 func CheckLeaks() {

--- a/params.go
+++ b/params.go
@@ -7,6 +7,15 @@ import (
 	"runtime"
 )
 
+type addParamError struct {
+	name string
+	err  error
+}
+
+func (e addParamError) Error() string {
+	return "failed to add parameter " + e.name + ": " + e.err.Error()
+}
+
 type bnParam struct {
 	value   _BIGNUM_PTR
 	private bool
@@ -26,9 +35,9 @@ type paramBuilder struct {
 
 // newParamBuilder creates a new paramBuilder.
 func newParamBuilder() (*paramBuilder, error) {
-	bld := go_openssl_OSSL_PARAM_BLD_new()
-	if bld == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
+	bld, err := go_openssl_OSSL_PARAM_BLD_new()
+	if err != nil {
+		return nil, err
 	}
 	pb := &paramBuilder{
 		bld:      bld,
@@ -78,9 +87,9 @@ func (b *paramBuilder) build() (_OSSL_PARAM_PTR, error) {
 	if !b.check() {
 		return nil, b.err
 	}
-	param := go_openssl_OSSL_PARAM_BLD_to_param(b.bld)
-	if param == nil {
-		return nil, newOpenSSLError("OSSL_PARAM_BLD_build")
+	param, err := go_openssl_OSSL_PARAM_BLD_to_param(b.bld)
+	if err != nil {
+		return nil, err
 	}
 	return param, nil
 }
@@ -92,8 +101,8 @@ func (b *paramBuilder) addUTF8String(name cString, value *byte, size int) {
 		return
 	}
 	// OSSL_PARAM_BLD_push_utf8_string calculates the size if it is zero.
-	if go_openssl_OSSL_PARAM_BLD_push_utf8_string(b.bld, name.ptr(), value, size) != 1 {
-		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_utf8_string(" + name.str() + ")")
+	if _, err := go_openssl_OSSL_PARAM_BLD_push_utf8_string(b.bld, name.ptr(), value, size); err != nil {
+		b.err = addParamError{name.str(), err}
 	}
 }
 
@@ -106,8 +115,8 @@ func (b *paramBuilder) addOctetString(name cString, value []byte) {
 	if len(value) != 0 {
 		b.pinner.Pin(&value[0])
 	}
-	if go_openssl_OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), pbase(value), len(value)) != 1 {
-		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_octet_string(" + name.str() + ")")
+	if _, err := go_openssl_OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), pbase(value), len(value)); err != nil {
+		b.err = addParamError{name.str(), err}
 	}
 }
 
@@ -116,8 +125,8 @@ func (b *paramBuilder) addInt32(name cString, value int32) {
 	if !b.check() {
 		return
 	}
-	if go_openssl_OSSL_PARAM_BLD_push_int32(b.bld, name.ptr(), value) != 1 {
-		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_int32(" + name.str() + ")")
+	if _, err := go_openssl_OSSL_PARAM_BLD_push_int32(b.bld, name.ptr(), value); err != nil {
+		b.err = addParamError{name.str(), err}
 	}
 }
 
@@ -126,8 +135,8 @@ func (b *paramBuilder) addBN(name cString, value _BIGNUM_PTR) {
 	if !b.check() {
 		return
 	}
-	if go_openssl_OSSL_PARAM_BLD_push_BN(b.bld, name.ptr(), value) != 1 {
-		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_BN(" + name.str() + ")")
+	if _, err := go_openssl_OSSL_PARAM_BLD_push_BN(b.bld, name.ptr(), value); err != nil {
+		b.err = addParamError{name.str(), err}
 	}
 }
 
@@ -143,9 +152,9 @@ func (b *paramBuilder) addBin(name cString, value []byte, private bool) {
 		// Nothing to do.
 		return
 	}
-	bn := go_openssl_BN_bin2bn(base(value), int32(len(value)), nil)
-	if bn == nil {
-		b.err = newOpenSSLError("BN_bin2bn")
+	bn, err := go_openssl_BN_bin2bn(base(value), int32(len(value)), nil)
+	if err != nil {
+		b.err = err
 		return
 	}
 	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
@@ -164,9 +173,9 @@ func (b *paramBuilder) addBigInt(name cString, value BigInt, private bool) {
 		// Nothing to do.
 		return
 	}
-	bn := bigToBN(value)
-	if bn == nil {
-		b.err = newOpenSSLError("bigToBN")
+	bn, err := bigToBN(value)
+	if err != nil {
+		b.err = err
 		return
 	}
 	b.bnToFree = append(b.bnToFree, bnParam{bn, private})

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -28,9 +28,9 @@ func SupportsPBKDF2() bool {
 var fetchPBKDF2 = sync.OnceValues(func() (_EVP_KDF_PTR, error) {
 	checkMajorVersion(3)
 
-	kdf := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_PBKDF2.ptr(), nil)
-	if kdf == nil {
-		return nil, newOpenSSLError("EVP_KDF_fetch")
+	kdf, err := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_PBKDF2.ptr(), nil)
+	if err != nil {
+		return nil, err
 	}
 	return kdf, nil
 })
@@ -45,9 +45,9 @@ func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byt
 		return nil, errors.New("unsupported hash function")
 	}
 	out := make([]byte, keyLen)
-	ok := go_openssl_PKCS5_PBKDF2_HMAC(base(password), int32(len(password)), base(salt), int32(len(salt)), int32(iter), md, int32(keyLen), base(out))
-	if ok != 1 {
-		return nil, newOpenSSLError("PKCS5_PBKDF2_HMAC")
+	_, err = go_openssl_PKCS5_PBKDF2_HMAC(base(password), int32(len(password)), base(salt), int32(len(salt)), int32(iter), md, int32(keyLen), base(out))
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/rand.go
+++ b/rand.go
@@ -7,10 +7,13 @@ import "C"
 type randReader int
 
 func (randReader) Read(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
 	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
 	// We check it even so.
-	if len(b) > 0 && go_openssl_RAND_bytes(base(b), int32(len(b))) == 0 {
-		return 0, newOpenSSLError("RAND_bytes")
+	if _, err := go_openssl_RAND_bytes(base(b), int32(len(b))); err != nil {
+		return 0, err
 	}
 	return len(b), nil
 }

--- a/rc4.go
+++ b/rc4.go
@@ -55,8 +55,8 @@ func (c *RC4Cipher) XORKeyStream(dst, src []byte) {
 	// which is what crypto/rc4 does.
 	_ = dst[len(src)-1]
 	var outLen int32
-	if go_openssl_EVP_EncryptUpdate(c.ctx, base(dst), &outLen, base(src), int32(len(src))) != 1 {
-		panic("crypto/cipher: EncryptUpdate failed")
+	if _, err := go_openssl_EVP_EncryptUpdate(c.ctx, base(dst), &outLen, base(src), int32(len(src))); err != nil {
+		panic("crypto/rc4: " + err.Error())
 	}
 	if int(outLen) != len(src) {
 		panic("crypto/rc4: src not fully XORed")

--- a/rsa.go
+++ b/rsa.go
@@ -120,7 +120,7 @@ func (k *PublicKeyRSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyRSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PublicKeyRSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
@@ -199,7 +199,7 @@ func (k *PrivateKeyRSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyRSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
+func (k *PrivateKeyRSA) withKey(f func(_EVP_PKEY_PTR) error) error {
 	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
@@ -301,15 +301,16 @@ func HashSignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte) ([]byte
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
 	defer runtime.KeepAlive(pub)
-	if _, err := pub.withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
-		size, err := go_openssl_EVP_PKEY_get_size(pkey)
+	var size int32
+	if err := pub.withKey(func(pkey _EVP_PKEY_PTR) (err error) {
+		size, err = go_openssl_EVP_PKEY_get_size(pkey)
 		if err != nil {
-			return 0, err
+			return err
 		}
 		if len(sig) < int(size) {
-			return 0, errors.New("crypto/rsa: verification error")
+			return errors.New("crypto/rsa: verification error")
 		}
-		return 0, nil
+		return nil
 	}); err != nil {
 		return err
 	}

--- a/rsa.go
+++ b/rsa.go
@@ -23,9 +23,9 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 	defer go_openssl_EVP_PKEY_free(pkey)
 	switch vMajor {
 	case 1:
-		key := go_openssl_EVP_PKEY_get1_RSA(pkey)
-		if key == nil {
-			return bad(newOpenSSLError("EVP_PKEY_get1_RSA failed"))
+		key, err := go_openssl_EVP_PKEY_get1_RSA(pkey)
+		if err != nil {
+			return bad(err)
 		}
 		defer go_openssl_RSA_free(key)
 		var n, e, d, p, q, dmp1, dmq1, iqmp _BIGNUM_PTR
@@ -36,20 +36,18 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		P, Q = bnToBig(p), bnToBig(q)
 		Dp, Dq, Qinv = bnToBig(dmp1), bnToBig(dmq1), bnToBig(iqmp)
 	case 3:
-		tmp := go_openssl_BN_new()
-		if tmp == nil {
-			return bad(newOpenSSLError("BN_new failed"))
+		tmp, err := go_openssl_BN_new()
+		if err != nil {
+			return bad(err)
 		}
 		defer func() {
 			go_openssl_BN_clear_free(tmp)
 		}()
-		var err error
 		setBigInt := func(bi *BigInt, param cString) bool {
 			if err != nil {
 				return false
 			}
-			if go_openssl_EVP_PKEY_get_bn_param(pkey, param.ptr(), &tmp) != 1 {
-				err = newOpenSSLError("EVP_PKEY_get_bn_param failed")
+			if _, err = go_openssl_EVP_PKEY_get_bn_param(pkey, param.ptr(), &tmp); err != nil {
 				return false
 			}
 			*bi = bnToBig(tmp)
@@ -81,22 +79,29 @@ func NewPublicKeyRSA(n, e BigInt) (*PublicKeyRSA, error) {
 	var pkey _EVP_PKEY_PTR
 	switch vMajor {
 	case 1:
-		key := go_openssl_RSA_new()
-		if key == nil {
-			return nil, newOpenSSLError("RSA_new failed")
+		key, err := go_openssl_RSA_new()
+		if err != nil {
+			return nil, err
 		}
-		if go_openssl_RSA_set0_key(key, bigToBN(n), bigToBN(e), nil) != 1 {
-			return nil, fail("RSA_set0_key")
-		}
-		pkey = go_openssl_EVP_PKEY_new()
-		if pkey == nil {
+		// No need to check for errors here, RSA_set0_* functions will fail
+		// if the BNs are NULL and we will free non-NULL BNs in the error handling.
+		bn, _ := bigToBN(n)
+		be, _ := bigToBN(e)
+		if _, err := go_openssl_RSA_set0_key(key, bn, be, nil); err != nil {
+			go_openssl_BN_free(bn)
+			go_openssl_BN_free(be)
 			go_openssl_RSA_free(key)
-			return nil, newOpenSSLError("EVP_PKEY_new failed")
+			return nil, err
 		}
-		if go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		pkey, err = go_openssl_EVP_PKEY_new()
+		if err != nil {
+			go_openssl_RSA_free(key)
+			return nil, err
+		}
+		if _, err := go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_RSA, (unsafe.Pointer)(key)); err != nil {
 			go_openssl_RSA_free(key)
 			go_openssl_EVP_PKEY_free(pkey)
-			return nil, newOpenSSLError("EVP_PKEY_assign failed")
+			return nil, err
 		}
 	case 3:
 		var err error
@@ -115,7 +120,7 @@ func (k *PublicKeyRSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PublicKeyRSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PublicKeyRSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
@@ -132,32 +137,50 @@ func NewPrivateKeyRSA(n, e, d, p, q, dp, dq, qinv BigInt) (*PrivateKeyRSA, error
 	var pkey _EVP_PKEY_PTR
 	switch vMajor {
 	case 1:
-		key := go_openssl_RSA_new()
-		if key == nil {
-			return nil, newOpenSSLError("RSA_new failed")
+		key, err := go_openssl_RSA_new()
+		if err != nil {
+			return nil, err
 		}
-		if go_openssl_RSA_set0_key(key, bigToBN(n), bigToBN(e), bigToBN(d)) != 1 {
-			return nil, fail("RSA_set0_key")
+		// No need to check for errors here, RSA_set0_* functions will fail
+		// if the BNs are NULL and we will free non-NULL BNs in the error handling.
+		bn, _ := bigToBN(n)
+		be, _ := bigToBN(e)
+		bd, _ := bigToBN(d)
+		if _, err := go_openssl_RSA_set0_key(key, bn, be, bd); err != nil {
+			go_openssl_BN_free(bn)
+			go_openssl_BN_free(be)
+			go_openssl_BN_clear_free(bd)
+			return nil, err
 		}
 		if p != nil && q != nil {
-			if go_openssl_RSA_set0_factors(key, bigToBN(p), bigToBN(q)) != 1 {
-				return nil, fail("RSA_set0_factors")
+			bp, _ := bigToBN(p)
+			bq, _ := bigToBN(q)
+			if _, err := go_openssl_RSA_set0_factors(key, bp, bq); err != nil {
+				go_openssl_BN_clear_free(bp)
+				go_openssl_BN_clear_free(bq)
+				return nil, err
 			}
 		}
 		if dp != nil && dq != nil && qinv != nil {
-			if go_openssl_RSA_set0_crt_params(key, bigToBN(dp), bigToBN(dq), bigToBN(qinv)) != 1 {
-				return nil, fail("RSA_set0_crt_params")
+			bdp, _ := bigToBN(dp)
+			bdq, _ := bigToBN(dq)
+			bqinv, _ := bigToBN(qinv)
+			if _, err := go_openssl_RSA_set0_crt_params(key, bdp, bdq, bqinv); err != nil {
+				go_openssl_BN_free(bdp)
+				go_openssl_BN_free(bdq)
+				go_openssl_BN_free(bqinv)
+				return nil, err
 			}
 		}
-		pkey = go_openssl_EVP_PKEY_new()
-		if pkey == nil {
+		pkey, err = go_openssl_EVP_PKEY_new()
+		if err != nil {
 			go_openssl_RSA_free(key)
-			return nil, newOpenSSLError("EVP_PKEY_new failed")
+			return nil, err
 		}
-		if go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_RSA, (unsafe.Pointer)(key)) != 1 {
+		if _, err := go_openssl_EVP_PKEY_assign(pkey, _EVP_PKEY_RSA, (unsafe.Pointer)(key)); err != nil {
 			go_openssl_RSA_free(key)
 			go_openssl_EVP_PKEY_free(pkey)
-			return nil, newOpenSSLError("EVP_PKEY_assign failed")
+			return nil, err
 		}
 	case 3:
 		var err error
@@ -176,7 +199,7 @@ func (k *PrivateKeyRSA) finalize() {
 	go_openssl_EVP_PKEY_free(k._pkey)
 }
 
-func (k *PrivateKeyRSA) withKey(f func(_EVP_PKEY_PTR) int32) int32 {
+func (k *PrivateKeyRSA) withKey(f func(_EVP_PKEY_PTR) (int32, error)) (int32, error) {
 	// Because of the finalizer, any time _pkey is passed to cgo, that call must
 	// be followed by a call to runtime.KeepAlive, to make sure k is not
 	// collected (and finalized) before the cgo call returns.
@@ -277,14 +300,18 @@ func HashSignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte) ([]byte
 }
 
 func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
-	if pub.withKey(func(pkey _EVP_PKEY_PTR) int32 {
-		size := go_openssl_EVP_PKEY_get_size(pkey)
-		if len(sig) < int(size) {
-			return 0
+	defer runtime.KeepAlive(pub)
+	if _, err := pub.withKey(func(pkey _EVP_PKEY_PTR) (int32, error) {
+		size, err := go_openssl_EVP_PKEY_get_size(pkey)
+		if err != nil {
+			return 0, err
 		}
-		return 1
-	}) == 0 {
-		return errors.New("crypto/rsa: verification error")
+		if len(sig) < int(size) {
+			return 0, errors.New("crypto/rsa: verification error")
+		}
+		return 0, nil
+	}); err != nil {
+		return err
 	}
 	return evpVerify(pub.withKey, _RSA_PKCS1_PADDING, 0, h, sig, hashed)
 }

--- a/shims.h
+++ b/shims.h
@@ -120,34 +120,34 @@ typedef int point_conversion_form_t;
 // ERR API
 void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 void ERR_clear_error(void) __attribute__((tag(""),tag("init_3")));
-unsigned long ERR_get_error_line(const char **file, int *line) __attribute__((tag("legacy_1")));
-unsigned long ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags) __attribute__((tag("3")));
+unsigned long ERR_get_error_line(const char **file, int *line) __attribute__((tag("legacy_1"),noerror));
+unsigned long ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags) __attribute__((tag("3"),noerror));
 
 // OPENSSL API
-const char *OpenSSL_version(int type);
+const char *OpenSSL_version(int type) __attribute__((noerror));
 void OPENSSL_init(void);
 int OPENSSL_init_crypto(uint64_t ops, const _OPENSSL_INIT_SETTINGS_PTR settings);
-unsigned long OpenSSL_version_num(void) __attribute__((tag("version"),optional));
-unsigned int OPENSSL_version_major(void) __attribute__((tag("version"),optional));
-unsigned int OPENSSL_version_minor(void) __attribute__((tag("version"),optional));
-unsigned int OPENSSL_version_patch(void) __attribute__((tag("version"),optional));
+unsigned long OpenSSL_version_num(void) __attribute__((tag("version"),optional,noerror));
+unsigned int OPENSSL_version_major(void) __attribute__((tag("version"),optional,noerror));
+unsigned int OPENSSL_version_minor(void) __attribute__((tag("version"),optional,noerror));
+unsigned int OPENSSL_version_patch(void) __attribute__((tag("version"),optional,noerror));
 
 // CRYPTO API
 void *CRYPTO_malloc(size_t num, const char *file, int line);
 void CRYPTO_free(void *str, const char *file, int line);
 
 // FIPS API
-int FIPS_mode(void) __attribute__((tag("legacy_1"),tag("init_1")));
+int FIPS_mode(void) __attribute__((tag("legacy_1"),tag("init_1"),noerror));
 int FIPS_mode_set(int r) __attribute__((tag("legacy_1"),tag("init_1")));
 
 // EVP Config API
-int EVP_default_properties_is_fips_enabled(_OSSL_LIB_CTX_PTR libctx) __attribute__((tag("3"),tag("init_3")));
+int EVP_default_properties_is_fips_enabled(_OSSL_LIB_CTX_PTR libctx) __attribute__((tag("3"),tag("init_3"),noerror));
 int EVP_default_properties_enable_fips(_OSSL_LIB_CTX_PTR libctx, int enable) __attribute__((tag("3")));
 
 // OSSL_PROVIDER API
-int OSSL_PROVIDER_available(_OSSL_LIB_CTX_PTR libctx, const char *name) __attribute__((tag("3")));
+int OSSL_PROVIDER_available(_OSSL_LIB_CTX_PTR libctx, const char *name) __attribute__((tag("3"),noerror));
 _OSSL_PROVIDER_PTR OSSL_PROVIDER_try_load(_OSSL_LIB_CTX_PTR libctx, const char *name, int retain_fallbacks) __attribute__((tag("3")));
-const char *OSSL_PROVIDER_get0_name(const _OSSL_PROVIDER_PTR prov) __attribute__((tag("3")));
+const char *OSSL_PROVIDER_get0_name(const _OSSL_PROVIDER_PTR prov) __attribute__((tag("3"),noerror));
 
 // RAND API
 int RAND_bytes(unsigned char *arg0, int arg1);
@@ -155,26 +155,26 @@ int RAND_bytes(unsigned char *arg0, int arg1);
 // EVP_MD API
 _EVP_MD_PTR EVP_MD_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3"),tag("init_3")));
 void EVP_MD_free(_EVP_MD_PTR md) __attribute__((tag("3"),tag("init_3")));
-const char *EVP_MD_get0_name(const _EVP_MD_PTR md) __attribute__((tag("3")));
-int EVP_MD_get_type(const _EVP_MD_PTR md) __attribute__((tag("3")));
-const _OSSL_PROVIDER_PTR EVP_MD_get0_provider(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("init_3")));
-int EVP_MD_get_size(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("legacy_1","EVP_MD_size")));
-int EVP_MD_get_block_size(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("legacy_1","EVP_MD_block_size")));
-const _EVP_MD_PTR EVP_md5_sha1(void);
-const _EVP_MD_PTR EVP_ripemd160(void);
-const _EVP_MD_PTR EVP_md4(void);
-const _EVP_MD_PTR EVP_md5(void);
-const _EVP_MD_PTR EVP_sha1(void);
-const _EVP_MD_PTR EVP_sha224(void);
-const _EVP_MD_PTR EVP_sha256(void);
-const _EVP_MD_PTR EVP_sha384(void);
-const _EVP_MD_PTR EVP_sha512(void);
-const _EVP_MD_PTR EVP_sha512_224(void) __attribute__((tag("111")));
-const _EVP_MD_PTR EVP_sha512_256(void) __attribute__((tag("111")));
-const _EVP_MD_PTR EVP_sha3_224(void) __attribute__((tag("111")));
-const _EVP_MD_PTR EVP_sha3_256(void) __attribute__((tag("111")));
-const _EVP_MD_PTR EVP_sha3_384(void) __attribute__((tag("111")));
-const _EVP_MD_PTR EVP_sha3_512(void) __attribute__((tag("111")));
+const char *EVP_MD_get0_name(const _EVP_MD_PTR md) __attribute__((tag("3"),noerror));
+int EVP_MD_get_type(const _EVP_MD_PTR md) __attribute__((tag("3"),noerror));
+const _OSSL_PROVIDER_PTR EVP_MD_get0_provider(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("init_3"),noerror));
+int EVP_MD_get_size(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("legacy_1","EVP_MD_size"),noerror));
+int EVP_MD_get_block_size(const _EVP_MD_PTR md) __attribute__((tag("3"),tag("legacy_1","EVP_MD_block_size"),noerror));
+const _EVP_MD_PTR EVP_md5_sha1(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_ripemd160(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_md4(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_md5(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha1(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha224(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha256(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha384(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha512(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha512_224(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha512_256(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha3_224(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha3_256(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha3_384(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha3_512(void) __attribute__((tag("111"),noerror));
 
 _EVP_MD_CTX_PTR EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(_EVP_MD_CTX_PTR ctx);
@@ -203,25 +203,25 @@ void HMAC_CTX_free(_HMAC_CTX_PTR arg0) __attribute__((tag("legacy_1")));
 
 // EVP_CIPHER API
 _EVP_CIPHER_PTR EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3")));
-const char *EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR cipher) __attribute__((tag("3")));
-const _EVP_CIPHER_PTR EVP_aes_128_gcm(void);
-const _EVP_CIPHER_PTR EVP_aes_128_cbc(void);
-const _EVP_CIPHER_PTR EVP_aes_128_ctr(void);
-const _EVP_CIPHER_PTR EVP_aes_128_ecb(void);
-const _EVP_CIPHER_PTR EVP_aes_192_gcm(void);
-const _EVP_CIPHER_PTR EVP_aes_192_cbc(void);
-const _EVP_CIPHER_PTR EVP_aes_192_ctr(void);
-const _EVP_CIPHER_PTR EVP_aes_192_ecb(void);
-const _EVP_CIPHER_PTR EVP_aes_256_cbc(void);
-const _EVP_CIPHER_PTR EVP_aes_256_ctr(void);
-const _EVP_CIPHER_PTR EVP_aes_256_ecb(void);
-const _EVP_CIPHER_PTR EVP_aes_256_gcm(void);
-const _EVP_CIPHER_PTR EVP_des_ecb(void);
-const _EVP_CIPHER_PTR EVP_des_cbc(void);
-const _EVP_CIPHER_PTR EVP_des_ede3_ecb(void);
-const _EVP_CIPHER_PTR EVP_des_ede3_cbc(void);
-const _EVP_CIPHER_PTR EVP_rc4(void);
-int EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR cipher) __attribute__((tag("3"),tag("legacy_1","EVP_CIPHER_block_size")));
+const char *EVP_CIPHER_get0_name(const _EVP_CIPHER_PTR cipher) __attribute__((tag("3"),noerror));
+const _EVP_CIPHER_PTR EVP_aes_128_gcm(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_128_cbc(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_128_ctr(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_128_ecb(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_192_gcm(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_192_cbc(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_192_ctr(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_192_ecb(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_256_cbc(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_256_ctr(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_256_ecb(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_aes_256_gcm(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_des_ecb(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_des_cbc(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_des_ede3_ecb(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_des_ede3_cbc(void) __attribute__((noerror));
+const _EVP_CIPHER_PTR EVP_rc4(void) __attribute__((noerror));
+int EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR cipher) __attribute__((tag("3"),tag("legacy_1","EVP_CIPHER_block_size"),noerror));
 
 _EVP_CIPHER_CTX_PTR EVP_CIPHER_CTX_new(void);
 int EVP_CIPHER_CTX_set_padding(_EVP_CIPHER_CTX_PTR x, int padding);
@@ -294,31 +294,31 @@ int EVP_PKEY_CTX_add1_hkdf_info(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg
 // RSA API
 _RSA_PTR RSA_new(void) __attribute__((tag("legacy_1")));
 void RSA_free(_RSA_PTR arg0) __attribute__((tag("legacy_1")));
+void RSA_get0_factors(const _RSA_PTR rsa, const _BIGNUM_PTR *p, const _BIGNUM_PTR *q) __attribute__((tag("legacy_1"),noerror));
 int RSA_set0_factors(_RSA_PTR rsa, _BIGNUM_PTR p, _BIGNUM_PTR q) __attribute__((tag("legacy_1")));
+void RSA_get0_crt_params(const _RSA_PTR r, const _BIGNUM_PTR *dmp1, const _BIGNUM_PTR *dmq1, const _BIGNUM_PTR *iqmp) __attribute__((tag("legacy_1"),noerror));
 int RSA_set0_crt_params(_RSA_PTR rsa, _BIGNUM_PTR dmp1, _BIGNUM_PTR dmp2, _BIGNUM_PTR iqmp) __attribute__((tag("legacy_1")));
-void RSA_get0_crt_params(const _RSA_PTR r, const _BIGNUM_PTR *dmp1, const _BIGNUM_PTR *dmq1, const _BIGNUM_PTR *iqmp) __attribute__((tag("legacy_1")));
+void RSA_get0_key(const _RSA_PTR rsa, const _BIGNUM_PTR *n, const _BIGNUM_PTR *e, const _BIGNUM_PTR *d) __attribute__((tag("legacy_1"),noerror));
 int RSA_set0_key(_RSA_PTR r, _BIGNUM_PTR n, _BIGNUM_PTR e, _BIGNUM_PTR d) __attribute__((tag("legacy_1")));
-void RSA_get0_factors(const _RSA_PTR rsa, const _BIGNUM_PTR *p, const _BIGNUM_PTR *q) __attribute__((tag("legacy_1")));
-void RSA_get0_key(const _RSA_PTR rsa, const _BIGNUM_PTR *n, const _BIGNUM_PTR *e, const _BIGNUM_PTR *d) __attribute__((tag("legacy_1")));
 
 // BIGNUM API
 _BIGNUM_PTR BN_new(void);
 void BN_free(_BIGNUM_PTR arg0);
 void BN_clear(_BIGNUM_PTR arg0);
 void BN_clear_free(_BIGNUM_PTR arg0);
-int BN_num_bits(const _BIGNUM_PTR arg0);
+int BN_num_bits(const _BIGNUM_PTR arg0) __attribute__((noerror));
 _BIGNUM_PTR BN_bin2bn(const unsigned char *arg0, int arg1, _BIGNUM_PTR arg2);
 _BIGNUM_PTR BN_lebin2bn(const unsigned char *s, int len, _BIGNUM_PTR ret);
-int BN_bn2lebinpad(const _BIGNUM_PTR a, unsigned char *to, int tolen);
-int BN_bn2binpad(const _BIGNUM_PTR a, unsigned char *to, int tolen);
+int BN_bn2lebinpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1")));
+int BN_bn2binpad(const _BIGNUM_PTR a, unsigned char *to, int tolen) __attribute__((errcond("== -1")));
 
 // EC API
 int EC_KEY_set_public_key_affine_coordinates(_EC_KEY_PTR key, _BIGNUM_PTR x, _BIGNUM_PTR y) __attribute__((tag("legacy_1")));
 int EC_KEY_set_public_key(_EC_KEY_PTR key, const _EC_POINT_PTR pub) __attribute__((tag("legacy_1")));
 void EC_KEY_free(_EC_KEY_PTR arg0) __attribute__((tag("legacy_1")));
-const _EC_GROUP_PTR EC_KEY_get0_group(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1")));
-const _BIGNUM_PTR EC_KEY_get0_private_key(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1")));
-const _EC_POINT_PTR EC_KEY_get0_public_key(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1")));
+const _EC_GROUP_PTR EC_KEY_get0_group(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1"),noerror));
+const _BIGNUM_PTR EC_KEY_get0_private_key(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1"),noerror));
+const _EC_POINT_PTR EC_KEY_get0_public_key(const _EC_KEY_PTR arg0) __attribute__((tag("legacy_1"),noerror));
 _EC_KEY_PTR EC_KEY_new_by_curve_name(int arg0) __attribute__((tag("legacy_1")));
 int EC_KEY_set_private_key(_EC_KEY_PTR arg0, const _BIGNUM_PTR arg1) __attribute__((tag("legacy_1")));
 int EC_KEY_check_key(const _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
@@ -376,4 +376,4 @@ int EVP_KDF_derive(_EVP_KDF_CTX_PTR ctx, unsigned char *key, size_t keylen, cons
 int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const _EVP_MD_PTR digest, int keylen, unsigned char *out);
 
 // OBJ API
-const char *OBJ_nid2sn(int n);
+const char *OBJ_nid2sn(int n) __attribute__((noerror));

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -60,44 +60,44 @@ func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
 func tls1PRF1(result, secret, label, seed []byte, md _EVP_MD_PTR) error {
 	checkMajorVersion(1)
 
-	ctx := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_TLS1_PRF, nil)
-	if ctx == nil {
-		return newOpenSSLError("EVP_PKEY_CTX_new_id")
+	ctx, err := go_openssl_EVP_PKEY_CTX_new_id(_EVP_PKEY_TLS1_PRF, nil)
+	if err != nil {
+		return err
 	}
 	defer func() {
 		go_openssl_EVP_PKEY_CTX_free(ctx)
 	}()
 
-	if go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
-		return newOpenSSLError("EVP_PKEY_derive_init")
+	if _, err := go_openssl_EVP_PKEY_derive_init(ctx); err != nil {
+		return err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
 		_EVP_PKEY_OP_DERIVE,
 		_EVP_PKEY_CTRL_TLS_MD,
-		0, unsafe.Pointer(md)) != 1 {
-		return newOpenSSLError("EVP_PKEY_CTX_set_tls1_prf_md")
+		0, unsafe.Pointer(md)); err != nil {
+		return err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
 		_EVP_PKEY_OP_DERIVE,
 		_EVP_PKEY_CTRL_TLS_SECRET,
-		int32(len(secret)), unsafe.Pointer(base(secret))) != 1 {
-		return newOpenSSLError("EVP_PKEY_CTX_set1_tls1_prf_secret")
+		int32(len(secret)), unsafe.Pointer(base(secret))); err != nil {
+		return err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
 		_EVP_PKEY_OP_DERIVE,
 		_EVP_PKEY_CTRL_TLS_SEED,
-		int32(len(label)), unsafe.Pointer(base(label))) != 1 {
-		return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
+		int32(len(label)), unsafe.Pointer(base(label))); err != nil {
+		return err
 	}
-	if go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+	if _, err := go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
 		_EVP_PKEY_OP_DERIVE,
 		_EVP_PKEY_CTRL_TLS_SEED,
-		int32(len(seed)), unsafe.Pointer(base(seed))) != 1 {
-		return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
+		int32(len(seed)), unsafe.Pointer(base(seed))); err != nil {
+		return err
 	}
 	outLen := len(result)
-	if go_openssl_EVP_PKEY_derive(ctx, base(result), &outLen) != 1 {
-		return newOpenSSLError("EVP_PKEY_derive")
+	if _, err := go_openssl_EVP_PKEY_derive(ctx, base(result), &outLen); err != nil {
+		return err
 	}
 	// The Go standard library expects TLS1PRF to return the requested number of bytes,
 	// fail if it doesn't. While there is no known situation where this will happen,
@@ -115,9 +115,9 @@ func tls1PRF1(result, secret, label, seed []byte, md _EVP_MD_PTR) error {
 var fetchTLS1PRF3 = sync.OnceValues(func() (_EVP_KDF_PTR, error) {
 	checkMajorVersion(3)
 
-	kdf := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS1_PRF.ptr(), nil)
-	if kdf == nil {
-		return nil, newOpenSSLError("EVP_KDF_fetch")
+	kdf, err := go_openssl_EVP_KDF_fetch(nil, _OSSL_KDF_NAME_TLS1_PRF.ptr(), nil)
+	if err != nil {
+		return nil, err
 	}
 	return kdf, nil
 })
@@ -130,9 +130,9 @@ func tls1PRF3(result, secret, label, seed []byte, md _EVP_MD_PTR) error {
 	if err != nil {
 		return err
 	}
-	ctx := go_openssl_EVP_KDF_CTX_new(kdf)
-	if ctx == nil {
-		return newOpenSSLError("EVP_KDF_CTX_new")
+	ctx, err := go_openssl_EVP_KDF_CTX_new(kdf)
+	if err != nil {
+		return err
 	}
 	defer go_openssl_EVP_KDF_CTX_free(ctx)
 
@@ -150,8 +150,8 @@ func tls1PRF3(result, secret, label, seed []byte, md _EVP_MD_PTR) error {
 	}
 	defer go_openssl_OSSL_PARAM_free(params)
 
-	if go_openssl_EVP_KDF_derive(ctx, base(result), len(result), params) != 1 {
-		return newOpenSSLError("EVP_KDF_derive")
+	if _, err := go_openssl_EVP_KDF_derive(ctx, base(result), len(result), params); err != nil {
+		return err
 	}
 	return nil
 }

--- a/zossl.go
+++ b/zossl.go
@@ -162,16 +162,31 @@ func mkcgoUnload_version() {
 	C.__mkcgoUnload_version()
 }
 
-func go_openssl_BN_bin2bn(arg0 *byte, arg1 int32, arg2 _BIGNUM_PTR) _BIGNUM_PTR {
-	return C.BN_bin2bn((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1), arg2)
+func go_openssl_BN_bin2bn(arg0 *byte, arg1 int32, arg2 _BIGNUM_PTR) (_BIGNUM_PTR, error) {
+	_ret := C.BN_bin2bn((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1), arg2)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("BN_bin2bn")
+	}
+	return _ret, _err
 }
 
-func go_openssl_BN_bn2binpad(a _BIGNUM_PTR, to *byte, tolen int32) int32 {
-	return int32(C.BN_bn2binpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen)))
+func go_openssl_BN_bn2binpad(a _BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
+	_ret := C.BN_bn2binpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen))
+	var _err error
+	if _ret == -1 {
+		_err = newOpenSSLError("BN_bn2binpad")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_BN_bn2lebinpad(a _BIGNUM_PTR, to *byte, tolen int32) int32 {
-	return int32(C.BN_bn2lebinpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen)))
+func go_openssl_BN_bn2lebinpad(a _BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
+	_ret := C.BN_bn2lebinpad(a, (*C.uchar)(unsafe.Pointer(to)), C.int(tolen))
+	var _err error
+	if _ret == -1 {
+		_err = newOpenSSLError("BN_bn2lebinpad")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_BN_clear(arg0 _BIGNUM_PTR) {
@@ -186,12 +201,22 @@ func go_openssl_BN_free(arg0 _BIGNUM_PTR) {
 	C.BN_free(arg0)
 }
 
-func go_openssl_BN_lebin2bn(s *byte, len int32, ret _BIGNUM_PTR) _BIGNUM_PTR {
-	return C.BN_lebin2bn((*C.uchar)(unsafe.Pointer(s)), C.int(len), ret)
+func go_openssl_BN_lebin2bn(s *byte, len int32, ret _BIGNUM_PTR) (_BIGNUM_PTR, error) {
+	_ret := C.BN_lebin2bn((*C.uchar)(unsafe.Pointer(s)), C.int(len), ret)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("BN_lebin2bn")
+	}
+	return _ret, _err
 }
 
-func go_openssl_BN_new() _BIGNUM_PTR {
-	return C.BN_new()
+func go_openssl_BN_new() (_BIGNUM_PTR, error) {
+	_ret := C.BN_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("BN_new")
+	}
+	return _ret, _err
 }
 
 func go_openssl_BN_num_bits(arg0 _BIGNUM_PTR) int32 {
@@ -202,16 +227,26 @@ func go_openssl_CRYPTO_free(str unsafe.Pointer, file *byte, line int32) {
 	C.CRYPTO_free(str, (*C.char)(unsafe.Pointer(file)), C.int(line))
 }
 
-func go_openssl_CRYPTO_malloc(num int, file *byte, line int32) unsafe.Pointer {
-	return unsafe.Pointer(C.CRYPTO_malloc(C.size_t(num), (*C.char)(unsafe.Pointer(file)), C.int(line)))
+func go_openssl_CRYPTO_malloc(num int, file *byte, line int32) (unsafe.Pointer, error) {
+	_ret := C.CRYPTO_malloc(C.size_t(num), (*C.char)(unsafe.Pointer(file)), C.int(line))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("CRYPTO_malloc")
+	}
+	return _ret, _err
 }
 
 func go_openssl_DSA_free(r _DSA_PTR) {
 	C.DSA_free(r)
 }
 
-func go_openssl_DSA_generate_key(a _DSA_PTR) int32 {
-	return int32(C.DSA_generate_key(a))
+func go_openssl_DSA_generate_key(a _DSA_PTR) (int32, error) {
+	_ret := C.DSA_generate_key(a)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("DSA_generate_key")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_DSA_get0_key(d _DSA_PTR, pub_key *_BIGNUM_PTR, priv_key *_BIGNUM_PTR) {
@@ -222,28 +257,53 @@ func go_openssl_DSA_get0_pqg(d _DSA_PTR, p *_BIGNUM_PTR, q *_BIGNUM_PTR, g *_BIG
 	C.DSA_get0_pqg(d, p, q, g)
 }
 
-func go_openssl_DSA_new() _DSA_PTR {
-	return C.DSA_new()
+func go_openssl_DSA_new() (_DSA_PTR, error) {
+	_ret := C.DSA_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("DSA_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_DSA_set0_key(d _DSA_PTR, pub_key _BIGNUM_PTR, priv_key _BIGNUM_PTR) int32 {
-	return int32(C.DSA_set0_key(d, pub_key, priv_key))
+func go_openssl_DSA_set0_key(d _DSA_PTR, pub_key _BIGNUM_PTR, priv_key _BIGNUM_PTR) (int32, error) {
+	_ret := C.DSA_set0_key(d, pub_key, priv_key)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("DSA_set0_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_DSA_set0_pqg(d _DSA_PTR, p _BIGNUM_PTR, q _BIGNUM_PTR, g _BIGNUM_PTR) int32 {
-	return int32(C.DSA_set0_pqg(d, p, q, g))
+func go_openssl_DSA_set0_pqg(d _DSA_PTR, p _BIGNUM_PTR, q _BIGNUM_PTR, g _BIGNUM_PTR) (int32, error) {
+	_ret := C.DSA_set0_pqg(d, p, q, g)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("DSA_set0_pqg")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EC_GROUP_free(group _EC_GROUP_PTR) {
 	C.EC_GROUP_free(group)
 }
 
-func go_openssl_EC_GROUP_new_by_curve_name(nid int32) _EC_GROUP_PTR {
-	return C.EC_GROUP_new_by_curve_name(C.int(nid))
+func go_openssl_EC_GROUP_new_by_curve_name(nid int32) (_EC_GROUP_PTR, error) {
+	_ret := C.EC_GROUP_new_by_curve_name(C.int(nid))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EC_GROUP_new_by_curve_name")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EC_KEY_check_key(key _EC_KEY_PTR) int32 {
-	return int32(C.EC_KEY_check_key(key))
+func go_openssl_EC_KEY_check_key(key _EC_KEY_PTR) (int32, error) {
+	_ret := C.EC_KEY_check_key(key)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_KEY_check_key")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EC_KEY_free(arg0 _EC_KEY_PTR) {
@@ -251,59 +311,109 @@ func go_openssl_EC_KEY_free(arg0 _EC_KEY_PTR) {
 }
 
 func go_openssl_EC_KEY_get0_group(arg0 _EC_KEY_PTR) _EC_GROUP_PTR {
-	return _EC_GROUP_PTR(C.EC_KEY_get0_group(arg0))
+	return C.EC_KEY_get0_group(arg0)
 }
 
 func go_openssl_EC_KEY_get0_private_key(arg0 _EC_KEY_PTR) _BIGNUM_PTR {
-	return _BIGNUM_PTR(C.EC_KEY_get0_private_key(arg0))
+	return C.EC_KEY_get0_private_key(arg0)
 }
 
 func go_openssl_EC_KEY_get0_public_key(arg0 _EC_KEY_PTR) _EC_POINT_PTR {
-	return _EC_POINT_PTR(C.EC_KEY_get0_public_key(arg0))
+	return C.EC_KEY_get0_public_key(arg0)
 }
 
-func go_openssl_EC_KEY_new_by_curve_name(arg0 int32) _EC_KEY_PTR {
-	return C.EC_KEY_new_by_curve_name(C.int(arg0))
+func go_openssl_EC_KEY_new_by_curve_name(arg0 int32) (_EC_KEY_PTR, error) {
+	_ret := C.EC_KEY_new_by_curve_name(C.int(arg0))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EC_KEY_new_by_curve_name")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EC_KEY_set_private_key(arg0 _EC_KEY_PTR, arg1 _BIGNUM_PTR) int32 {
-	return int32(C.EC_KEY_set_private_key(arg0, arg1))
+func go_openssl_EC_KEY_set_private_key(arg0 _EC_KEY_PTR, arg1 _BIGNUM_PTR) (int32, error) {
+	_ret := C.EC_KEY_set_private_key(arg0, arg1)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_KEY_set_private_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EC_KEY_set_public_key(key _EC_KEY_PTR, pub _EC_POINT_PTR) int32 {
-	return int32(C.EC_KEY_set_public_key(key, pub))
+func go_openssl_EC_KEY_set_public_key(key _EC_KEY_PTR, pub _EC_POINT_PTR) (int32, error) {
+	_ret := C.EC_KEY_set_public_key(key, pub)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_KEY_set_public_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EC_KEY_set_public_key_affine_coordinates(key _EC_KEY_PTR, x _BIGNUM_PTR, y _BIGNUM_PTR) int32 {
-	return int32(C.EC_KEY_set_public_key_affine_coordinates(key, x, y))
+func go_openssl_EC_KEY_set_public_key_affine_coordinates(key _EC_KEY_PTR, x _BIGNUM_PTR, y _BIGNUM_PTR) (int32, error) {
+	_ret := C.EC_KEY_set_public_key_affine_coordinates(key, x, y)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_KEY_set_public_key_affine_coordinates")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EC_POINT_free(arg0 _EC_POINT_PTR) {
 	C.EC_POINT_free(arg0)
 }
 
-func go_openssl_EC_POINT_get_affine_coordinates_GFp(arg0 _EC_GROUP_PTR, arg1 _EC_POINT_PTR, arg2 _BIGNUM_PTR, arg3 _BIGNUM_PTR, arg4 _BN_CTX_PTR) int32 {
-	return int32(C.EC_POINT_get_affine_coordinates_GFp(arg0, arg1, arg2, arg3, arg4))
+func go_openssl_EC_POINT_get_affine_coordinates_GFp(arg0 _EC_GROUP_PTR, arg1 _EC_POINT_PTR, arg2 _BIGNUM_PTR, arg3 _BIGNUM_PTR, arg4 _BN_CTX_PTR) (int32, error) {
+	_ret := C.EC_POINT_get_affine_coordinates_GFp(arg0, arg1, arg2, arg3, arg4)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_POINT_get_affine_coordinates_GFp")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EC_POINT_mul(group _EC_GROUP_PTR, r _EC_POINT_PTR, n _BIGNUM_PTR, q _EC_POINT_PTR, m _BIGNUM_PTR, ctx _BN_CTX_PTR) int32 {
-	return int32(C.EC_POINT_mul(group, r, n, q, m, ctx))
+func go_openssl_EC_POINT_mul(group _EC_GROUP_PTR, r _EC_POINT_PTR, n _BIGNUM_PTR, q _EC_POINT_PTR, m _BIGNUM_PTR, ctx _BN_CTX_PTR) (int32, error) {
+	_ret := C.EC_POINT_mul(group, r, n, q, m, ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_POINT_mul")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EC_POINT_new(arg0 _EC_GROUP_PTR) _EC_POINT_PTR {
-	return C.EC_POINT_new(arg0)
+func go_openssl_EC_POINT_new(arg0 _EC_GROUP_PTR) (_EC_POINT_PTR, error) {
+	_ret := C.EC_POINT_new(arg0)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EC_POINT_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EC_POINT_oct2point(group _EC_GROUP_PTR, p _EC_POINT_PTR, buf *byte, len int, ctx _BN_CTX_PTR) int32 {
-	return int32(C.EC_POINT_oct2point(group, p, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx))
+func go_openssl_EC_POINT_oct2point(group _EC_GROUP_PTR, p _EC_POINT_PTR, buf *byte, len int, ctx _BN_CTX_PTR) (int32, error) {
+	_ret := C.EC_POINT_oct2point(group, p, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_POINT_oct2point")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EC_POINT_point2oct(group _EC_GROUP_PTR, p _EC_POINT_PTR, form point_conversion_form_t, buf *byte, len int, ctx _BN_CTX_PTR) int {
-	return int(C.EC_POINT_point2oct(group, p, form, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx))
+func go_openssl_EC_POINT_point2oct(group _EC_GROUP_PTR, p _EC_POINT_PTR, form point_conversion_form_t, buf *byte, len int, ctx _BN_CTX_PTR) (int, error) {
+	_ret := C.EC_POINT_point2oct(group, p, form, (*C.uchar)(unsafe.Pointer(buf)), C.size_t(len), ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_POINT_point2oct")
+	}
+	return int(_ret), _err
 }
 
-func go_openssl_EC_POINT_set_affine_coordinates(arg0 _EC_GROUP_PTR, arg1 _EC_POINT_PTR, arg2 _BIGNUM_PTR, arg3 _BIGNUM_PTR, arg4 _BN_CTX_PTR) int32 {
-	return int32(C.EC_POINT_set_affine_coordinates(arg0, arg1, arg2, arg3, arg4))
+func go_openssl_EC_POINT_set_affine_coordinates(arg0 _EC_GROUP_PTR, arg1 _EC_POINT_PTR, arg2 _BIGNUM_PTR, arg3 _BIGNUM_PTR, arg4 _BN_CTX_PTR) (int32, error) {
+	_ret := C.EC_POINT_set_affine_coordinates(arg0, arg1, arg2, arg3, arg4)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EC_POINT_set_affine_coordinates")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_ERR_clear_error() {
@@ -322,28 +432,53 @@ func go_openssl_ERR_get_error_line(file **byte, line *int32) uint32 {
 	return uint32(C.ERR_get_error_line((**C.char)(unsafe.Pointer(file)), (*C.int)(unsafe.Pointer(line))))
 }
 
-func go_openssl_EVP_CIPHER_CTX_ctrl(ctx _EVP_CIPHER_CTX_PTR, __type int32, arg int32, ptr unsafe.Pointer) int32 {
-	return int32(C.EVP_CIPHER_CTX_ctrl(ctx, C.int(__type), C.int(arg), ptr))
+func go_openssl_EVP_CIPHER_CTX_ctrl(ctx _EVP_CIPHER_CTX_PTR, __type int32, arg int32, ptr unsafe.Pointer) (int32, error) {
+	_ret := C.EVP_CIPHER_CTX_ctrl(ctx, C.int(__type), C.int(arg), ptr)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_CIPHER_CTX_ctrl")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_CIPHER_CTX_free(arg0 _EVP_CIPHER_CTX_PTR) {
 	C.EVP_CIPHER_CTX_free(arg0)
 }
 
-func go_openssl_EVP_CIPHER_CTX_new() _EVP_CIPHER_CTX_PTR {
-	return C.EVP_CIPHER_CTX_new()
+func go_openssl_EVP_CIPHER_CTX_new() (_EVP_CIPHER_CTX_PTR, error) {
+	_ret := C.EVP_CIPHER_CTX_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_CIPHER_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_CIPHER_CTX_set_key_length(x _EVP_CIPHER_CTX_PTR, keylen int32) int32 {
-	return int32(C.EVP_CIPHER_CTX_set_key_length(x, C.int(keylen)))
+func go_openssl_EVP_CIPHER_CTX_set_key_length(x _EVP_CIPHER_CTX_PTR, keylen int32) (int32, error) {
+	_ret := C.EVP_CIPHER_CTX_set_key_length(x, C.int(keylen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_CIPHER_CTX_set_key_length")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_CIPHER_CTX_set_padding(x _EVP_CIPHER_CTX_PTR, padding int32) int32 {
-	return int32(C.EVP_CIPHER_CTX_set_padding(x, C.int(padding)))
+func go_openssl_EVP_CIPHER_CTX_set_padding(x _EVP_CIPHER_CTX_PTR, padding int32) (int32, error) {
+	_ret := C.EVP_CIPHER_CTX_set_padding(x, C.int(padding))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_CIPHER_CTX_set_padding")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_CIPHER_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) _EVP_CIPHER_PTR {
-	return C.EVP_CIPHER_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+func go_openssl_EVP_CIPHER_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (_EVP_CIPHER_PTR, error) {
+	_ret := C.EVP_CIPHER_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_CIPHER_fetch")
+	}
+	return _ret, _err
 }
 
 func go_openssl_EVP_CIPHER_get0_name(cipher _EVP_CIPHER_PTR) *byte {
@@ -354,160 +489,335 @@ func go_openssl_EVP_CIPHER_get_block_size(cipher _EVP_CIPHER_PTR) int32 {
 	return int32(C.EVP_CIPHER_get_block_size(cipher))
 }
 
-func go_openssl_EVP_CipherInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte, enc int32) int32 {
-	return int32(C.EVP_CipherInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc)))
+func go_openssl_EVP_CipherInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte, enc int32) (int32, error) {
+	_ret := C.EVP_CipherInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)), C.int(enc))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_CipherInit_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_CipherUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) int32 {
-	return int32(C.EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl)))
+func go_openssl_EVP_CipherUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
+	_ret := C.EVP_CipherUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_CipherUpdate")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DecryptFinal_ex(ctx _EVP_CIPHER_CTX_PTR, outm *byte, outl *int32) int32 {
-	return int32(C.EVP_DecryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(outm)), (*C.int)(unsafe.Pointer(outl))))
+func go_openssl_EVP_DecryptFinal_ex(ctx _EVP_CIPHER_CTX_PTR, outm *byte, outl *int32) (int32, error) {
+	_ret := C.EVP_DecryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(outm)), (*C.int)(unsafe.Pointer(outl)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DecryptFinal_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DecryptInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte) int32 {
-	return int32(C.EVP_DecryptInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv))))
+func go_openssl_EVP_DecryptInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte) (int32, error) {
+	_ret := C.EVP_DecryptInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DecryptInit_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DecryptUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) int32 {
-	return int32(C.EVP_DecryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl)))
+func go_openssl_EVP_DecryptUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
+	_ret := C.EVP_DecryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DecryptUpdate")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_Digest(data unsafe.Pointer, count int, md *byte, size *uint32, __type _EVP_MD_PTR, impl _ENGINE_PTR) int32 {
-	return int32(C.EVP_Digest(data, C.size_t(count), (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(size)), __type, impl))
+func go_openssl_EVP_Digest(data unsafe.Pointer, count int, md *byte, size *uint32, __type _EVP_MD_PTR, impl _ENGINE_PTR) (int32, error) {
+	_ret := C.EVP_Digest(data, C.size_t(count), (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(size)), __type, impl)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_Digest")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestFinal_ex(ctx _EVP_MD_CTX_PTR, md *byte, s *uint32) int32 {
-	return int32(C.EVP_DigestFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(s))))
+func go_openssl_EVP_DigestFinal_ex(ctx _EVP_MD_CTX_PTR, md *byte, s *uint32) (int32, error) {
+	_ret := C.EVP_DigestFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(s)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestFinal_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestInit(ctx _EVP_MD_CTX_PTR, __type _EVP_MD_PTR) int32 {
-	return int32(C.EVP_DigestInit(ctx, __type))
+func go_openssl_EVP_DigestInit(ctx _EVP_MD_CTX_PTR, __type _EVP_MD_PTR) (int32, error) {
+	_ret := C.EVP_DigestInit(ctx, __type)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestInit")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestInit_ex(ctx _EVP_MD_CTX_PTR, __type _EVP_MD_PTR, impl _ENGINE_PTR) int32 {
-	return int32(C.EVP_DigestInit_ex(ctx, __type, impl))
+func go_openssl_EVP_DigestInit_ex(ctx _EVP_MD_CTX_PTR, __type _EVP_MD_PTR, impl _ENGINE_PTR) (int32, error) {
+	_ret := C.EVP_DigestInit_ex(ctx, __type, impl)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestInit_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestSign(ctx _EVP_MD_CTX_PTR, sigret *byte, siglen *int, tbs *byte, tbslen int) int32 {
-	return int32(C.EVP_DigestSign(ctx, (*C.uchar)(unsafe.Pointer(sigret)), (*C.size_t)(unsafe.Pointer(siglen)), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen)))
+func go_openssl_EVP_DigestSign(ctx _EVP_MD_CTX_PTR, sigret *byte, siglen *int, tbs *byte, tbslen int) (int32, error) {
+	_ret := C.EVP_DigestSign(ctx, (*C.uchar)(unsafe.Pointer(sigret)), (*C.size_t)(unsafe.Pointer(siglen)), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestSign")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestSignFinal(ctx _EVP_MD_CTX_PTR, sig *byte, siglen *int) int32 {
-	return int32(C.EVP_DigestSignFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), (*C.size_t)(unsafe.Pointer(siglen))))
+func go_openssl_EVP_DigestSignFinal(ctx _EVP_MD_CTX_PTR, sig *byte, siglen *int) (int32, error) {
+	_ret := C.EVP_DigestSignFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), (*C.size_t)(unsafe.Pointer(siglen)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestSignFinal")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestSignInit(ctx _EVP_MD_CTX_PTR, pctx *_EVP_PKEY_CTX_PTR, __type _EVP_MD_PTR, e _ENGINE_PTR, pkey _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_DigestSignInit(ctx, pctx, __type, e, pkey))
+func go_openssl_EVP_DigestSignInit(ctx _EVP_MD_CTX_PTR, pctx *_EVP_PKEY_CTX_PTR, __type _EVP_MD_PTR, e _ENGINE_PTR, pkey _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_DigestSignInit(ctx, pctx, __type, e, pkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestSignInit")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestUpdate(ctx _EVP_MD_CTX_PTR, d unsafe.Pointer, cnt int) int32 {
-	return int32(C.EVP_DigestUpdate(ctx, d, C.size_t(cnt)))
+func go_openssl_EVP_DigestUpdate(ctx _EVP_MD_CTX_PTR, d unsafe.Pointer, cnt int) (int32, error) {
+	_ret := C.EVP_DigestUpdate(ctx, d, C.size_t(cnt))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestUpdate")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestVerify(ctx _EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) int32 {
-	return int32(C.EVP_DigestVerify(ctx, (*C.uchar)(unsafe.Pointer(sigret)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen)))
+func go_openssl_EVP_DigestVerify(ctx _EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
+	_ret := C.EVP_DigestVerify(ctx, (*C.uchar)(unsafe.Pointer(sigret)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestVerify")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestVerifyFinal(ctx _EVP_MD_CTX_PTR, sig *byte, siglen int) int32 {
-	return int32(C.EVP_DigestVerifyFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen)))
+func go_openssl_EVP_DigestVerifyFinal(ctx _EVP_MD_CTX_PTR, sig *byte, siglen int) (int32, error) {
+	_ret := C.EVP_DigestVerifyFinal(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestVerifyFinal")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_DigestVerifyInit(ctx _EVP_MD_CTX_PTR, pctx *_EVP_PKEY_CTX_PTR, __type _EVP_MD_PTR, e _ENGINE_PTR, pkey _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_DigestVerifyInit(ctx, pctx, __type, e, pkey))
+func go_openssl_EVP_DigestVerifyInit(ctx _EVP_MD_CTX_PTR, pctx *_EVP_PKEY_CTX_PTR, __type _EVP_MD_PTR, e _ENGINE_PTR, pkey _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_DigestVerifyInit(ctx, pctx, __type, e, pkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_DigestVerifyInit")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_EncryptFinal_ex(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32) int32 {
-	return int32(C.EVP_EncryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl))))
+func go_openssl_EVP_EncryptFinal_ex(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32) (int32, error) {
+	_ret := C.EVP_EncryptFinal_ex(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_EncryptFinal_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_EncryptInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte) int32 {
-	return int32(C.EVP_EncryptInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv))))
+func go_openssl_EVP_EncryptInit_ex(ctx _EVP_CIPHER_CTX_PTR, __type _EVP_CIPHER_PTR, impl _ENGINE_PTR, key *byte, iv *byte) (int32, error) {
+	_ret := C.EVP_EncryptInit_ex(ctx, __type, impl, (*C.uchar)(unsafe.Pointer(key)), (*C.uchar)(unsafe.Pointer(iv)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_EncryptInit_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_EncryptUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) int32 {
-	return int32(C.EVP_EncryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl)))
+func go_openssl_EVP_EncryptUpdate(ctx _EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
+	_ret := C.EVP_EncryptUpdate(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.int)(unsafe.Pointer(outl)), (*C.uchar)(unsafe.Pointer(in)), C.int(inl))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_EncryptUpdate")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_KDF_CTX_free(ctx _EVP_KDF_CTX_PTR) {
 	C.EVP_KDF_CTX_free(ctx)
 }
 
-func go_openssl_EVP_KDF_CTX_get_kdf_size(ctx _EVP_KDF_CTX_PTR) int {
-	return int(C.EVP_KDF_CTX_get_kdf_size(ctx))
+func go_openssl_EVP_KDF_CTX_get_kdf_size(ctx _EVP_KDF_CTX_PTR) (int, error) {
+	_ret := C.EVP_KDF_CTX_get_kdf_size(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_KDF_CTX_get_kdf_size")
+	}
+	return int(_ret), _err
 }
 
-func go_openssl_EVP_KDF_CTX_new(kdf _EVP_KDF_PTR) _EVP_KDF_CTX_PTR {
-	return C.EVP_KDF_CTX_new(kdf)
+func go_openssl_EVP_KDF_CTX_new(kdf _EVP_KDF_PTR) (_EVP_KDF_CTX_PTR, error) {
+	_ret := C.EVP_KDF_CTX_new(kdf)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_KDF_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_KDF_CTX_set_params(ctx _EVP_KDF_CTX_PTR, params _OSSL_PARAM_PTR) int32 {
-	return int32(C.EVP_KDF_CTX_set_params(ctx, params))
+func go_openssl_EVP_KDF_CTX_set_params(ctx _EVP_KDF_CTX_PTR, params _OSSL_PARAM_PTR) (int32, error) {
+	_ret := C.EVP_KDF_CTX_set_params(ctx, params)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_KDF_CTX_set_params")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_KDF_derive(ctx _EVP_KDF_CTX_PTR, key *byte, keylen int, params _OSSL_PARAM_PTR) int32 {
-	return int32(C.EVP_KDF_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params))
+func go_openssl_EVP_KDF_derive(ctx _EVP_KDF_CTX_PTR, key *byte, keylen int, params _OSSL_PARAM_PTR) (int32, error) {
+	_ret := C.EVP_KDF_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_KDF_derive")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_KDF_fetch(libctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) _EVP_KDF_PTR {
-	return C.EVP_KDF_fetch(libctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+func go_openssl_EVP_KDF_fetch(libctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (_EVP_KDF_PTR, error) {
+	_ret := C.EVP_KDF_fetch(libctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_KDF_fetch")
+	}
+	return _ret, _err
 }
 
 func go_openssl_EVP_KDF_free(kdf _EVP_KDF_PTR) {
 	C.EVP_KDF_free(kdf)
 }
 
-func go_openssl_EVP_MAC_CTX_dup(arg0 _EVP_MAC_CTX_PTR) _EVP_MAC_CTX_PTR {
-	return C.EVP_MAC_CTX_dup(arg0)
+func go_openssl_EVP_MAC_CTX_dup(arg0 _EVP_MAC_CTX_PTR) (_EVP_MAC_CTX_PTR, error) {
+	_ret := C.EVP_MAC_CTX_dup(arg0)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_MAC_CTX_dup")
+	}
+	return _ret, _err
 }
 
 func go_openssl_EVP_MAC_CTX_free(arg0 _EVP_MAC_CTX_PTR) {
 	C.EVP_MAC_CTX_free(arg0)
 }
 
-func go_openssl_EVP_MAC_CTX_new(arg0 _EVP_MAC_PTR) _EVP_MAC_CTX_PTR {
-	return C.EVP_MAC_CTX_new(arg0)
+func go_openssl_EVP_MAC_CTX_new(arg0 _EVP_MAC_PTR) (_EVP_MAC_CTX_PTR, error) {
+	_ret := C.EVP_MAC_CTX_new(arg0)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_MAC_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_MAC_CTX_set_params(ctx _EVP_MAC_CTX_PTR, params _OSSL_PARAM_PTR) int32 {
-	return int32(C.EVP_MAC_CTX_set_params(ctx, params))
+func go_openssl_EVP_MAC_CTX_set_params(ctx _EVP_MAC_CTX_PTR, params _OSSL_PARAM_PTR) (int32, error) {
+	_ret := C.EVP_MAC_CTX_set_params(ctx, params)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MAC_CTX_set_params")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_MAC_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) _EVP_MAC_PTR {
-	return C.EVP_MAC_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+func go_openssl_EVP_MAC_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (_EVP_MAC_PTR, error) {
+	_ret := C.EVP_MAC_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_MAC_fetch")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_MAC_final(ctx _EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) int32 {
-	return int32(C.EVP_MAC_final(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.size_t)(unsafe.Pointer(outl)), C.size_t(outsize)))
+func go_openssl_EVP_MAC_final(ctx _EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) (int32, error) {
+	_ret := C.EVP_MAC_final(ctx, (*C.uchar)(unsafe.Pointer(out)), (*C.size_t)(unsafe.Pointer(outl)), C.size_t(outsize))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MAC_final")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_MAC_init(ctx _EVP_MAC_CTX_PTR, key *byte, keylen int, params _OSSL_PARAM_PTR) int32 {
-	return int32(C.EVP_MAC_init(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params))
+func go_openssl_EVP_MAC_init(ctx _EVP_MAC_CTX_PTR, key *byte, keylen int, params _OSSL_PARAM_PTR) (int32, error) {
+	_ret := C.EVP_MAC_init(ctx, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen), params)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MAC_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_MAC_update(ctx _EVP_MAC_CTX_PTR, data *byte, datalen int) int32 {
-	return int32(C.EVP_MAC_update(ctx, (*C.uchar)(unsafe.Pointer(data)), C.size_t(datalen)))
+func go_openssl_EVP_MAC_update(ctx _EVP_MAC_CTX_PTR, data *byte, datalen int) (int32, error) {
+	_ret := C.EVP_MAC_update(ctx, (*C.uchar)(unsafe.Pointer(data)), C.size_t(datalen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MAC_update")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_MD_CTX_copy(out _EVP_MD_CTX_PTR, in _EVP_MD_CTX_PTR) int32 {
-	return int32(C.EVP_MD_CTX_copy(out, in))
+func go_openssl_EVP_MD_CTX_copy(out _EVP_MD_CTX_PTR, in _EVP_MD_CTX_PTR) (int32, error) {
+	_ret := C.EVP_MD_CTX_copy(out, in)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MD_CTX_copy")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_MD_CTX_copy_ex(out _EVP_MD_CTX_PTR, in _EVP_MD_CTX_PTR) int32 {
-	return int32(C.EVP_MD_CTX_copy_ex(out, in))
+func go_openssl_EVP_MD_CTX_copy_ex(out _EVP_MD_CTX_PTR, in _EVP_MD_CTX_PTR) (int32, error) {
+	_ret := C.EVP_MD_CTX_copy_ex(out, in)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_MD_CTX_copy_ex")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_MD_CTX_free(ctx _EVP_MD_CTX_PTR) {
 	C.EVP_MD_CTX_free(ctx)
 }
 
-func go_openssl_EVP_MD_CTX_new() _EVP_MD_CTX_PTR {
-	return C.EVP_MD_CTX_new()
+func go_openssl_EVP_MD_CTX_new() (_EVP_MD_CTX_PTR, error) {
+	_ret := C.EVP_MD_CTX_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_MD_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_MD_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) _EVP_MD_PTR {
-	return C.EVP_MD_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+func go_openssl_EVP_MD_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (_EVP_MD_PTR, error) {
+	_ret := C.EVP_MD_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_MD_fetch")
+	}
+	return _ret, _err
 }
 
 func go_openssl_EVP_MD_free(md _EVP_MD_PTR) {
@@ -519,7 +829,7 @@ func go_openssl_EVP_MD_get0_name(md _EVP_MD_PTR) *byte {
 }
 
 func go_openssl_EVP_MD_get0_provider(md _EVP_MD_PTR) _OSSL_PROVIDER_PTR {
-	return _OSSL_PROVIDER_PTR(C.EVP_MD_get0_provider(md))
+	return C.EVP_MD_get0_provider(md)
 }
 
 func go_openssl_EVP_MD_get_block_size(md _EVP_MD_PTR) int32 {
@@ -534,208 +844,453 @@ func go_openssl_EVP_MD_get_type(md _EVP_MD_PTR) int32 {
 	return int32(C.EVP_MD_get_type(md))
 }
 
-func go_openssl_EVP_PKEY_CTX_add1_hkdf_info(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) int32 {
-	return int32(C.EVP_PKEY_CTX_add1_hkdf_info(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2)))
+func go_openssl_EVP_PKEY_CTX_add1_hkdf_info(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_add1_hkdf_info(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_add1_hkdf_info")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_CTX_ctrl(ctx _EVP_PKEY_CTX_PTR, keytype int32, optype int32, cmd int32, p1 int32, p2 unsafe.Pointer) int32 {
-	return int32(C.EVP_PKEY_CTX_ctrl(ctx, C.int(keytype), C.int(optype), C.int(cmd), C.int(p1), p2))
+func go_openssl_EVP_PKEY_CTX_ctrl(ctx _EVP_PKEY_CTX_PTR, keytype int32, optype int32, cmd int32, p1 int32, p2 unsafe.Pointer) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_ctrl(ctx, C.int(keytype), C.int(optype), C.int(cmd), C.int(p1), p2)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_ctrl")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_PKEY_CTX_free(arg0 _EVP_PKEY_CTX_PTR) {
 	C.EVP_PKEY_CTX_free(arg0)
 }
 
-func go_openssl_EVP_PKEY_CTX_new(arg0 _EVP_PKEY_PTR, arg1 _ENGINE_PTR) _EVP_PKEY_CTX_PTR {
-	return C.EVP_PKEY_CTX_new(arg0, arg1)
+func go_openssl_EVP_PKEY_CTX_new(arg0 _EVP_PKEY_PTR, arg1 _ENGINE_PTR) (_EVP_PKEY_CTX_PTR, error) {
+	_ret := C.EVP_PKEY_CTX_new(arg0, arg1)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_CTX_new_from_pkey(libctx _OSSL_LIB_CTX_PTR, pkey _EVP_PKEY_PTR, propquery *byte) _EVP_PKEY_CTX_PTR {
-	return C.EVP_PKEY_CTX_new_from_pkey(libctx, pkey, (*C.char)(unsafe.Pointer(propquery)))
+func go_openssl_EVP_PKEY_CTX_new_from_pkey(libctx _OSSL_LIB_CTX_PTR, pkey _EVP_PKEY_PTR, propquery *byte) (_EVP_PKEY_CTX_PTR, error) {
+	_ret := C.EVP_PKEY_CTX_new_from_pkey(libctx, pkey, (*C.char)(unsafe.Pointer(propquery)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_CTX_new_from_pkey")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_CTX_new_id(id int32, e _ENGINE_PTR) _EVP_PKEY_CTX_PTR {
-	return C.EVP_PKEY_CTX_new_id(C.int(id), e)
+func go_openssl_EVP_PKEY_CTX_new_id(id int32, e _ENGINE_PTR) (_EVP_PKEY_CTX_PTR, error) {
+	_ret := C.EVP_PKEY_CTX_new_id(C.int(id), e)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_CTX_new_id")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx _EVP_PKEY_CTX_PTR, label unsafe.Pointer, len int32) int32 {
-	return int32(C.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label, C.int(len)))
+func go_openssl_EVP_PKEY_CTX_set0_rsa_oaep_label(ctx _EVP_PKEY_CTX_PTR, label unsafe.Pointer, len int32) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, label, C.int(len))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_set0_rsa_oaep_label")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_CTX_set1_hkdf_key(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) int32 {
-	return int32(C.EVP_PKEY_CTX_set1_hkdf_key(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2)))
+func go_openssl_EVP_PKEY_CTX_set1_hkdf_key(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_set1_hkdf_key(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_set1_hkdf_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_CTX_set1_hkdf_salt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) int32 {
-	return int32(C.EVP_PKEY_CTX_set1_hkdf_salt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2)))
+func go_openssl_EVP_PKEY_CTX_set1_hkdf_salt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_set1_hkdf_salt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.int(arg2))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_set1_hkdf_salt")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_CTX_set_hkdf_md(arg0 _EVP_PKEY_CTX_PTR, arg1 _EVP_MD_PTR) int32 {
-	return int32(C.EVP_PKEY_CTX_set_hkdf_md(arg0, arg1))
+func go_openssl_EVP_PKEY_CTX_set_hkdf_md(arg0 _EVP_PKEY_CTX_PTR, arg1 _EVP_MD_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_set_hkdf_md(arg0, arg1)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_set_hkdf_md")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_CTX_set_hkdf_mode(arg0 _EVP_PKEY_CTX_PTR, arg1 int32) int32 {
-	return int32(C.EVP_PKEY_CTX_set_hkdf_mode(arg0, C.int(arg1)))
+func go_openssl_EVP_PKEY_CTX_set_hkdf_mode(arg0 _EVP_PKEY_CTX_PTR, arg1 int32) (int32, error) {
+	_ret := C.EVP_PKEY_CTX_set_hkdf_mode(arg0, C.int(arg1))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_CTX_set_hkdf_mode")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_Q_keygen_EC(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) _EVP_PKEY_PTR {
-	return C.EVP_PKEY_Q_keygen_EC(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), (*C.char)(unsafe.Pointer(arg1)))
+func go_openssl_EVP_PKEY_Q_keygen_EC(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_Q_keygen_EC(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), (*C.char)(unsafe.Pointer(arg1)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_Q_keygen_EC")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_Q_keygen_ED25519(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte) _EVP_PKEY_PTR {
-	return C.EVP_PKEY_Q_keygen_ED25519(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)))
+func go_openssl_EVP_PKEY_Q_keygen_ED25519(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_Q_keygen_ED25519(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_Q_keygen_ED25519")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_Q_keygen_RSA(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 int) _EVP_PKEY_PTR {
-	return C.EVP_PKEY_Q_keygen_RSA(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), C.size_t(arg1))
+func go_openssl_EVP_PKEY_Q_keygen_RSA(ctx _OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 int) (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_Q_keygen_RSA(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), C.size_t(arg1))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_Q_keygen_RSA")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_assign(pkey _EVP_PKEY_PTR, __type int32, key unsafe.Pointer) int32 {
-	return int32(C.EVP_PKEY_assign(pkey, C.int(__type), key))
+func go_openssl_EVP_PKEY_assign(pkey _EVP_PKEY_PTR, __type int32, key unsafe.Pointer) (int32, error) {
+	_ret := C.EVP_PKEY_assign(pkey, C.int(__type), key)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_assign")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_decrypt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) int32 {
-	return int32(C.EVP_PKEY_decrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4)))
+func go_openssl_EVP_PKEY_decrypt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
+	_ret := C.EVP_PKEY_decrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_decrypt")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_decrypt_init(arg0 _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_decrypt_init(arg0))
+func go_openssl_EVP_PKEY_decrypt_init(arg0 _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_decrypt_init(arg0)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_decrypt_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_derive(ctx _EVP_PKEY_CTX_PTR, key *byte, keylen *int) int32 {
-	return int32(C.EVP_PKEY_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), (*C.size_t)(unsafe.Pointer(keylen))))
+func go_openssl_EVP_PKEY_derive(ctx _EVP_PKEY_CTX_PTR, key *byte, keylen *int) (int32, error) {
+	_ret := C.EVP_PKEY_derive(ctx, (*C.uchar)(unsafe.Pointer(key)), (*C.size_t)(unsafe.Pointer(keylen)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_derive")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_derive_init(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_derive_init(ctx))
+func go_openssl_EVP_PKEY_derive_init(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_derive_init(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_derive_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_derive_set_peer(ctx _EVP_PKEY_CTX_PTR, peer _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_derive_set_peer(ctx, peer))
+func go_openssl_EVP_PKEY_derive_set_peer(ctx _EVP_PKEY_CTX_PTR, peer _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_derive_set_peer(ctx, peer)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_derive_set_peer")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_encrypt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) int32 {
-	return int32(C.EVP_PKEY_encrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4)))
+func go_openssl_EVP_PKEY_encrypt(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
+	_ret := C.EVP_PKEY_encrypt(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_encrypt")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_encrypt_init(arg0 _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_encrypt_init(arg0))
+func go_openssl_EVP_PKEY_encrypt_init(arg0 _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_encrypt_init(arg0)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_encrypt_init")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_PKEY_free(arg0 _EVP_PKEY_PTR) {
 	C.EVP_PKEY_free(arg0)
 }
 
-func go_openssl_EVP_PKEY_fromdata(ctx _EVP_PKEY_CTX_PTR, pkey *_EVP_PKEY_PTR, selection int32, params _OSSL_PARAM_PTR) int32 {
-	return int32(C.EVP_PKEY_fromdata(ctx, pkey, C.int(selection), params))
+func go_openssl_EVP_PKEY_fromdata(ctx _EVP_PKEY_CTX_PTR, pkey *_EVP_PKEY_PTR, selection int32, params _OSSL_PARAM_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_fromdata(ctx, pkey, C.int(selection), params)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_fromdata")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_fromdata_init(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_fromdata_init(ctx))
+func go_openssl_EVP_PKEY_fromdata_init(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_fromdata_init(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_fromdata_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get0_DSA(pkey _EVP_PKEY_PTR) _DSA_PTR {
-	return C.EVP_PKEY_get0_DSA(pkey)
+func go_openssl_EVP_PKEY_get0_DSA(pkey _EVP_PKEY_PTR) (_DSA_PTR, error) {
+	_ret := C.EVP_PKEY_get0_DSA(pkey)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_get0_DSA")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_get0_EC_KEY(pkey _EVP_PKEY_PTR) _EC_KEY_PTR {
-	return C.EVP_PKEY_get0_EC_KEY(pkey)
+func go_openssl_EVP_PKEY_get0_EC_KEY(pkey _EVP_PKEY_PTR) (_EC_KEY_PTR, error) {
+	_ret := C.EVP_PKEY_get0_EC_KEY(pkey)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_get0_EC_KEY")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_get1_RSA(pkey _EVP_PKEY_PTR) _RSA_PTR {
-	return C.EVP_PKEY_get1_RSA(pkey)
+func go_openssl_EVP_PKEY_get1_RSA(pkey _EVP_PKEY_PTR) (_RSA_PTR, error) {
+	_ret := C.EVP_PKEY_get1_RSA(pkey)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_get1_RSA")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_get1_encoded_public_key(pkey _EVP_PKEY_PTR, ppub **byte) int {
-	return int(C.EVP_PKEY_get1_encoded_public_key(pkey, (**C.uchar)(unsafe.Pointer(ppub))))
+func go_openssl_EVP_PKEY_get1_encoded_public_key(pkey _EVP_PKEY_PTR, ppub **byte) (int, error) {
+	_ret := C.EVP_PKEY_get1_encoded_public_key(pkey, (**C.uchar)(unsafe.Pointer(ppub)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get1_encoded_public_key")
+	}
+	return int(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get_bits(pkey _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_get_bits(pkey))
+func go_openssl_EVP_PKEY_get_bits(pkey _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_get_bits(pkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get_bits")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get_bn_param(pkey _EVP_PKEY_PTR, key_name *byte, bn *_BIGNUM_PTR) int32 {
-	return int32(C.EVP_PKEY_get_bn_param(pkey, (*C.char)(unsafe.Pointer(key_name)), bn))
+func go_openssl_EVP_PKEY_get_bn_param(pkey _EVP_PKEY_PTR, key_name *byte, bn *_BIGNUM_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_get_bn_param(pkey, (*C.char)(unsafe.Pointer(key_name)), bn)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get_bn_param")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get_raw_private_key(pkey _EVP_PKEY_PTR, priv *byte, len *int) int32 {
-	return int32(C.EVP_PKEY_get_raw_private_key(pkey, (*C.uchar)(unsafe.Pointer(priv)), (*C.size_t)(unsafe.Pointer(len))))
+func go_openssl_EVP_PKEY_get_raw_private_key(pkey _EVP_PKEY_PTR, priv *byte, len *int) (int32, error) {
+	_ret := C.EVP_PKEY_get_raw_private_key(pkey, (*C.uchar)(unsafe.Pointer(priv)), (*C.size_t)(unsafe.Pointer(len)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get_raw_private_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get_raw_public_key(pkey _EVP_PKEY_PTR, pub *byte, len *int) int32 {
-	return int32(C.EVP_PKEY_get_raw_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), (*C.size_t)(unsafe.Pointer(len))))
+func go_openssl_EVP_PKEY_get_raw_public_key(pkey _EVP_PKEY_PTR, pub *byte, len *int) (int32, error) {
+	_ret := C.EVP_PKEY_get_raw_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), (*C.size_t)(unsafe.Pointer(len)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get_raw_public_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_get_size(pkey _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_get_size(pkey))
+func go_openssl_EVP_PKEY_get_size(pkey _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_get_size(pkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_get_size")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_keygen(ctx _EVP_PKEY_CTX_PTR, ppkey *_EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_keygen(ctx, ppkey))
+func go_openssl_EVP_PKEY_keygen(ctx _EVP_PKEY_CTX_PTR, ppkey *_EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_keygen(ctx, ppkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_keygen")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_keygen_init(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_keygen_init(ctx))
+func go_openssl_EVP_PKEY_keygen_init(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_keygen_init(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_keygen_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_new() _EVP_PKEY_PTR {
-	return C.EVP_PKEY_new()
+func go_openssl_EVP_PKEY_new() (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_new_raw_private_key(__type int32, e _ENGINE_PTR, key *byte, keylen int) _EVP_PKEY_PTR {
-	return C.EVP_PKEY_new_raw_private_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen))
+func go_openssl_EVP_PKEY_new_raw_private_key(__type int32, e _ENGINE_PTR, key *byte, keylen int) (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_new_raw_private_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_new_raw_private_key")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_new_raw_public_key(__type int32, e _ENGINE_PTR, key *byte, keylen int) _EVP_PKEY_PTR {
-	return C.EVP_PKEY_new_raw_public_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen))
+func go_openssl_EVP_PKEY_new_raw_public_key(__type int32, e _ENGINE_PTR, key *byte, keylen int) (_EVP_PKEY_PTR, error) {
+	_ret := C.EVP_PKEY_new_raw_public_key(C.int(__type), e, (*C.uchar)(unsafe.Pointer(key)), C.size_t(keylen))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_PKEY_new_raw_public_key")
+	}
+	return _ret, _err
 }
 
-func go_openssl_EVP_PKEY_paramgen(ctx _EVP_PKEY_CTX_PTR, ppkey *_EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_paramgen(ctx, ppkey))
+func go_openssl_EVP_PKEY_paramgen(ctx _EVP_PKEY_CTX_PTR, ppkey *_EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_paramgen(ctx, ppkey)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_paramgen")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_paramgen_init(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_paramgen_init(ctx))
+func go_openssl_EVP_PKEY_paramgen_init(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_paramgen_init(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_paramgen_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_private_check(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_private_check(ctx))
+func go_openssl_EVP_PKEY_private_check(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_private_check(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_private_check")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_public_check_quick(ctx _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_public_check_quick(ctx))
+func go_openssl_EVP_PKEY_public_check_quick(ctx _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_public_check_quick(ctx)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_public_check_quick")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_set1_EC_KEY(pkey _EVP_PKEY_PTR, key _EC_KEY_PTR) int32 {
-	return int32(C.EVP_PKEY_set1_EC_KEY(pkey, key))
+func go_openssl_EVP_PKEY_set1_EC_KEY(pkey _EVP_PKEY_PTR, key _EC_KEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_set1_EC_KEY(pkey, key)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_set1_EC_KEY")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_set1_encoded_public_key(pkey _EVP_PKEY_PTR, pub *byte, publen int) int32 {
-	return int32(C.EVP_PKEY_set1_encoded_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), C.size_t(publen)))
+func go_openssl_EVP_PKEY_set1_encoded_public_key(pkey _EVP_PKEY_PTR, pub *byte, publen int) (int32, error) {
+	_ret := C.EVP_PKEY_set1_encoded_public_key(pkey, (*C.uchar)(unsafe.Pointer(pub)), C.size_t(publen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_set1_encoded_public_key")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_sign(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) int32 {
-	return int32(C.EVP_PKEY_sign(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4)))
+func go_openssl_EVP_PKEY_sign(arg0 _EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
+	_ret := C.EVP_PKEY_sign(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.size_t)(unsafe.Pointer(arg2)), (*C.uchar)(unsafe.Pointer(arg3)), C.size_t(arg4))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_sign")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_sign_init(arg0 _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_sign_init(arg0))
+func go_openssl_EVP_PKEY_sign_init(arg0 _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_sign_init(arg0)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_sign_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_up_ref(key _EVP_PKEY_PTR) int32 {
-	return int32(C.EVP_PKEY_up_ref(key))
+func go_openssl_EVP_PKEY_up_ref(key _EVP_PKEY_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_up_ref(key)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_up_ref")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_verify(ctx _EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) int32 {
-	return int32(C.EVP_PKEY_verify(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen)))
+func go_openssl_EVP_PKEY_verify(ctx _EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
+	_ret := C.EVP_PKEY_verify(ctx, (*C.uchar)(unsafe.Pointer(sig)), C.size_t(siglen), (*C.uchar)(unsafe.Pointer(tbs)), C.size_t(tbslen))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_verify")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_PKEY_verify_init(arg0 _EVP_PKEY_CTX_PTR) int32 {
-	return int32(C.EVP_PKEY_verify_init(arg0))
+func go_openssl_EVP_PKEY_verify_init(arg0 _EVP_PKEY_CTX_PTR) (int32, error) {
+	_ret := C.EVP_PKEY_verify_init(arg0)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_PKEY_verify_init")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_EVP_SIGNATURE_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) _EVP_SIGNATURE_PTR {
-	return C.EVP_SIGNATURE_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+func go_openssl_EVP_SIGNATURE_fetch(ctx _OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (_EVP_SIGNATURE_PTR, error) {
+	_ret := C.EVP_SIGNATURE_fetch(ctx, (*C.char)(unsafe.Pointer(algorithm)), (*C.char)(unsafe.Pointer(properties)))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("EVP_SIGNATURE_fetch")
+	}
+	return _ret, _err
 }
 
 func go_openssl_EVP_SIGNATURE_free(signature _EVP_SIGNATURE_PTR) {
@@ -743,55 +1298,60 @@ func go_openssl_EVP_SIGNATURE_free(signature _EVP_SIGNATURE_PTR) {
 }
 
 func go_openssl_EVP_aes_128_cbc() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_128_cbc())
+	return C.EVP_aes_128_cbc()
 }
 
 func go_openssl_EVP_aes_128_ctr() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_128_ctr())
+	return C.EVP_aes_128_ctr()
 }
 
 func go_openssl_EVP_aes_128_ecb() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_128_ecb())
+	return C.EVP_aes_128_ecb()
 }
 
 func go_openssl_EVP_aes_128_gcm() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_128_gcm())
+	return C.EVP_aes_128_gcm()
 }
 
 func go_openssl_EVP_aes_192_cbc() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_192_cbc())
+	return C.EVP_aes_192_cbc()
 }
 
 func go_openssl_EVP_aes_192_ctr() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_192_ctr())
+	return C.EVP_aes_192_ctr()
 }
 
 func go_openssl_EVP_aes_192_ecb() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_192_ecb())
+	return C.EVP_aes_192_ecb()
 }
 
 func go_openssl_EVP_aes_192_gcm() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_192_gcm())
+	return C.EVP_aes_192_gcm()
 }
 
 func go_openssl_EVP_aes_256_cbc() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_256_cbc())
+	return C.EVP_aes_256_cbc()
 }
 
 func go_openssl_EVP_aes_256_ctr() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_256_ctr())
+	return C.EVP_aes_256_ctr()
 }
 
 func go_openssl_EVP_aes_256_ecb() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_256_ecb())
+	return C.EVP_aes_256_ecb()
 }
 
 func go_openssl_EVP_aes_256_gcm() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_aes_256_gcm())
+	return C.EVP_aes_256_gcm()
 }
 
-func go_openssl_EVP_default_properties_enable_fips(libctx _OSSL_LIB_CTX_PTR, enable int32) int32 {
-	return int32(C.EVP_default_properties_enable_fips(libctx, C.int(enable)))
+func go_openssl_EVP_default_properties_enable_fips(libctx _OSSL_LIB_CTX_PTR, enable int32) (int32, error) {
+	_ret := C.EVP_default_properties_enable_fips(libctx, C.int(enable))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("EVP_default_properties_enable_fips")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_EVP_default_properties_is_fips_enabled(libctx _OSSL_LIB_CTX_PTR) int32 {
@@ -799,115 +1359,145 @@ func go_openssl_EVP_default_properties_is_fips_enabled(libctx _OSSL_LIB_CTX_PTR)
 }
 
 func go_openssl_EVP_des_cbc() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_des_cbc())
+	return C.EVP_des_cbc()
 }
 
 func go_openssl_EVP_des_ecb() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_des_ecb())
+	return C.EVP_des_ecb()
 }
 
 func go_openssl_EVP_des_ede3_cbc() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_des_ede3_cbc())
+	return C.EVP_des_ede3_cbc()
 }
 
 func go_openssl_EVP_des_ede3_ecb() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_des_ede3_ecb())
+	return C.EVP_des_ede3_ecb()
 }
 
 func go_openssl_EVP_md4() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_md4())
+	return C.EVP_md4()
 }
 
 func go_openssl_EVP_md5() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_md5())
+	return C.EVP_md5()
 }
 
 func go_openssl_EVP_md5_sha1() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_md5_sha1())
+	return C.EVP_md5_sha1()
 }
 
 func go_openssl_EVP_rc4() _EVP_CIPHER_PTR {
-	return _EVP_CIPHER_PTR(C.EVP_rc4())
+	return C.EVP_rc4()
 }
 
 func go_openssl_EVP_ripemd160() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_ripemd160())
+	return C.EVP_ripemd160()
 }
 
 func go_openssl_EVP_sha1() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha1())
+	return C.EVP_sha1()
 }
 
 func go_openssl_EVP_sha224() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha224())
+	return C.EVP_sha224()
 }
 
 func go_openssl_EVP_sha256() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha256())
+	return C.EVP_sha256()
 }
 
 func go_openssl_EVP_sha384() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha384())
+	return C.EVP_sha384()
 }
 
 func go_openssl_EVP_sha3_224() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha3_224())
+	return C.EVP_sha3_224()
 }
 
 func go_openssl_EVP_sha3_256() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha3_256())
+	return C.EVP_sha3_256()
 }
 
 func go_openssl_EVP_sha3_384() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha3_384())
+	return C.EVP_sha3_384()
 }
 
 func go_openssl_EVP_sha3_512() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha3_512())
+	return C.EVP_sha3_512()
 }
 
 func go_openssl_EVP_sha512() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha512())
+	return C.EVP_sha512()
 }
 
 func go_openssl_EVP_sha512_224() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha512_224())
+	return C.EVP_sha512_224()
 }
 
 func go_openssl_EVP_sha512_256() _EVP_MD_PTR {
-	return _EVP_MD_PTR(C.EVP_sha512_256())
+	return C.EVP_sha512_256()
 }
 
 func go_openssl_FIPS_mode() int32 {
 	return int32(C.FIPS_mode())
 }
 
-func go_openssl_FIPS_mode_set(r int32) int32 {
-	return int32(C.FIPS_mode_set(C.int(r)))
+func go_openssl_FIPS_mode_set(r int32) (int32, error) {
+	_ret := C.FIPS_mode_set(C.int(r))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("FIPS_mode_set")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_HMAC_CTX_copy(dest _HMAC_CTX_PTR, src _HMAC_CTX_PTR) int32 {
-	return int32(C.HMAC_CTX_copy(dest, src))
+func go_openssl_HMAC_CTX_copy(dest _HMAC_CTX_PTR, src _HMAC_CTX_PTR) (int32, error) {
+	_ret := C.HMAC_CTX_copy(dest, src)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("HMAC_CTX_copy")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_HMAC_CTX_free(arg0 _HMAC_CTX_PTR) {
 	C.HMAC_CTX_free(arg0)
 }
 
-func go_openssl_HMAC_CTX_new() _HMAC_CTX_PTR {
-	return C.HMAC_CTX_new()
+func go_openssl_HMAC_CTX_new() (_HMAC_CTX_PTR, error) {
+	_ret := C.HMAC_CTX_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("HMAC_CTX_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_HMAC_Final(arg0 _HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) int32 {
-	return int32(C.HMAC_Final(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.uint)(unsafe.Pointer(arg2))))
+func go_openssl_HMAC_Final(arg0 _HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) (int32, error) {
+	_ret := C.HMAC_Final(arg0, (*C.uchar)(unsafe.Pointer(arg1)), (*C.uint)(unsafe.Pointer(arg2)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("HMAC_Final")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_HMAC_Init_ex(arg0 _HMAC_CTX_PTR, arg1 unsafe.Pointer, arg2 int32, arg3 _EVP_MD_PTR, arg4 _ENGINE_PTR) int32 {
-	return int32(C.HMAC_Init_ex(arg0, arg1, C.int(arg2), arg3, arg4))
+func go_openssl_HMAC_Init_ex(arg0 _HMAC_CTX_PTR, arg1 unsafe.Pointer, arg2 int32, arg3 _EVP_MD_PTR, arg4 _ENGINE_PTR) (int32, error) {
+	_ret := C.HMAC_Init_ex(arg0, arg1, C.int(arg2), arg3, arg4)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("HMAC_Init_ex")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_HMAC_Update(arg0 _HMAC_CTX_PTR, arg1 *byte, arg2 int) int32 {
-	return int32(C.HMAC_Update(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.size_t(arg2)))
+func go_openssl_HMAC_Update(arg0 _HMAC_CTX_PTR, arg1 *byte, arg2 int) (int32, error) {
+	_ret := C.HMAC_Update(arg0, (*C.uchar)(unsafe.Pointer(arg1)), C.size_t(arg2))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("HMAC_Update")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_OBJ_nid2sn(n int32) *byte {
@@ -918,8 +1508,13 @@ func go_openssl_OPENSSL_init() {
 	C.OPENSSL_init()
 }
 
-func go_openssl_OPENSSL_init_crypto(ops uint64, settings _OPENSSL_INIT_SETTINGS_PTR) int32 {
-	return int32(C.OPENSSL_init_crypto(C.uint64_t(ops), settings))
+func go_openssl_OPENSSL_init_crypto(ops uint64, settings _OPENSSL_INIT_SETTINGS_PTR) (int32, error) {
+	_ret := C.OPENSSL_init_crypto(C.uint64_t(ops), settings)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("OPENSSL_init_crypto")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_OPENSSL_version_major_Available() bool {
@@ -950,28 +1545,58 @@ func go_openssl_OSSL_PARAM_BLD_free(bld _OSSL_PARAM_BLD_PTR) {
 	C.OSSL_PARAM_BLD_free(bld)
 }
 
-func go_openssl_OSSL_PARAM_BLD_new() _OSSL_PARAM_BLD_PTR {
-	return C.OSSL_PARAM_BLD_new()
+func go_openssl_OSSL_PARAM_BLD_new() (_OSSL_PARAM_BLD_PTR, error) {
+	_ret := C.OSSL_PARAM_BLD_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_OSSL_PARAM_BLD_push_BN(bld _OSSL_PARAM_BLD_PTR, key *byte, bn _BIGNUM_PTR) int32 {
-	return int32(C.OSSL_PARAM_BLD_push_BN(bld, (*C.char)(unsafe.Pointer(key)), bn))
+func go_openssl_OSSL_PARAM_BLD_push_BN(bld _OSSL_PARAM_BLD_PTR, key *byte, bn _BIGNUM_PTR) (int32, error) {
+	_ret := C.OSSL_PARAM_BLD_push_BN(bld, (*C.char)(unsafe.Pointer(key)), bn)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_push_BN")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_OSSL_PARAM_BLD_push_int32(bld _OSSL_PARAM_BLD_PTR, key *byte, num int32) int32 {
-	return int32(C.OSSL_PARAM_BLD_push_int32(bld, (*C.char)(unsafe.Pointer(key)), C.int32_t(num)))
+func go_openssl_OSSL_PARAM_BLD_push_int32(bld _OSSL_PARAM_BLD_PTR, key *byte, num int32) (int32, error) {
+	_ret := C.OSSL_PARAM_BLD_push_int32(bld, (*C.char)(unsafe.Pointer(key)), C.int32_t(num))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_push_int32")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_OSSL_PARAM_BLD_push_octet_string(bld _OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) int32 {
-	return int32(C.OSSL_PARAM_BLD_push_octet_string(bld, (*C.char)(unsafe.Pointer(key)), buf, C.size_t(bsize)))
+func go_openssl_OSSL_PARAM_BLD_push_octet_string(bld _OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) (int32, error) {
+	_ret := C.OSSL_PARAM_BLD_push_octet_string(bld, (*C.char)(unsafe.Pointer(key)), buf, C.size_t(bsize))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_push_octet_string")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld _OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) int32 {
-	return int32(C.OSSL_PARAM_BLD_push_utf8_string(bld, (*C.char)(unsafe.Pointer(key)), (*C.char)(unsafe.Pointer(buf)), C.size_t(bsize)))
+func go_openssl_OSSL_PARAM_BLD_push_utf8_string(bld _OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) (int32, error) {
+	_ret := C.OSSL_PARAM_BLD_push_utf8_string(bld, (*C.char)(unsafe.Pointer(key)), (*C.char)(unsafe.Pointer(buf)), C.size_t(bsize))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_push_utf8_string")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_OSSL_PARAM_BLD_to_param(bld _OSSL_PARAM_BLD_PTR) _OSSL_PARAM_PTR {
-	return C.OSSL_PARAM_BLD_to_param(bld)
+func go_openssl_OSSL_PARAM_BLD_to_param(bld _OSSL_PARAM_BLD_PTR) (_OSSL_PARAM_PTR, error) {
+	_ret := C.OSSL_PARAM_BLD_to_param(bld)
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("OSSL_PARAM_BLD_to_param")
+	}
+	return _ret, _err
 }
 
 func go_openssl_OSSL_PARAM_free(p _OSSL_PARAM_PTR) {
@@ -986,8 +1611,13 @@ func go_openssl_OSSL_PROVIDER_get0_name(prov _OSSL_PROVIDER_PTR) *byte {
 	return (*byte)(unsafe.Pointer(C.OSSL_PROVIDER_get0_name(prov)))
 }
 
-func go_openssl_OSSL_PROVIDER_try_load(libctx _OSSL_LIB_CTX_PTR, name *byte, retain_fallbacks int32) _OSSL_PROVIDER_PTR {
-	return C.OSSL_PROVIDER_try_load(libctx, (*C.char)(unsafe.Pointer(name)), C.int(retain_fallbacks))
+func go_openssl_OSSL_PROVIDER_try_load(libctx _OSSL_LIB_CTX_PTR, name *byte, retain_fallbacks int32) (_OSSL_PROVIDER_PTR, error) {
+	_ret := C.OSSL_PROVIDER_try_load(libctx, (*C.char)(unsafe.Pointer(name)), C.int(retain_fallbacks))
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("OSSL_PROVIDER_try_load")
+	}
+	return _ret, _err
 }
 
 func go_openssl_OpenSSL_version(__type int32) *byte {
@@ -1002,12 +1632,22 @@ func go_openssl_OpenSSL_version_num() uint32 {
 	return uint32(C.OpenSSL_version_num())
 }
 
-func go_openssl_PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest _EVP_MD_PTR, keylen int32, out *byte) int32 {
-	return int32(C.PKCS5_PBKDF2_HMAC((*C.char)(unsafe.Pointer(pass)), C.int(passlen), (*C.uchar)(unsafe.Pointer(salt)), C.int(saltlen), C.int(iter), digest, C.int(keylen), (*C.uchar)(unsafe.Pointer(out))))
+func go_openssl_PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest _EVP_MD_PTR, keylen int32, out *byte) (int32, error) {
+	_ret := C.PKCS5_PBKDF2_HMAC((*C.char)(unsafe.Pointer(pass)), C.int(passlen), (*C.uchar)(unsafe.Pointer(salt)), C.int(saltlen), C.int(iter), digest, C.int(keylen), (*C.uchar)(unsafe.Pointer(out)))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("PKCS5_PBKDF2_HMAC")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_RAND_bytes(arg0 *byte, arg1 int32) int32 {
-	return int32(C.RAND_bytes((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1)))
+func go_openssl_RAND_bytes(arg0 *byte, arg1 int32) (int32, error) {
+	_ret := C.RAND_bytes((*C.uchar)(unsafe.Pointer(arg0)), C.int(arg1))
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("RAND_bytes")
+	}
+	return int32(_ret), _err
 }
 
 func go_openssl_RSA_free(arg0 _RSA_PTR) {
@@ -1026,18 +1666,38 @@ func go_openssl_RSA_get0_key(rsa _RSA_PTR, n *_BIGNUM_PTR, e *_BIGNUM_PTR, d *_B
 	C.RSA_get0_key(rsa, n, e, d)
 }
 
-func go_openssl_RSA_new() _RSA_PTR {
-	return C.RSA_new()
+func go_openssl_RSA_new() (_RSA_PTR, error) {
+	_ret := C.RSA_new()
+	var _err error
+	if _ret == nil {
+		_err = newOpenSSLError("RSA_new")
+	}
+	return _ret, _err
 }
 
-func go_openssl_RSA_set0_crt_params(rsa _RSA_PTR, dmp1 _BIGNUM_PTR, dmp2 _BIGNUM_PTR, iqmp _BIGNUM_PTR) int32 {
-	return int32(C.RSA_set0_crt_params(rsa, dmp1, dmp2, iqmp))
+func go_openssl_RSA_set0_crt_params(rsa _RSA_PTR, dmp1 _BIGNUM_PTR, dmp2 _BIGNUM_PTR, iqmp _BIGNUM_PTR) (int32, error) {
+	_ret := C.RSA_set0_crt_params(rsa, dmp1, dmp2, iqmp)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("RSA_set0_crt_params")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_RSA_set0_factors(rsa _RSA_PTR, p _BIGNUM_PTR, q _BIGNUM_PTR) int32 {
-	return int32(C.RSA_set0_factors(rsa, p, q))
+func go_openssl_RSA_set0_factors(rsa _RSA_PTR, p _BIGNUM_PTR, q _BIGNUM_PTR) (int32, error) {
+	_ret := C.RSA_set0_factors(rsa, p, q)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("RSA_set0_factors")
+	}
+	return int32(_ret), _err
 }
 
-func go_openssl_RSA_set0_key(r _RSA_PTR, n _BIGNUM_PTR, e _BIGNUM_PTR, d _BIGNUM_PTR) int32 {
-	return int32(C.RSA_set0_key(r, n, e, d))
+func go_openssl_RSA_set0_key(r _RSA_PTR, n _BIGNUM_PTR, e _BIGNUM_PTR, d _BIGNUM_PTR) (int32, error) {
+	_ret := C.RSA_set0_key(r, n, e, d)
+	var _err error
+	if _ret <= 0 {
+		_err = newOpenSSLError("RSA_set0_key")
+	}
+	return int32(_ret), _err
 }


### PR DESCRIPTION
This PR is a first step to solve #231. Now the Go autogenerated code is in charge of constructing a Go error from a OpenSSL error, which is still done using the `newOpenSSLError` function.

This PR shouldn't modify behavior, except for the few places we were previously omitting the error, but now we don't to make the code more robust.

The main benefit of this PR (other than helping fixing #231) is that it is no longer the developer responsibility to correctly construct a Go error when there is an OpenSSL failure. This was a problematic things, as demonstrated by the fact that there were many error handling patterns implemented across the codebase. Now the developer don't have to think about how to construct an error, just pass the autogenerated error up the chain.