### PR TITLE
Add tests for `internal/mkcgo`

### DIFF
--- a/cmd/checkheader/main.go
+++ b/cmd/checkheader/main.go
@@ -100,8 +100,14 @@ func gccRun(program string) error {
 }
 
 func generate(header string) (string, error) {
-	src, err := mkcgo.Parse(header)
+	r, err := os.Open(header)
 	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	var src mkcgo.Source
+	if err := src.Parse(r); err != nil {
 		return "", err
 	}
 	w := &strings.Builder{}
@@ -131,7 +137,7 @@ func generate(header string) (string, error) {
 	}
 	var i int
 	for _, fn := range src.Funcs {
-		if fn.VariadicInst {
+		if fn.VariadicTarget != "" {
 			// Variadic instantiations are not real OpenSSL functions,
 			// skip them.
 			continue
@@ -141,7 +147,7 @@ func generate(header string) (string, error) {
 			tags = []mkcgo.TagAttr{{}}
 		}
 		for _, tag := range tags {
-			importName := fn.ImportName
+			importName := fn.ImportName()
 			if tag.Name != "" {
 				importName = tag.Name
 			}
@@ -169,7 +175,7 @@ func generate(header string) (string, error) {
 			for _, p := range fn.Params {
 				sparams = append(sparams, p.Type)
 			}
-			fmt.Fprintf(w, "%s (*__check_%d)(%s) = %s;\n", fn.Ret.Type, i, strings.Join(sparams, ", "), importName)
+			fmt.Fprintf(w, "%s (*__check_%d)(%s) = %s;\n", fn.Ret, i, strings.Join(sparams, ", "), importName)
 			for range conds {
 				fmt.Fprintf(w, "#endif\n")
 			}

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -125,7 +125,7 @@ func generateGoAliases(funcs []*mkcgo.Func, w io.Writer) {
 			}
 			handleType(p.Type)
 		}
-		handleType(fn.Ret.Type)
+		handleType(fn.Ret)
 	}
 	types := make([]string, 0, len(ctypes))
 	for typ := range ctypes {
@@ -199,9 +199,9 @@ func generateCHeader(src *mkcgo.Source, w io.Writer) {
 			continue
 		}
 		if fnNeedErrWrapper(fn) {
-			fmt.Fprintf(w, "%s %s(%s);\n", fn.Ret.Type, fnCName(fn), fnCErrWrapperParams(fn, false))
+			fmt.Fprintf(w, "%s %s(%s);\n", fn.Ret, fnCName(fn), fnCErrWrapperParams(fn, false))
 		} else {
-			fmt.Fprintf(w, "%s %s(%s);\n", fn.Ret.Type, fnCName(fn), fnToCArgs(fn, true, false))
+			fmt.Fprintf(w, "%s %s(%s);\n", fn.Ret, fnCName(fn), fnToCArgs(fn, true, false))
 		}
 	}
 	fmt.Fprintf(w, "\n")
@@ -233,10 +233,10 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 
 	// Function pointer declarations.
 	for _, fn := range src.Funcs {
-		if fn.VariadicInst {
+		if fn.VariadicTarget != "" {
 			continue
 		}
-		fmt.Fprintf(w, "%s (*_g_%s)(%s);\n", fn.Ret.Type, fn.ImportName, fnToCArgs(fn, true, false))
+		fmt.Fprintf(w, "%s (*_g_%s)(%s);\n", fn.Ret, fn.ImportName(), fnToCArgs(fn, true, false))
 	}
 	fmt.Fprintf(w, "\n")
 
@@ -253,7 +253,7 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 	for _, tag := range src.Tags() {
 		fmt.Fprintf(w, "void __mkcgo_load_%s(void* handle) {\n", tag)
 		for _, fn := range src.Funcs {
-			if fn.VariadicInst {
+			if fn.VariadicTarget != "" {
 				continue
 			}
 			tags := fn.Tags
@@ -264,11 +264,11 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 				if tagAttr.Tag == tag {
 					if tagAttr.Name != "" {
 						// TODO: if necessary, support optional functions in here too.
-						fmt.Fprintf(w, "\t__mkcgo__dlsym2(%s, %s)\n", fn.ImportName, tagAttr.Name)
+						fmt.Fprintf(w, "\t__mkcgo__dlsym2(%s, %s)\n", fn.ImportName(), tagAttr.Name)
 					} else if fn.Optional {
-						fmt.Fprintf(w, "\t__mkcgo__dlsym_nocheck(%s, %s)\n", fn.ImportName, fn.ImportName)
+						fmt.Fprintf(w, "\t__mkcgo__dlsym_nocheck(%s, %s)\n", fn.ImportName(), fn.ImportName())
 					} else {
-						fmt.Fprintf(w, "\t__mkcgo__dlsym(%s)\n", fn.ImportName)
+						fmt.Fprintf(w, "\t__mkcgo__dlsym(%s)\n", fn.ImportName())
 					}
 					break
 				}
@@ -278,7 +278,7 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 
 		fmt.Fprintf(w, "void __mkcgo_unload_%s() {\n", tag)
 		for _, fn := range src.Funcs {
-			if fn.VariadicInst {
+			if fn.VariadicTarget != "" {
 				continue
 			}
 			tags := fn.Tags
@@ -287,7 +287,7 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 			}
 			for _, tagAttr := range tags {
 				if tagAttr.Tag == tag {
-					fmt.Fprintf(w, "\t_g_%s = NULL;\n", fn.ImportName)
+					fmt.Fprintf(w, "\t_g_%s = NULL;\n", fn.ImportName())
 					break
 				}
 			}
@@ -308,7 +308,7 @@ func generateC(src *mkcgo.Source, w io.Writer) {
 		if fn.Optional {
 			// Generate a function that returns true if the function is available.
 			fmt.Fprintf(w, "int %s() {\n", fnCNameAvailable(fn))
-			fmt.Fprintf(w, "\treturn _g_%s != NULL;\n", fn.ImportName)
+			fmt.Fprintf(w, "\treturn _g_%s != NULL;\n", fn.ImportName())
 			fmt.Fprintf(w, "}\n\n")
 		}
 		generateCFn(typedefs, fn, w)
@@ -320,7 +320,7 @@ func generateGoFn(fn *mkcgo.Func, w io.Writer) {
 	fnCall := fmt.Sprintf("C.%s(%s)", fnCName(fn), fnToGoArgs(fn))
 	// Function definition
 	fmt.Fprintf(w, "func %s(%s)", goSymName(fn.Name), fnToGoParams(fn))
-	if retIsVoid(fn.Ret) {
+	if isVoid(fn.Ret) {
 		// Easy path, just call the C function. No need to write the return types,
 		// nor do error handling, nor cast the return value.
 		fmt.Fprintf(w, "{\n")
@@ -328,7 +328,7 @@ func generateGoFn(fn *mkcgo.Func, w io.Writer) {
 		fmt.Fprintf(w, "}\n\n")
 		return
 	}
-	goType, needCast := cTypeToGo(fn.Ret.Type, false)
+	goType, needCast := cTypeToGo(fn.Ret, false)
 	if fn.NoError {
 		fmt.Fprintf(w, " %s ", goType)
 	} else {
@@ -381,24 +381,24 @@ func generateGoFn(fn *mkcgo.Func, w io.Writer) {
 
 func generateCFn(typedefs map[string]string, fn *mkcgo.Func, w io.Writer) {
 	if !fnNeedErrWrapper(fn) {
-		fmt.Fprintf(w, "%s %s(%s) {\n\t", fn.Ret.Type, fnCName(fn), fnToCArgs(fn, true, true))
-		if !retIsVoid(fn.Ret) {
+		fmt.Fprintf(w, "%s %s(%s) {\n\t", fn.Ret, fnCName(fn), fnToCArgs(fn, true, true))
+		if !isVoid(fn.Ret) {
 			fmt.Fprintf(w, "return ")
 		}
-		fmt.Fprintf(w, "_g_%s(%s);\n", fn.ImportName, fnToCArgs(fn, false, true))
+		fmt.Fprintf(w, "_g_%s(%s);\n", fn.ImportName(), fnToCArgs(fn, false, true))
 		fmt.Fprintf(w, "}\n\n")
 		return
 	}
 
-	fmt.Fprintf(w, "%s %s(%s) {\n", fn.Ret.Type, fnCName(fn), fnCErrWrapperParams(fn, true))
+	fmt.Fprintf(w, "%s %s(%s) {\n", fn.Ret, fnCName(fn), fnCErrWrapperParams(fn, true))
 	fmt.Fprintf(w, "\tmkcgo_err_clear();\n") // clear any previous error
-	fmt.Fprintf(w, "\t%s _ret = _g_%s(%s);\n", fn.Ret.Type, fn.ImportName, fnToCArgs(fn, false, true))
+	fmt.Fprintf(w, "\t%s _ret = _g_%s(%s);\n", fn.Ret, fn.ImportName(), fnToCArgs(fn, false, true))
 	errCond := "<= 0"
 	if fn.ErrCond != "" {
 		errCond = fn.ErrCond
-	} else if strings.Contains(fn.Ret.Type, "*") {
+	} else if strings.Contains(fn.Ret, "*") {
 		errCond = "== NULL"
-	} else if typ, ok := typedefs[fn.Ret.Type]; ok && typ == "void*" {
+	} else if typ, ok := typedefs[fn.Ret]; ok && typ == "void*" {
 		errCond = "== NULL"
 	}
 	fmt.Fprintf(w, "\tif (_ret %s) *_err_state = mkcgo_err_retrieve();\n", errCond)
@@ -470,7 +470,7 @@ var cstdTypesToCgo = map[string]string{
 // the type needs to be casted to goType or not.
 func cTypeToGo(t string, cgo bool) (string, bool) {
 	t, _ = strings.CutPrefix(t, "const ")
-	if t == "void" {
+	if isVoid(t) {
 		return "", true
 	}
 	if strings.HasPrefix(t, "void*") {
@@ -515,7 +515,7 @@ func paramToC(i int, p *mkcgo.Param, addType, addName bool) string {
 	if addType {
 		s += p.Type
 	}
-	if addName && p.Type != "void" {
+	if addName && !isVoid(p.Type) {
 		if len(s) > 0 {
 			s += " "
 		}
@@ -524,8 +524,9 @@ func paramToC(i int, p *mkcgo.Param, addType, addName bool) string {
 	return s
 }
 
-func retIsVoid(r *mkcgo.Return) bool {
-	return r.Type == "void"
+// isVoid reports whether typ is a void type.
+func isVoid(typ string) bool {
+	return typ == "void"
 }
 
 // fnToGoParams returns source code for function f parameters.
@@ -580,7 +581,7 @@ func fnCErrWrapperParams(fn *mkcgo.Func, addName bool) string {
 	args := fnToCArgs(fn, true, addName)
 	if len(args) == 0 {
 		args = errArg
-	} else if args == "void" {
+	} else if isVoid(args) {
 		args = errArg
 	} else {
 		args += ", " + errArg
@@ -605,7 +606,7 @@ func fnCNameAvailable(fn *mkcgo.Func) string {
 
 // fnNeedErrWrapper reports whether function fn needs an error wrapper.
 func fnNeedErrWrapper(fn *mkcgo.Func) bool {
-	return !fn.NoError && !retIsVoid(fn.Ret)
+	return !fn.NoError && !isVoid(fn.Ret)
 }
 
 // fnCalledFromGo reports whether function fn is called from Go code.

--- a/cmd/mkcgo/main.go
+++ b/cmd/mkcgo/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"flag"
 	"fmt"
 	"go/format"
 	"log"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/golang-fips/openssl/v2/internal/mkcgo"
@@ -35,17 +37,31 @@ func main() {
 		usage()
 	}
 
+	var src mkcgo.Source
 	// Parse source files.
-	src, err := mkcgo.Parse(flag.Args()...)
-	if err != nil {
-		log.Fatal(err)
+	for _, arg := range flag.Args() {
+		file, err := os.Open(arg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = src.Parse(file)
+		file.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
+	// Sort functions by name to get deterministic output
+	// even when the order of the functions in the source file changes.
+	slices.SortFunc(src.Funcs, func(a, b *mkcgo.Func) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
 	var gobuf, go124buf, hbuf, cbuf bytes.Buffer
-	generateGo(src, &gobuf)
-	generateGo124(src, &go124buf)
-	generateCHeader(src, &hbuf)
-	generateC(src, &cbuf)
+	generateGo(&src, &gobuf)
+	generateGo124(&src, &go124buf)
+	generateCHeader(&src, &hbuf)
+	generateC(&src, &cbuf)
 
 	// Format the generated Go source code.
 	godata := goformat(gobuf.Bytes())

--- a/hash_test.go
+++ b/hash_test.go
@@ -360,6 +360,28 @@ func TestCgo(t *testing.T) {
 	openssl.SHA256(d.Data[:])
 }
 
+func TestHashAllocations(t *testing.T) {
+	if Asan() {
+		t.Skip("skipping allocations test with sanitizers")
+	}
+	msg := []byte("testing")
+	n := int(testing.AllocsPerRun(10, func() {
+		sink ^= openssl.SHA1(msg)[0]
+		sink ^= openssl.SHA224(msg)[0]
+		sink ^= openssl.SHA256(msg)[0]
+		sink ^= openssl.SHA512(msg)[0]
+	}))
+	want := 4
+	if compareCurrentVersion("go1.24") >= 0 {
+		// The go1.24 compiler is able to optimize the allocation away.
+		// See cgo_go124.go for more information.
+		want = 0
+	}
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
 func BenchmarkSHA256(b *testing.B) {
 	b.StopTimer()
 	h := openssl.NewSHA256()

--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -1,7 +1,12 @@
+// The mkcgo package provides a C header syntax parser.
+// It supports just the necessary features to parse the OpenSSL symbols used in this project.
 package mkcgo
 
 import (
+	"errors"
+	"fmt"
 	"slices"
+	"strings"
 )
 
 // Source is a collection of type definitions and functions.
@@ -9,9 +14,10 @@ type Source struct {
 	TypeDefs []*TypeDef
 	Enums    []*Enum
 	Funcs    []*Func
-	Files    []string
-	Comments []string // All line comments. Directives in this slice start with "#"
+	Comments []string // All line comments. Leading and trailing spaces are trimmed.
 	Includes []string // All #include directives, without the #include prefix.
+
+	symbols map[string]struct{} // All symbols defined in the source.
 }
 
 // TypeDef describes a type definition.
@@ -26,16 +32,61 @@ type Enum struct {
 	Value string
 }
 
-// Func describes a function.
-type Func struct {
-	FuncAttributes
-	Name   string
-	Params []*Param
-	Ret    *Return
+// FuncAttrs contains attributes of a function.
+type FuncAttrs struct {
+	Tags           []TagAttr
+	VariadicTarget string
+	Optional       bool
+	NoError        bool
+	ErrCond        string
+	NoEscape       bool
+	NoCallback     bool
 }
 
+// Func describes a function.
+type Func struct {
+	FuncAttrs
+	Name   string
+	Params []*Param
+	Ret    string
+}
+
+// Variadic returns true if the ends with a variadic parameter.
 func (f *Func) Variadic() bool {
 	return len(f.Params) > 0 && f.Params[len(f.Params)-1].Variadic()
+}
+
+// ImportName returns the import name of the function.
+func (f *Func) ImportName() string {
+	if f.VariadicTarget != "" {
+		return f.VariadicTarget
+	}
+	return f.Name
+}
+
+// String returns a string representation of the function,
+// which is not necessarily valid Go nor C code.
+func (f *Func) String() string {
+	var bld strings.Builder
+	if f.Ret != "" {
+		bld.WriteString(f.Ret)
+		bld.WriteByte(' ')
+	}
+	bld.WriteString(f.Name)
+	bld.WriteByte('(')
+	for i, p := range f.Params {
+		if i > 0 {
+			bld.WriteString(", ")
+		}
+		bld.WriteString(p.Type)
+		if p.Name != "" {
+			bld.WriteByte(' ')
+			bld.WriteString(p.Name)
+		}
+	}
+	bld.WriteString(") ")
+	bld.WriteString(fmt.Sprintf("%v", f.FuncAttrs))
+	return bld.String()
 }
 
 // TagAttr is an attribute of a tag with an optional name.
@@ -46,8 +97,8 @@ type TagAttr struct {
 
 // Param is a function parameter.
 type Param struct {
-	Name string
 	Type string
+	Name string
 }
 
 func (p *Param) Variadic() bool {
@@ -72,4 +123,79 @@ func (src *Source) Tags() []string {
 	}
 	slices.Sort(tags)
 	return tags
+}
+
+type attribute struct {
+	name        string
+	description string
+	handle      func(*FuncAttrs, ...string) error
+}
+
+var attributes = [...]attribute{
+	{
+		name:        "tag",
+		description: "The function will be loaded together with other functions with the same tag. It can contain an optional name, which is the import name for the tag.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			var name string
+			if len(s) > 1 {
+				name = s[1]
+			}
+			opts.Tags = append(opts.Tags, TagAttr{Tag: s[0], Name: name})
+			return nil
+		},
+	},
+	{
+		name:        "variadic",
+		description: "The function has variadic arguments, and its name is a custom wrapper for the actual C name, defined in this attribute.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			opts.VariadicTarget = s[0]
+			return nil
+		},
+	},
+	{
+		name:        "optional",
+		description: "The function is optional",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			opts.Optional = true
+			return nil
+		},
+	},
+	{
+		name:        "noerror",
+		description: "The function does not return an error, and the program will panic if the function returns an error.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			if opts.ErrCond != "" {
+				return errors.New("not allowed with errcond attribute")
+			}
+			opts.NoError = true
+			return nil
+		},
+	},
+	{
+		name:        "errcond",
+		description: "The function returns an error if the C function returns a value that matches the condition in this attribute.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			if opts.NoError {
+				return errors.New("not allowed with noerror attribute")
+			}
+			opts.ErrCond = s[0]
+			return nil
+		},
+	},
+	{
+		name:        "noescape",
+		description: "The C function does not keep a copy of the Go pointer.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			opts.NoEscape = true
+			return nil
+		},
+	},
+	{
+		name:        "nocallback",
+		description: "The C function does not call back into Go.",
+		handle: func(opts *FuncAttrs, s ...string) error {
+			opts.NoCallback = true
+			return nil
+		},
+	},
 }

--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -43,6 +43,36 @@ type FuncAttrs struct {
 	NoCallback     bool
 }
 
+func (attrs *FuncAttrs) String() string {
+	var bld strings.Builder
+	if len(attrs.Tags) != 0 {
+		bld.Write([]byte(fmt.Sprintf("%s", attrs.Tags)))
+	}
+	if attrs.VariadicTarget != "" {
+		bld.WriteString(", variadic(")
+		bld.WriteString(attrs.VariadicTarget)
+		bld.WriteByte(')')
+	}
+	if attrs.Optional {
+		bld.WriteString(", optional")
+	}
+	if attrs.NoError {
+		bld.WriteString(", noerror")
+	}
+	if attrs.ErrCond != "" {
+		bld.WriteString(", errcond(")
+		bld.WriteString(attrs.ErrCond)
+		bld.WriteByte(')')
+	}
+	if attrs.NoEscape {
+		bld.WriteString(", noescape")
+	}
+	if attrs.NoCallback {
+		bld.WriteString(", nocallback")
+	}
+	return strings.TrimPrefix(bld.String(), ", ")
+}
+
 // Func describes a function.
 type Func struct {
 	FuncAttrs
@@ -84,8 +114,11 @@ func (f *Func) String() string {
 			bld.WriteString(p.Name)
 		}
 	}
-	bld.WriteString(") ")
-	bld.WriteString(fmt.Sprintf("%v", f.FuncAttrs))
+	bld.WriteString(")")
+	if attrs := f.FuncAttrs.String(); attrs != "" {
+		bld.WriteString(" ")
+		bld.WriteString(attrs)
+	}
 	return bld.String()
 }
 

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -1,0 +1,402 @@
+package mkcgo_test
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/golang-fips/openssl/v2/internal/mkcgo"
+)
+
+func TestFuncVariadic(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   []*mkcgo.Param
+		expected bool
+	}{
+		{
+			name:     "No parameters",
+			params:   []*mkcgo.Param{},
+			expected: false,
+		},
+		{
+			name: "Non-variadic parameters",
+			params: []*mkcgo.Param{
+				{Name: "param1", Type: "int"},
+				{Name: "param2", Type: "string"},
+			},
+			expected: false,
+		},
+		{
+			name: "Last parameter is variadic",
+			params: []*mkcgo.Param{
+				{Name: "param1", Type: "int"},
+				{Name: "param2", Type: "..."},
+			},
+			expected: true,
+		},
+		{
+			name: "Single variadic parameter",
+			params: []*mkcgo.Param{
+				{Name: "param1", Type: "..."},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := &mkcgo.Func{Params: tt.params}
+			if got := fn.Variadic(); got != tt.expected {
+				t.Errorf("Func.Variadic() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+func TestSourceTags(t *testing.T) {
+	tests := []struct {
+		name  string
+		funcs []*mkcgo.Func
+		want  []string
+	}{
+		{
+			name:  "No functions",
+			funcs: []*mkcgo.Func{},
+			want:  []string{""},
+		},
+		{
+			name: "Functions with no tags",
+			funcs: []*mkcgo.Func{
+				{Name: "Func1", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{}}},
+				{Name: "Func2", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{}}},
+			},
+			want: []string{""},
+		},
+		{
+			name: "Functions with unique tags",
+			funcs: []*mkcgo.Func{
+				{Name: "Func1", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag1"}}}},
+				{Name: "Func2", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag2"}}}},
+			},
+			want: []string{"", "tag1", "tag2"},
+		},
+		{
+			name: "Functions with duplicate tags",
+			funcs: []*mkcgo.Func{
+				{Name: "Func1", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag1"}}}},
+				{Name: "Func2", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2"}}}},
+			},
+			want: []string{"", "tag1", "tag2"},
+		},
+		{
+			name: "Functions with unsorted tags",
+			funcs: []*mkcgo.Func{
+				{Name: "Func1", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag3"}}}},
+				{Name: "Func2", FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2"}}}},
+			},
+			want: []string{"", "tag1", "tag2", "tag3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := &mkcgo.Source{Funcs: tt.funcs}
+			got := src.Tags()
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("Source.Tags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFuncImportName(t *testing.T) {
+	tests := []struct {
+		name           string
+		variadicTarget string
+		funcName       string
+		want           string
+	}{
+		{
+			name:           "No VariadicTarget",
+			variadicTarget: "",
+			funcName:       "TestFunc",
+			want:           "TestFunc",
+		},
+		{
+			name:           "With VariadicTarget",
+			variadicTarget: "TargetFunc",
+			funcName:       "TestFunc",
+			want:           "TargetFunc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := &mkcgo.Func{
+				FuncAttrs: mkcgo.FuncAttrs{VariadicTarget: tt.variadicTarget},
+				Name:      tt.funcName,
+			}
+			if got := fn.ImportName(); got != tt.want {
+				t.Errorf("Func.ImportName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFuncString(t *testing.T) {
+	tests := []struct {
+		name     string
+		function *mkcgo.Func
+		want     string
+	}{
+		{
+			name:     "Function with no return type and no parameters",
+			function: &mkcgo.Func{Name: "TestFunc"},
+			want:     "TestFunc() {[]  false false  false false}",
+		},
+		{
+			name:     "Function with return type and no parameters",
+			function: &mkcgo.Func{Name: "TestFunc", Ret: "int"},
+			want:     "int TestFunc() {[]  false false  false false}",
+		},
+		{
+			name:     "Function with parameters and no return type",
+			function: &mkcgo.Func{Name: "TestFunc", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}, {Type: "string", Name: "param2"}}},
+			want:     "TestFunc(int param1, string param2) {[]  false false  false false}",
+		},
+		{
+			name:     "Function with return type and parameters",
+			function: &mkcgo.Func{Name: "TestFunc", Ret: "void", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}, {Type: "float", Name: "param2"}}},
+			want:     "void TestFunc(int param1, float param2) {[]  false false  false false}",
+		},
+		{
+			name: "Function with attributes",
+			function: &mkcgo.Func{Name: "TestFunc", Ret: "void", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}},
+				FuncAttrs: mkcgo.FuncAttrs{
+					Tags:       []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2"}},
+					Optional:   true,
+					NoError:    true,
+					ErrCond:    "error_condition",
+					NoEscape:   true,
+					NoCallback: true,
+				},
+			},
+			want: "void TestFunc(int param1) {[{tag1 } {tag2 }]  true true error_condition true true}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.function.String()
+			if got != tt.want {
+				t.Errorf("Func.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		content string
+		want    *mkcgo.Source
+	}{
+		{
+			content: `
+#include <stdlib.h>
+#include <stdint.h>`,
+			want: &mkcgo.Source{
+				Includes: []string{"<stdlib.h>", "<stdint.h>"},
+			},
+		}, {
+			content: `
+// C0
+// #include <string.h>`,
+			want: &mkcgo.Source{
+				Comments: []string{"C0", "#include <string.h>"},
+			},
+		}, {
+			content: `
+typedef void* TD0;
+typedef const char* TD1;
+typedef unsigned int* TD2;`,
+			want: &mkcgo.Source{
+				TypeDefs: []*mkcgo.TypeDef{
+					{"TD0", "void*"},
+					{"TD1", "const char*"},
+					{"TD2", "unsigned int*"},
+				},
+			},
+		}, {
+			content: `
+enum {
+	E0 = 1,
+	E1 = (1+1),
+	E2 =(1+2),
+};`,
+			want: &mkcgo.Source{
+				Enums: []*mkcgo.Enum{
+					{"E0", "1"},
+					{"E1", "(1+1)"},
+					{"E2", "(1+2)"},
+				},
+			},
+		}, {
+			content: `
+void F0(void) __attribute__((tag("t0"),noerror,tag("t1","tn0")));
+int F1(int p1) __attribute__((errcond("ec0"),  noescape,    nocallback));
+int * F2(int **p1, void  * p2);
+int *F3(int p1, void***) __attribute__((optional));
+unsigned   long F4(int func, int type, ...);
+int* F5(float, double) __attribute__((variadic("F4")));
+void F6();`,
+			want: &mkcgo.Source{
+				Funcs: []*mkcgo.Func{
+					{Name: "F0", Ret: "void", Params: []*mkcgo.Param{{"void", ""}}, FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "t0"}, {Tag: "t1", Name: "tn0"}}, NoError: true}},
+					{Name: "F1", Ret: "int", Params: []*mkcgo.Param{{"int", "p1"}}, FuncAttrs: mkcgo.FuncAttrs{ErrCond: "ec0", NoEscape: true, NoCallback: true}},
+					{Name: "F2", Ret: "int*", Params: []*mkcgo.Param{{"int**", "p1"}, {"void*", "p2"}}},
+					{Name: "F3", Ret: "int*", Params: []*mkcgo.Param{{"int", "p1"}, {"void***", ""}}, FuncAttrs: mkcgo.FuncAttrs{Optional: true}},
+					{Name: "F4", Ret: "unsigned long", Params: []*mkcgo.Param{{"int", "__func"}, {"int", "__type"}, {"...", ""}}},
+					{Name: "F5", Ret: "int*", Params: []*mkcgo.Param{{"float", ""}, {"double", ""}}, FuncAttrs: mkcgo.FuncAttrs{VariadicTarget: "F4"}},
+					{Name: "F6", Ret: "void", Params: []*mkcgo.Param{{"void", ""}}},
+				},
+			},
+		},
+	}
+	for i, tt := range tests {
+		// No need to specify a test name, the error message is enough to identify the test.
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var got mkcgo.Source
+			if err := got.Parse(strings.NewReader(tt.content)); err != nil {
+				t.Fatal(err)
+			}
+			testSlice(t, "Includes", got.Includes, tt.want.Includes)
+			testSlice(t, "Comments", got.Comments, tt.want.Comments)
+			testSlice(t, "TypeDefs", got.TypeDefs, tt.want.TypeDefs)
+			testSlice(t, "Enums", got.Enums, tt.want.Enums)
+			testSlice(t, "Funcs", got.Funcs, tt.want.Funcs)
+		})
+	}
+}
+
+func TestParseError(t *testing.T) {
+	tests := []struct {
+		content string
+		want    string
+	}{
+		{
+			content: `/**/`,
+			want:    `block comments are not supported`,
+		}, {
+			content: "enum {\nE0 1,\n};",
+			want:    `can't parse enum in line "E0 1,": can't extract enum value`,
+		}, {
+			content: `typedef T0;`,
+			want:    `can't extract type name`,
+		}, {
+			content: `void foo(;`,
+			want:    `invalid signature`,
+		}, {
+			content: `void;`,
+			want:    `invalid signature`,
+		}, {
+			content: `void (void);`,
+			want:    `missing name`,
+		}, {
+			content: `void foo(,);`,
+			want:    `empty parameter`,
+		}, {
+			content: `void foo2(int a) __attribute__((variadic("foo")));`,
+			want:    "variadic target not added yet",
+		}, {
+			content: `
+void foo();
+void foo2(int a) __attribute__((variadic("foo")));
+`, want: "variadic target is not variadic",
+		}, {
+			content: `void foo(void) __attribute__();`,
+			want:    `can't extract function attributes: __attribute__ should be followed by double parentheses`,
+		}, {
+			content: `void foo(void) __attribute__;`,
+			want:    `can't extract function attributes: __attribute__ should be followed by double parentheses`,
+		}, {
+			content: `void foo(void) __attribute__((tag("a")optional));`,
+			want:    `can't extract function attributes: parameters must be separated by commas`,
+		}, {
+			content: `void foo(void) __attribute__((tag("a"());`,
+			want:    `can't extract function attributes: unbalanced parentheses`,
+		}, {
+			content: `void foo(void) __attribute__(());`,
+			want:    `can't extract function attributes: empty attribute`,
+		}, {
+			content: `__attribute__((optional));`,
+			want:    `empty function signature`,
+		}, {
+			content: `void foo(void) __attribute__((errcond("a"),noerror));`,
+			want:    `can't extract function attributes: error parsing attribute noerror: not allowed with errcond attribute`,
+		}, {
+			content: `void foo(void) __attribute__((noerror,errcond("a")));`,
+			want:    `can't extract function attributes: error parsing attribute errcond: not allowed with noerror attribute`,
+		}, {
+			content: `void foo(void) __attribute__((foo_bar));`,
+			want:    `can't extract function attributes: unknown mkcgo attribute: foo_bar`,
+		}, {
+			content: `
+enum {
+	E0 = 0,
+	E0 = 1,
+};`,
+			want: `duplicate symbol "E0"`,
+		}, {
+			content: `
+enum {
+	E1 = 0,
+};
+typedef void* E1;
+`,
+			want: `duplicate symbol "E1"`,
+		}, {
+			content: `
+typedef void* E2;
+void E2(void);
+`,
+			want: `duplicate symbol "E2"`,
+		},
+	}
+	for i, tt := range tests {
+		// No need to specify a test name, the error message is enough to identify the test.
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var src mkcgo.Source
+			err := src.Parse(strings.NewReader(tt.content))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("want error %q to contain %q", tt.want, err)
+			}
+		})
+	}
+}
+
+// testSlice checks that got and want are equal.
+// If they are not, it reports an error with a detailed message.
+func testSlice[S ~[]E, E comparable](t *testing.T, name string, got, want S) {
+	t.Helper()
+	if reflect.DeepEqual(got, want) {
+		return
+	}
+	str := fmt.Sprintf("== %s ==\n", name)
+	if len(got) != len(want) {
+		str += fmt.Sprintf("len: got %d, want %d\n", len(got), len(want))
+	}
+	n := max(len(got), len(want))
+	for i := range n {
+		if i >= len(got) {
+			str += fmt.Sprintf("[%d]:got nil, want {%v}\n", i, want[i])
+		} else if i >= len(want) {
+			str += fmt.Sprintf("[%d]:got {%v}, want nil\n", i, got[i])
+		} else if !reflect.DeepEqual(got[i], want[i]) {
+			str += fmt.Sprintf("[%d]:got {%v}, want {%v}\n", i, got[i], want[i])
+		}
+	}
+	t.Error(str)
+}

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -156,28 +156,28 @@ func TestFuncString(t *testing.T) {
 		{
 			name:     "Function with no return type and no parameters",
 			function: &mkcgo.Func{Name: "TestFunc"},
-			want:     "TestFunc() {[]  false false  false false}",
+			want:     "TestFunc()",
 		},
 		{
 			name:     "Function with return type and no parameters",
 			function: &mkcgo.Func{Name: "TestFunc", Ret: "int"},
-			want:     "int TestFunc() {[]  false false  false false}",
+			want:     "int TestFunc()",
 		},
 		{
 			name:     "Function with parameters and no return type",
 			function: &mkcgo.Func{Name: "TestFunc", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}, {Type: "string", Name: "param2"}}},
-			want:     "TestFunc(int param1, string param2) {[]  false false  false false}",
+			want:     "TestFunc(int param1, string param2)",
 		},
 		{
 			name:     "Function with return type and parameters",
 			function: &mkcgo.Func{Name: "TestFunc", Ret: "void", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}, {Type: "float", Name: "param2"}}},
-			want:     "void TestFunc(int param1, float param2) {[]  false false  false false}",
+			want:     "void TestFunc(int param1, float param2)",
 		},
 		{
 			name: "Function with attributes",
 			function: &mkcgo.Func{Name: "TestFunc", Ret: "void", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}},
 				FuncAttrs: mkcgo.FuncAttrs{
-					Tags:       []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2"}},
+					Tags:       []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2", Name: "name"}},
 					Optional:   true,
 					NoError:    true,
 					ErrCond:    "error_condition",
@@ -185,7 +185,7 @@ func TestFuncString(t *testing.T) {
 					NoCallback: true,
 				},
 			},
-			want: "void TestFunc(int param1) {[{tag1 } {tag2 }]  true true error_condition true true}",
+			want: "void TestFunc(int param1) [{tag1 } {tag2 name}], optional, noerror, errcond(error_condition), noescape, nocallback",
 		},
 	}
 
@@ -252,7 +252,7 @@ int * F2(int **p1, void  * p2);
 int *F3(int p1, void***) __attribute__((optional));
 unsigned   long F4(int func, int type, ...);
 int* F5(float, double) __attribute__((variadic("F4")));
-void F6();`,
+void F6() __attribute__(());`,
 			want: &mkcgo.Source{
 				Funcs: []*mkcgo.Func{
 					{Name: "F0", Ret: "void", Params: []*mkcgo.Param{{"void", ""}}, FuncAttrs: mkcgo.FuncAttrs{Tags: []mkcgo.TagAttr{{Tag: "t0"}, {Tag: "t1", Name: "tn0"}}, NoError: true}},
@@ -328,9 +328,6 @@ void foo2(int a) __attribute__((variadic("foo")));
 		}, {
 			content: `void foo(void) __attribute__((tag("a"());`,
 			want:    `can't extract function attributes: unbalanced parentheses`,
-		}, {
-			content: `void foo(void) __attribute__(());`,
-			want:    `can't extract function attributes: empty attribute`,
 		}, {
 			content: `__attribute__((optional));`,
 			want:    `empty function signature`,

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -56,6 +56,7 @@ func TestFuncVariadic(t *testing.T) {
 		})
 	}
 }
+
 func TestSourceTags(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -309,7 +310,7 @@ func TestParseError(t *testing.T) {
 			want:    `empty parameter`,
 		}, {
 			content: `void foo2(int a) __attribute__((variadic("foo")));`,
-			want:    "variadic target not added yet",
+			want:    "variadic target not found in preceding code",
 		}, {
 			content: `
 void foo();

--- a/internal/mkcgo/parse.go
+++ b/internal/mkcgo/parse.go
@@ -132,7 +132,7 @@ func (src *Source) addFn(s string) error {
 			return f.Name == attrs.VariadicTarget
 		})
 		if idx == -1 {
-			return fmt.Errorf("variadic target not added yet")
+			return fmt.Errorf("variadic target not found in preceding code")
 		}
 		if !src.Funcs[idx].Variadic() {
 			return fmt.Errorf("variadic target is not variadic")
@@ -259,7 +259,7 @@ func extractFunctionAttributes(s string, fnAttrs *FuncAttrs) (string, error) {
 		return "", errors.New("__attribute__ should be followed by double parentheses")
 	}
 	if body == "" {
-		return "", errors.New("empty attribute")
+		return trim(prefix + suffix), nil
 	}
 	for body != "" {
 		// Attributes are separated by commas. Get the next attribute.

--- a/internal/mkcgo/parse.go
+++ b/internal/mkcgo/parse.go
@@ -2,142 +2,28 @@ package mkcgo
 
 import (
 	"bufio"
-	"cmp"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"slices"
 	"strings"
 )
 
-type FuncAttributes struct {
-	Tags         []TagAttr
-	VariadicInst bool
-	ImportName   string
-	Optional     bool
-	NoError      bool
-	ErrCond      string
-	NoEscape     bool
-	NoCallback   bool
-}
-
-type attribute struct {
-	name        string
-	description string
-	handle      func(*FuncAttributes, ...string) error
-}
-
-var attributes = [...]attribute{
-	{
-		name:        "tag",
-		description: "The function will be loaded together with other functions with the same tag. It can contain an optional name, which is the import name for the tag.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			var name string
-			if len(s) > 1 {
-				name = s[1]
-			}
-			opts.Tags = append(opts.Tags, TagAttr{Tag: s[0], Name: name})
-			return nil
-		},
-	},
-	{
-		name:        "variadic",
-		description: "The function has variadic arguments, and its name is a custom wrapper for the actual C name, defined in this attribute.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			opts.VariadicInst = true
-			opts.ImportName = s[0]
-			return nil
-		},
-	},
-	{
-		name:        "optional",
-		description: "The function is optional",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			opts.Optional = true
-			return nil
-		},
-	},
-	{
-		name:        "noerror",
-		description: "The function does not return an error, and the program will panic if the function returns an error.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			if opts.ErrCond != "" {
-				return errors.New("noerror attribute is not allowed with errcond attribute")
-			}
-			opts.NoError = true
-			return nil
-		},
-	},
-	{
-		name:        "errcond",
-		description: "The function returns an error if the C function returns a value that matches the condition in this attribute.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			if opts.NoError {
-				return errors.New("errcond attribute is not allowed with noerror attribute")
-			}
-			opts.ErrCond = s[0]
-			return nil
-		},
-	},
-	{
-		name:        "noescape",
-		description: "The C function does not keep a copy of the Go pointer.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			opts.NoEscape = true
-			return nil
-		},
-	},
-	{
-		name:        "nocallback",
-		description: "The C function does not call back into Go.",
-		handle: func(opts *FuncAttributes, s ...string) error {
-			opts.NoCallback = true
-			return nil
-		},
-	},
-}
-
-// Parse parses files listed in fs and extracts all syscall
-// functions listed in sys comments. It returns source files
-// and functions collection *Source if successful.
-func Parse(fs ...string) (*Source, error) {
-	src := &Source{
-		Files: fs,
-	}
-	for _, file := range fs {
-		if err := src.parseFile(file); err != nil {
-			return nil, err
-		}
-	}
-	slices.SortFunc(src.Funcs, func(fi, fj *Func) int {
-		return cmp.Compare(fi.Name, fj.Name)
-	})
-	return src, nil
-}
-
-// parseFile parses file name and extracts all symbols.
-func (src *Source) parseFile(name string) error {
-	file, err := os.Open(name)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	s := bufio.NewScanner(file)
-	var inBlockComment, inEnum bool
+// Parse parses r and adds all symbols to src.
+func (src *Source) Parse(r io.Reader) error {
+	s := bufio.NewScanner(r)
+	var inEnum bool
 	for s.Scan() {
 		line := trim(s.Text())
 		// Process comments.
-		comment, line := processComments(line, &inBlockComment)
+		if strings.Contains(line, "/*") || strings.Contains(line, "*/") {
+			// Block comment.
+			return errors.New("block comments are not supported")
+		}
+		comment, line := processComments(line)
 		comment = trim(comment)
 		if comment != "" {
-			if inBlockComment {
-				// The comment is inside a block comment.
-				// Append it to the previous comment.
-				src.Comments[len(src.Comments)-1] += "\n" + comment
-			} else {
-				src.Comments = append(src.Comments, comment)
-			}
+			src.Comments = append(src.Comments, comment)
 		}
 		line = trim(line)
 		if line == "" {
@@ -149,11 +35,9 @@ func (src *Source) parseFile(name string) error {
 				inEnum = false
 				continue
 			}
-			enum, err := newEnum(line)
-			if err != nil {
-				return err
+			if err := src.addEnum(line); err != nil {
+				return fmt.Errorf("can't parse enum in line %q: %w", line, err)
 			}
-			src.Enums = append(src.Enums, enum)
 			continue
 		}
 		if strings.HasPrefix(line, "enum {") {
@@ -162,8 +46,8 @@ func (src *Source) parseFile(name string) error {
 		}
 
 		// Process preprocessor directives.
-		if strings.HasPrefix(line, "#") {
-			if v, ok := strings.CutPrefix(line, "#include "); ok {
+		if v, found := strings.CutPrefix(line, "#"); found {
+			if v, found = strings.CutPrefix(v, "include "); found {
 				src.Includes = append(src.Includes, v)
 			}
 			// Skip all other preprocessor directives.
@@ -171,100 +55,116 @@ func (src *Source) parseFile(name string) error {
 		}
 
 		// Process typedefs.
-		if strings.Contains(line, "typedef ") {
-			td, err := newTypeDef(line)
-			if err != nil {
-				return err
+		if v, found := strings.CutPrefix(line, "typedef "); found {
+			if err := src.addTypeDef(v); err != nil {
+				return fmt.Errorf("can't parse typedef in line %q: %w", line, err)
 			}
-			src.TypeDefs = append(src.TypeDefs, td)
-			continue
-		}
-
-		// Process attributes.
-		var fnOps FuncAttributes
-		line, err = extractFunctionAttributes(line, &fnOps)
-		if err != nil {
-			return err
-		}
-		if line == "" {
 			continue
 		}
 
 		// Process function.
-		f, err := newFn(line, fnOps)
-		if err != nil {
-			return err
+		if err := src.addFn(line); err != nil {
+			return fmt.Errorf("can't parse function in line %q: %w", line, err)
 		}
-		src.Funcs = append(src.Funcs, f)
 	}
-	if err := s.Err(); err != nil {
-		return err
+	return s.Err()
+}
+
+func (src *Source) addSymbol(name string) error {
+	if src.symbols == nil {
+		src.symbols = make(map[string]struct{})
 	}
+	if _, ok := src.symbols[name]; ok {
+		return fmt.Errorf("duplicate symbol %q", name)
+	}
+	src.symbols[name] = struct{}{}
 	return nil
 }
 
-// newEnum parses string s and returns created enum definition Enum.
-func newEnum(line string) (*Enum, error) {
+// addEnum parses string s and returns created enum definition Enum.
+func (src *Source) addEnum(line string) error {
 	line = strings.TrimSuffix(line, ",")
 	split := strings.SplitN(line, "=", 2)
 	if len(split) != 2 {
-		return nil, errors.New("could not extract enum value from \"" + line + "\"")
+		return errors.New("can't extract enum value")
 	}
-	return &Enum{
-		Name:  trim(split[0]),
-		Value: trim(split[1]),
-	}, nil
+	name, value := trim(split[0]), trim(split[1])
+	if err := src.addSymbol(name); err != nil {
+		return err
+	}
+	src.Enums = append(src.Enums, &Enum{
+		Name:  name,
+		Value: value,
+	})
+	return nil
 }
 
-// newTypeDef parses string s and returns created type definition TypeDef.
-func newTypeDef(line string) (*TypeDef, error) {
-	after, found := strings.CutPrefix(line, "typedef ")
-	if !found {
-		return nil, errors.New("could not extract typedef from \"" + line + "\"")
-	}
-	after = strings.TrimSuffix(after, ";")
+// addTypeDef parses string s and returns created type definition TypeDef.
+// line should have the typedef prefix removed.
+func (src *Source) addTypeDef(line string) error {
+	after := strings.TrimSuffix(line, ";")
 	idx := strings.LastIndex(after, " ")
 	if idx < 0 {
-		return nil, errors.New("could not extract type name from \"" + after + "\"")
+		return errors.New("can't extract type name")
 	}
-	return &TypeDef{
-		Name: trim(after[idx+1:]),
-		Type: trim(after[:idx]),
-	}, nil
+	name, typ := normalizeParam(after[idx+1:], after[:idx])
+	if err := src.addSymbol(name); err != nil {
+		return err
+	}
+	src.TypeDefs = append(src.TypeDefs, &TypeDef{
+		Name: name,
+		Type: typ,
+	})
+	return nil
 }
 
-// newFn parses string s and return created function Fn.
-func newFn(s string, attrs FuncAttributes) (*Func, error) {
+// addFn parses string s and return created function Fn.
+func (src *Source) addFn(s string) error {
+	s = strings.TrimSuffix(s, ";")
+	var attrs FuncAttrs
+	s, err := extractFunctionAttributes(s, &attrs)
+	if err != nil {
+		return fmt.Errorf("can't extract function attributes: %w", err)
+	}
+	if attrs.VariadicTarget != "" {
+		// Validate variadic target.
+		idx := slices.IndexFunc(src.Funcs, func(f *Func) bool {
+			return f.Name == attrs.VariadicTarget
+		})
+		if idx == -1 {
+			return fmt.Errorf("variadic target not added yet")
+		}
+		if !src.Funcs[idx].Variadic() {
+			return fmt.Errorf("variadic target is not variadic")
+		}
+	}
+	if s == "" {
+		return errors.New("empty function signature")
+	}
 	// function name and args
 	prefix, body, _, found := extractSection(s, "(", ")")
 	if !found || prefix == "" {
-		return nil, errors.New("could not extract function name and parameters from \"" + s + "\"")
-	}
-	fn := &Func{
-		FuncAttributes: attrs,
-		Ret:            &Return{},
-	}
-	var err error
-	fn.Params, err = extractParams(body)
-	if err != nil {
-		return nil, err
+		return errors.New("invalid signature")
 	}
 	nameIdx := strings.LastIndexByte(prefix, ' ')
 	if nameIdx < 0 || nameIdx+1 >= len(prefix) {
-		return nil, errors.New("could not extract function name from \"" + s + "\"")
+		return errors.New("missing name")
 	}
-	name, typ := normalizeParam(prefix[nameIdx+1:], prefix[:nameIdx])
-	fn.Name = name
-	if attrs.ImportName != "" {
-		fn.ImportName = attrs.ImportName
-	} else {
-		fn.ImportName = name
+	params, err := extractParams(body)
+	if err != nil {
+		return err
 	}
-	fn.Ret = &Return{
-		Type: trim(typ),
-		Name: "_r0",
+	name, ret := normalizeParam(prefix[nameIdx+1:], prefix[:nameIdx])
+	if err := src.addSymbol(name); err != nil {
+		return err
 	}
-	return fn, nil
+	src.Funcs = append(src.Funcs, &Func{
+		Name:      name,
+		Ret:       ret,
+		FuncAttrs: attrs,
+		Params:    params,
+	})
+	return nil
 }
 
 // normalizeParam normalizes parameter name and type.
@@ -279,6 +179,10 @@ func normalizeParam(name, typ string) (string, string) {
 	case "type", "func":
 		name = "__" + name
 	}
+	// Remove duplicated spaces.
+	for strings.Contains(typ, "  ") {
+		typ = strings.ReplaceAll(typ, "  ", " ")
+	}
 	// Remove all spaces between the asterisks and the type.
 	typ = strings.ReplaceAll(typ, " *", "*")
 	return trim(name), trim(typ)
@@ -290,9 +194,9 @@ func trim(s string) string {
 }
 
 // extractSection extracts text out of string s starting after start
-// and ending just before end. found return value will indicate success,
+// and ending just before end. ok return value will indicate success,
 // and prefix, body and suffix will contain correspondent parts of string s.
-func extractSection(s string, start, end string) (prefix, body, suffix string, found bool) {
+func extractSection(s string, start, end string) (prefix, body, suffix string, ok bool) {
 	s = trim(s)
 	if v, ok := strings.CutPrefix(s, start); ok {
 		// no prefix
@@ -306,14 +210,14 @@ func extractSection(s string, start, end string) (prefix, body, suffix string, f
 		body = a[1]
 	}
 	idxStart := strings.Index(body, start)
-	idxEnd := strings.Index(body, end)
-	needBalancing := idxStart != -1 && idxEnd != -1 && idxStart < idxEnd
+	idxEnd := strings.LastIndex(body, end)
+	if idxEnd == -1 {
+		// no end
+		return "", "", s, false
+	}
+	needBalancing := idxStart != -1 && idxStart < idxEnd
 	if !needBalancing {
-		a := strings.SplitN(body, end, 2)
-		if len(a) != 2 {
-			return "", "", "", false
-		}
-		return prefix, a[0], a[1], true
+		return prefix, trim(body[:idxEnd]), trim(body[idxEnd+len(end):]), true
 	}
 	depth := 1
 	for i := range len(body) {
@@ -322,36 +226,21 @@ func extractSection(s string, start, end string) (prefix, body, suffix string, f
 		} else if strings.HasPrefix(body[i:], end) {
 			depth--
 			if depth == 0 {
-				return prefix, body[:i], body[i+len(end):], true
+				suffix = body[i+len(end):]
+				body = body[:i]
+				ok = true
+				break
 			}
 		}
 	}
-	return "", "", s, false
+	return
 }
 
 // processComments removes comments from line and returns the result.
-// inBlockComment is true if the line is inside a block comment.
-func processComments(line string, inBlockComment *bool) (comment, remmaining string) {
-	if *inBlockComment {
-		// Remove the rest of the block comment.
-		var found bool
-		comment, line, found = strings.Cut(line, "*/")
-		if !found {
-			return comment, ""
-		}
-		*inBlockComment = false
-	}
+func processComments(line string) (comment, remmaining string) {
 	// Remove line comments.
 	if before, comment, found := strings.Cut(line, "//"); found {
 		return comment, before
-	}
-	// Remove block comments.
-	if prefix, _, suffix, found := extractSection(line, "/*", "*/"); found {
-		line = prefix + suffix
-	}
-	// Remove block comments that span multiple lines.
-	if line, comment, *inBlockComment = strings.Cut(line, "/*"); *inBlockComment {
-		return comment, line
 	}
 	return "", line
 }
@@ -359,25 +248,20 @@ func processComments(line string, inBlockComment *bool) (comment, remmaining str
 // extractFunctionAttributes extracts mkcgo attributes from string s.
 // The attributes format follows the GCC __attribute__ syntax as
 // described in https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html.
-func extractFunctionAttributes(s string, fnAttrs *FuncAttributes) (string, error) {
+func extractFunctionAttributes(s string, fnAttrs *FuncAttrs) (string, error) {
 	// There can be spaces between __attribute__ and the opening parenthesis.
 	prefix, body, found := strings.Cut(s, "__attribute__")
 	if !found {
 		return s, nil
 	}
-	_, body, suffix, found := extractSection(body, "(", ")")
+	_, body, suffix, found := extractSection(body, "((", "))")
 	if !found {
-		return s, nil
+		return "", errors.New("__attribute__ should be followed by double parentheses")
 	}
-	if !strings.HasPrefix(body, "(") || !strings.HasSuffix(body, ")") {
-		// Attributes are enclosed in double parentheses.
-		return s, nil
+	if body == "" {
+		return "", errors.New("empty attribute")
 	}
-	body = trim(body[1 : len(body)-1])
-	for {
-		if body == "" {
-			break
-		}
+	for body != "" {
 		// Attributes are separated by commas. Get the next attribute.
 		// We can't just use strings.Split because the attribute argument
 		// can contain commas.
@@ -393,11 +277,11 @@ func extractFunctionAttributes(s string, fnAttrs *FuncAttributes) (string, error
 			name = body[:idxParen]
 			_, args, body, found = extractSection(body[idxParen:], "(", ")")
 			if !found {
-				return "", errors.New("unbalanced parentheses in line: " + s)
+				return "", errors.New("unbalanced parentheses")
 			}
 			body = trim(body)
 			if len(body) > 0 && body[0] != ',' {
-				return "", errors.New("parameters must be separated by commas in line: " + s)
+				return "", errors.New("parameters must be separated by commas")
 			}
 			body = strings.TrimPrefix(body, ",")
 		} else if idxComma == -1 && idxParen == -1 {
@@ -411,12 +295,15 @@ func extractFunctionAttributes(s string, fnAttrs *FuncAttributes) (string, error
 			if name != attr.name {
 				continue
 			}
-			vargs := strings.Split(args, ",")
-			for i := range vargs {
-				vargs[i] = trim(strings.Trim(vargs[i], `"`))
+			var vargs []string
+			if args != "" {
+				vargs = strings.Split(args, ",")
+				for i := range vargs {
+					vargs[i] = trim(strings.Trim(vargs[i], `"`))
+				}
 			}
 			if err := attr.handle(fnAttrs, vargs...); err != nil {
-				return "", fmt.Errorf("error parsing attribute in line: %v: %w", s, err)
+				return "", fmt.Errorf("error parsing attribute %s: %w", name, err)
 			}
 			handled = true
 			break
@@ -432,12 +319,16 @@ func extractFunctionAttributes(s string, fnAttrs *FuncAttributes) (string, error
 func extractParams(s string) ([]*Param, error) {
 	s = trim(s)
 	if s == "" {
-		return nil, nil
+		// No parameters, normalize to "void".
+		return []*Param{{"void", ""}}, nil
 	}
 	a := strings.Split(s, ",")
 	ps := make([]*Param, 0, len(a))
 	for i := range a {
 		s2 := trim(a[i])
+		if s2 == "" {
+			return nil, errors.New("empty parameter")
+		}
 		b := strings.LastIndexByte(s2, ' ')
 		var name, typ string
 		if b != -1 {


### PR DESCRIPTION
This PR adds unit tests for the `internal/mkcgo` package. The coverage is 100% (if that means somethinf 😄):

```
go test -cover ./internal/mkcgo 
ok      github.com/golang-fips/openssl/v2/internal/mkcgo        7.642s  coverage: 99.6% of statements
```

I've refactored some APIs to make to make them easier to test, added some additional validations, and fixed some bugs (which `shims.h` was not exercising) along the way.

Test for `cmd/mkcgo` will come in a follow-up PR.