### PR TITLE
Link with -ldl

### DIFF
--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -20,7 +20,8 @@ func generateGo(src *mkcgo.Source, w io.Writer) {
 
 	// This block outputs C header includes and forward declarations for loader functions.
 	fmt.Fprintf(w, "/*\n")
-	fmt.Fprintf(w, "#cgo CFLAGS: -Wno-attributes\n\n")
+	fmt.Fprintf(w, "#cgo CFLAGS: -Wno-attributes\n")
+	fmt.Fprintf(w, "#cgo LDFLAGS: -ldl\n\n")
 	if *includeHeader != "" {
 		fmt.Fprintf(w, "#include \"%s\"\n", *includeHeader)
 	}

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -21,7 +21,7 @@ func generateGo(src *mkcgo.Source, w io.Writer) {
 	// This block outputs C header includes and forward declarations for loader functions.
 	fmt.Fprintf(w, "/*\n")
 	fmt.Fprintf(w, "#cgo CFLAGS: -Wno-attributes\n")
-	fmt.Fprintf(w, "#cgo LDFLAGS: -ldl\n\n")
+	fmt.Fprintf(w, "#cgo unix LDFLAGS: -ldl\n\n")
 	if *includeHeader != "" {
 		fmt.Fprintf(w, "#include \"%s\"\n", *includeHeader)
 	}

--- a/internal/ossl/zossl.go
+++ b/internal/ossl/zossl.go
@@ -4,6 +4,7 @@ package ossl
 
 /*
 #cgo CFLAGS: -Wno-attributes
+#cgo LDFLAGS: -ldl
 
 #include "zossl.h"
 */

--- a/internal/ossl/zossl.go
+++ b/internal/ossl/zossl.go
@@ -4,7 +4,7 @@ package ossl
 
 /*
 #cgo CFLAGS: -Wno-attributes
-#cgo LDFLAGS: -ldl
+#cgo unix LDFLAGS: -ldl
 
 #include "zossl.h"
 */


### PR DESCRIPTION
The `internal/ossl` package calls `dlsym` without linking against the dynamic linking library (aka `dl`). This is normally OK, as the root package (`openssl`) already adds the `#cgo LDFLAGS: -ldl` directive.

The problem is that the Go linker tries to build the `internal/ossl` alone to infer if internal linking is possible, in which case the aforementioned cgo directive is not used and the linker falls back to external linking.

We haven't hit this earlier because most C toolchains import the dynamic linking library automatically. Regardless, we should strive for maximum compatibility, so better be explicit. For example, the C toolchain installed in Mariner 1 doesn't add that library automatically, and that's blocking this PR: https://github.com/microsoft/go/pull/1596. 