### PR TITLE
Add exclamation mark for versions less than Go 1.25

### DIFF
--- a/hashclone.go
+++ b/hashclone.go
@@ -1,4 +1,4 @@
-//go:build !cmd_go_bootstrap
+//go:build !go1.25 && !cmd_go_bootstrap
 
 package openssl
 


### PR DESCRIPTION
This pull request updates the build constraint in the `hashclone.go` file to ensure compatibility with Go versions earlier than 1.25.