### PR TITLE
Wrap hash state not marshallable errors with ErrUnsupported

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -6,7 +6,6 @@ import "C"
 import (
 	"crypto"
 	"errors"
-	"fmt"
 	"hash"
 	"runtime"
 	"strconv"
@@ -373,11 +372,19 @@ func (h *evpHash) Clone() (HashCloner, error) {
 	return h2, nil
 }
 
-var errHashNotMarshallable = fmt.Errorf("openssl: hash state is not marshallable: %w", errors.ErrUnsupported)
+type errMarshallUnsupported struct{}
+
+func (e errMarshallUnsupported) Error() string {
+	return "cryptokit: hash state is not marshallable"
+}
+
+func (e errMarshallUnsupported) Unwrap() error {
+	return errors.ErrUnsupported
+}
 
 func (d *evpHash) MarshalBinary() ([]byte, error) {
 	if !d.alg.marshallable {
-		return nil, errHashNotMarshallable
+		return nil, errMarshallUnsupported{}
 	}
 	buf := make([]byte, 0, d.alg.marshalledSize)
 	return d.AppendBinary(buf)
@@ -386,7 +393,7 @@ func (d *evpHash) MarshalBinary() ([]byte, error) {
 func (d *evpHash) AppendBinary(buf []byte) ([]byte, error) {
 	defer runtime.KeepAlive(d)
 	if !d.alg.marshallable {
-		return nil, errHashNotMarshallable
+		return nil, errMarshallUnsupported{}
 	}
 	d.init()
 	switch d.alg.provider {
@@ -403,7 +410,7 @@ func (d *evpHash) UnmarshalBinary(b []byte) error {
 	defer runtime.KeepAlive(d)
 	d.init()
 	if !d.alg.marshallable {
-		return errHashNotMarshallable
+		return errMarshallUnsupported{}
 	}
 	if len(b) < len(d.alg.magic) || string(b[:len(d.alg.magic)]) != d.alg.magic {
 		return errors.New("openssl: invalid hash state identifier")

--- a/hash.go
+++ b/hash.go
@@ -6,6 +6,7 @@ import "C"
 import (
 	"crypto"
 	"errors"
+	"fmt"
 	"hash"
 	"runtime"
 	"strconv"
@@ -372,7 +373,7 @@ func (h *evpHash) Clone() (HashCloner, error) {
 	return h2, nil
 }
 
-var errHashNotMarshallable = errors.New("openssl: hash state is not marshallable")
+var errHashNotMarshallable = fmt.Errorf("openssl: hash state is not marshallable: %w", errors.ErrUnsupported)
 
 func (d *evpHash) MarshalBinary() ([]byte, error) {
 	if !d.alg.marshallable {

--- a/hash_test.go
+++ b/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto"
 	"encoding"
+	"errors"
 	"hash"
 	"io"
 	"runtime"
@@ -195,7 +196,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 			// Append binary data to the prebuilt slice
 			state, err := hashWithBinaryAppender.AppendBinary(prebuiltSlice)
 			if err != nil {
-				if strings.Contains(err.Error(), "hash state is not marshallable") {
+				if errors.Is(err, errors.ErrUnsupported) {
 					t.Skip("AppendBinary not supported")
 				}
 				t.Errorf("could not append binary: %v", err)


### PR DESCRIPTION
This pull request refactors error handling in the OpenSSL package to provide easier to assert error messages by wrapping errors with additional context using errors.ErrUnsupported. It also includes minor import adjustments in the affected files.
This PR addresses one of the steps of: https://github.com/microsoft/go/issues/1683