### PR TITLE
[ms-go1.25-support] don't call ERR_clear_error before every OpenSSL call

### DIFF
--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -176,7 +176,6 @@ func generateCHeader(src *mkcgo.Source, w io.Writer) {
 	fmt.Fprintf(w, "typedef void* %s;\n", mkcgoErrState)
 	fmt.Fprintf(w, "%s mkcgo_err_retrieve();\n", mkcgoErrState)
 	fmt.Fprintf(w, "void mkcgo_err_free(%s);\n", mkcgoErrState)
-	fmt.Fprintf(w, "void mkcgo_err_clear();\n\n")
 
 	// Add forward declarations for loader functions.
 	for _, tag := range src.Tags() {
@@ -392,7 +391,6 @@ func generateCFn(typedefs map[string]string, fn *mkcgo.Func, w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "%s %s(%s) {\n", fn.Ret, fnCName(fn), fnCErrWrapperParams(fn, true))
-	fmt.Fprintf(w, "\tmkcgo_err_clear();\n") // clear any previous error
 	fmt.Fprintf(w, "\t%s _ret = _g_%s(%s);\n", fn.Ret, fn.ImportName(), fnToCArgs(fn, false, true))
 	errCond := "<= 0"
 	if fn.ErrCond != "" {

--- a/internal/ossl/errors.go
+++ b/internal/ossl/errors.go
@@ -16,12 +16,6 @@ typedef struct ossl_err_state_st {
 	char *file[ERR_NUM_MAX];
 } ossl_err_state;
 
-// mkcgo_err_clear clears the error queue in OpenSSL.
-void mkcgo_err_clear() {
-	// Clear the error queue.
-	_mkcgo_ERR_clear_error();
-}
-
 // mkcgo_err_retrieve retrieves the error state from OpenSSL.
 // It returns a pointer to a mkcgo_err_state structure
 // that contains the error codes, lines, and file names.

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -749,21 +749,18 @@ void __mkcgo_unload_version() {
 }
 
 _BIGNUM_PTR _mkcgo_BN_bin2bn(const unsigned char* _arg0, int _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_BIGNUM_PTR _ret = _g_BN_bin2bn(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_BN_bn2binpad(const _BIGNUM_PTR _arg0, unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_BN_bn2binpad(_arg0, _arg1, _arg2);
 	if (_ret == -1) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_BN_bn2lebinpad(const _BIGNUM_PTR _arg0, unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_BN_bn2lebinpad(_arg0, _arg1, _arg2);
 	if (_ret == -1) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -782,14 +779,12 @@ void _mkcgo_BN_free(_BIGNUM_PTR _arg0) {
 }
 
 _BIGNUM_PTR _mkcgo_BN_lebin2bn(const unsigned char* _arg0, int _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_BIGNUM_PTR _ret = _g_BN_lebin2bn(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _BIGNUM_PTR _mkcgo_BN_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_BIGNUM_PTR _ret = _g_BN_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -804,7 +799,6 @@ void _mkcgo_CRYPTO_free(void* _arg0, const char* _arg1, int _arg2) {
 }
 
 void* _mkcgo_CRYPTO_malloc(size_t _arg0, const char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	void* _ret = _g_CRYPTO_malloc(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -815,7 +809,6 @@ void _mkcgo_DSA_free(_DSA_PTR _arg0) {
 }
 
 int _mkcgo_DSA_generate_key(_DSA_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_DSA_generate_key(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -830,21 +823,18 @@ void _mkcgo_DSA_get0_pqg(const _DSA_PTR _arg0, const _BIGNUM_PTR* _arg1, const _
 }
 
 _DSA_PTR _mkcgo_DSA_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_DSA_PTR _ret = _g_DSA_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_DSA_set0_key(_DSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_DSA_set0_key(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_DSA_set0_pqg(_DSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_DSA_set0_pqg(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -855,14 +845,12 @@ void _mkcgo_EC_GROUP_free(_EC_GROUP_PTR _arg0) {
 }
 
 _EC_GROUP_PTR _mkcgo_EC_GROUP_new_by_curve_name(int _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EC_GROUP_PTR _ret = _g_EC_GROUP_new_by_curve_name(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_KEY_check_key(const _EC_KEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_KEY_check_key(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -885,28 +873,24 @@ const _EC_POINT_PTR _mkcgo_EC_KEY_get0_public_key(const _EC_KEY_PTR _arg0) {
 }
 
 _EC_KEY_PTR _mkcgo_EC_KEY_new_by_curve_name(int _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EC_KEY_PTR _ret = _g_EC_KEY_new_by_curve_name(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_KEY_set_private_key(_EC_KEY_PTR _arg0, const _BIGNUM_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_KEY_set_private_key(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_KEY_set_public_key(_EC_KEY_PTR _arg0, const _EC_POINT_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_KEY_set_public_key(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_KEY_set_public_key_affine_coordinates(_EC_KEY_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_KEY_set_public_key_affine_coordinates(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -917,42 +901,36 @@ void _mkcgo_EC_POINT_free(_EC_POINT_PTR _arg0) {
 }
 
 int _mkcgo_EC_POINT_get_affine_coordinates_GFp(const _EC_GROUP_PTR _arg0, const _EC_POINT_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_POINT_get_affine_coordinates_GFp(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_POINT_mul(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const _BIGNUM_PTR _arg2, const _EC_POINT_PTR _arg3, const _BIGNUM_PTR _arg4, _BN_CTX_PTR _arg5, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_POINT_mul(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EC_POINT_PTR _mkcgo_EC_POINT_new(const _EC_GROUP_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EC_POINT_PTR _ret = _g_EC_POINT_new(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_POINT_oct2point(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const unsigned char* _arg2, size_t _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_POINT_oct2point(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 size_t _mkcgo_EC_POINT_point2oct(const _EC_GROUP_PTR _arg0, const _EC_POINT_PTR _arg1, point_conversion_form_t _arg2, unsigned char* _arg3, size_t _arg4, _BN_CTX_PTR _arg5, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	size_t _ret = _g_EC_POINT_point2oct(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EC_POINT_set_affine_coordinates(const _EC_GROUP_PTR _arg0, _EC_POINT_PTR _arg1, const _BIGNUM_PTR _arg2, const _BIGNUM_PTR _arg3, _BN_CTX_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EC_POINT_set_affine_coordinates(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -975,7 +953,6 @@ unsigned long _mkcgo_ERR_get_error_line(const char** _arg0, int* _arg1) {
 }
 
 int _mkcgo_EVP_CIPHER_CTX_ctrl(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, int _arg2, void* _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_CIPHER_CTX_ctrl(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -986,28 +963,24 @@ void _mkcgo_EVP_CIPHER_CTX_free(_EVP_CIPHER_CTX_PTR _arg0) {
 }
 
 _EVP_CIPHER_CTX_PTR _mkcgo_EVP_CIPHER_CTX_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_CIPHER_CTX_PTR _ret = _g_EVP_CIPHER_CTX_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_CIPHER_CTX_set_key_length(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_CIPHER_CTX_set_key_length(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_CIPHER_CTX_set_padding(_EVP_CIPHER_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_CIPHER_CTX_set_padding(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_CIPHER_PTR _mkcgo_EVP_CIPHER_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_CIPHER_PTR _ret = _g_EVP_CIPHER_fetch(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1022,133 +995,114 @@ int _mkcgo_EVP_CIPHER_get_block_size(const _EVP_CIPHER_PTR _arg0) {
 }
 
 int _mkcgo_EVP_CipherInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, int _arg5, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_CipherInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_CipherUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DecryptFinal_ex(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DecryptInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DecryptUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_Digest(const void* _arg0, size_t _arg1, unsigned char* _arg2, unsigned int* _arg3, const _EVP_MD_PTR _arg4, _ENGINE_PTR _arg5, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_Digest(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestFinal_ex(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, unsigned int* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestFinal_ex(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestInit(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestInit(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestInit_ex(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, _ENGINE_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestInit_ex(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestSign(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestSign(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestSignFinal(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestSignFinal(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestSignInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, const _EVP_MD_PTR _arg2, _ENGINE_PTR _arg3, _EVP_PKEY_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestSignInit(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR _arg0, const void* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestUpdate(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestVerify(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestVerify(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestVerifyFinal(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_DigestVerifyInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, const _EVP_MD_PTR _arg2, _ENGINE_PTR _arg3, _EVP_PKEY_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_DigestVerifyInit(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_EncryptFinal_ex(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_EncryptFinal_ex(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_EncryptInit_ex(_EVP_CIPHER_CTX_PTR _arg0, const _EVP_CIPHER_PTR _arg1, _ENGINE_PTR _arg2, const unsigned char* _arg3, const unsigned char* _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_EncryptInit_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_EncryptUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, int* _arg2, const unsigned char* _arg3, int _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_EncryptUpdate(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1159,35 +1113,30 @@ void _mkcgo_EVP_KDF_CTX_free(_EVP_KDF_CTX_PTR _arg0) {
 }
 
 size_t _mkcgo_EVP_KDF_CTX_get_kdf_size(_EVP_KDF_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	size_t _ret = _g_EVP_KDF_CTX_get_kdf_size(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_KDF_CTX_PTR _mkcgo_EVP_KDF_CTX_new(_EVP_KDF_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_KDF_CTX_PTR _ret = _g_EVP_KDF_CTX_new(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_KDF_CTX_set_params(_EVP_KDF_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_KDF_CTX_set_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_KDF_derive(_EVP_KDF_CTX_PTR _arg0, unsigned char* _arg1, size_t _arg2, const _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_KDF_derive(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_KDF_PTR _mkcgo_EVP_KDF_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_KDF_PTR _ret = _g_EVP_KDF_fetch(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1198,7 +1147,6 @@ void _mkcgo_EVP_KDF_free(_EVP_KDF_PTR _arg0) {
 }
 
 _EVP_MAC_CTX_PTR _mkcgo_EVP_MAC_CTX_dup(const _EVP_MAC_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_MAC_CTX_PTR _ret = _g_EVP_MAC_CTX_dup(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1209,56 +1157,48 @@ void _mkcgo_EVP_MAC_CTX_free(_EVP_MAC_CTX_PTR _arg0) {
 }
 
 _EVP_MAC_CTX_PTR _mkcgo_EVP_MAC_CTX_new(_EVP_MAC_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_MAC_CTX_PTR _ret = _g_EVP_MAC_CTX_new(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MAC_CTX_set_params(_EVP_MAC_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MAC_CTX_set_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_MAC_PTR _mkcgo_EVP_MAC_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_MAC_PTR _ret = _g_EVP_MAC_fetch(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MAC_final(_EVP_MAC_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MAC_final(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MAC_init(_EVP_MAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MAC_init(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MAC_update(_EVP_MAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MAC_update(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MD_CTX_copy(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MD_CTX_copy(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR _arg0, const _EVP_MD_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MD_CTX_copy_ex(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1269,42 +1209,36 @@ void _mkcgo_EVP_MD_CTX_free(_EVP_MD_CTX_PTR _arg0) {
 }
 
 int _mkcgo_EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR _arg0, _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MD_CTX_get_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	const _OSSL_PARAM_PTR _ret = _g_EVP_MD_CTX_gettable_params(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_MD_CTX_PTR _mkcgo_EVP_MD_CTX_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_MD_CTX_PTR _ret = _g_EVP_MD_CTX_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_MD_CTX_set_params(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 const _OSSL_PARAM_PTR _mkcgo_EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	const _OSSL_PARAM_PTR _ret = _g_EVP_MD_CTX_settable_params(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_MD_PTR _mkcgo_EVP_MD_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_MD_PTR _ret = _g_EVP_MD_fetch(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1335,14 +1269,12 @@ int _mkcgo_EVP_MD_get_type(const _EVP_MD_PTR _arg0) {
 }
 
 int _mkcgo_EVP_PKEY_CTX_add1_hkdf_info(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_add1_hkdf_info(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR _arg0, int _arg1, int _arg2, int _arg3, int _arg4, void* _arg5, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_ctrl(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1353,133 +1285,114 @@ void _mkcgo_EVP_PKEY_CTX_free(_EVP_PKEY_CTX_PTR _arg0) {
 }
 
 _EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new(_EVP_PKEY_PTR _arg0, _ENGINE_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new(_arg0, _arg1);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR _arg0, _EVP_PKEY_PTR _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_from_pkey(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_CTX_PTR _mkcgo_EVP_PKEY_CTX_new_id(int _arg0, _ENGINE_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_CTX_PTR _ret = _g_EVP_PKEY_CTX_new_id(_arg0, _arg1);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR _arg0, void* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_set0_rsa_oaep_label(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_set1_hkdf_key(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_set1_hkdf_salt(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR _arg0, const _EVP_MD_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_set_hkdf_md(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_CTX_set_hkdf_mode(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, const char* _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2, _arg3);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2, _arg3);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_assign(_EVP_PKEY_PTR _arg0, int _arg1, void* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_assign(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_decrypt(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_decrypt(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_decrypt_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_decrypt_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_derive(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_derive(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_derive_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_derive_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_derive_set_peer(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_derive_set_peer(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_encrypt(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_encrypt(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_encrypt_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_encrypt_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1490,196 +1403,168 @@ void _mkcgo_EVP_PKEY_free(_EVP_PKEY_PTR _arg0) {
 }
 
 int _mkcgo_EVP_PKEY_fromdata(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, int _arg2, _OSSL_PARAM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_fromdata(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_fromdata_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _DSA_PTR _mkcgo_EVP_PKEY_get0_DSA(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_DSA_PTR _ret = _g_EVP_PKEY_get0_DSA(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EC_KEY_PTR _mkcgo_EVP_PKEY_get0_EC_KEY(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EC_KEY_PTR _ret = _g_EVP_PKEY_get0_EC_KEY(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _RSA_PTR _mkcgo_EVP_PKEY_get1_RSA(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_RSA_PTR _ret = _g_EVP_PKEY_get1_RSA(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 size_t _mkcgo_EVP_PKEY_get1_encoded_public_key(_EVP_PKEY_PTR _arg0, unsigned char** _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	size_t _ret = _g_EVP_PKEY_get1_encoded_public_key(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_get_bits(const _EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_get_bits(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_get_bn_param(const _EVP_PKEY_PTR _arg0, const char* _arg1, _BIGNUM_PTR* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_get_bn_param(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_get_raw_private_key(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR _arg0, unsigned char* _arg1, size_t* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_get_raw_public_key(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_get_size(const _EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_get_size(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_keygen(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_keygen(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_keygen_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_keygen_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_new_raw_private_key(int _arg0, _ENGINE_PTR _arg1, const unsigned char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new_raw_private_key(_arg0, _arg1, _arg2, _arg3);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_new_raw_public_key(int _arg0, _ENGINE_PTR _arg1, const unsigned char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_new_raw_public_key(_arg0, _arg1, _arg2, _arg3);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_paramgen(_EVP_PKEY_CTX_PTR _arg0, _EVP_PKEY_PTR* _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_paramgen(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_paramgen_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_paramgen_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_private_check(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_private_check(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_public_check_quick(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_public_check_quick(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR _arg0, _EC_KEY_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_set1_EC_KEY(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_set1_encoded_public_key(_EVP_PKEY_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_set1_encoded_public_key(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_sign(_EVP_PKEY_CTX_PTR _arg0, unsigned char* _arg1, size_t* _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_sign(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_sign_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_sign_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_up_ref(_EVP_PKEY_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_up_ref(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_verify(_EVP_PKEY_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, const unsigned char* _arg3, size_t _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_verify(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_EVP_PKEY_verify_init(_EVP_PKEY_CTX_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_PKEY_verify_init(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _EVP_SIGNATURE_PTR _mkcgo_EVP_SIGNATURE_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_EVP_SIGNATURE_PTR _ret = _g_EVP_SIGNATURE_fetch(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1738,7 +1623,6 @@ const _EVP_CIPHER_PTR _mkcgo_EVP_aes_256_gcm(void) {
 }
 
 int _mkcgo_EVP_default_properties_enable_fips(_OSSL_LIB_CTX_PTR _arg0, int _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_EVP_default_properties_enable_fips(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1833,14 +1717,12 @@ int _mkcgo_FIPS_mode(void) {
 }
 
 int _mkcgo_FIPS_mode_set(int _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_FIPS_mode_set(_arg0);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_HMAC_CTX_copy(_HMAC_CTX_PTR _arg0, _HMAC_CTX_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_HMAC_CTX_copy(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1851,28 +1733,24 @@ void _mkcgo_HMAC_CTX_free(_HMAC_CTX_PTR _arg0) {
 }
 
 _HMAC_CTX_PTR _mkcgo_HMAC_CTX_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_HMAC_CTX_PTR _ret = _g_HMAC_CTX_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_HMAC_Final(_HMAC_CTX_PTR _arg0, unsigned char* _arg1, unsigned int* _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_HMAC_Final(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_HMAC_Init_ex(_HMAC_CTX_PTR _arg0, const void* _arg1, int _arg2, const _EVP_MD_PTR _arg3, _ENGINE_PTR _arg4, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_HMAC_Init_ex(_arg0, _arg1, _arg2, _arg3, _arg4);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_HMAC_Update(_HMAC_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_HMAC_Update(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1887,7 +1765,6 @@ void _mkcgo_OPENSSL_init(void) {
 }
 
 int _mkcgo_OPENSSL_init_crypto(uint64_t _arg0, const _OPENSSL_INIT_SETTINGS_PTR _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_OPENSSL_init_crypto(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1922,42 +1799,36 @@ void _mkcgo_OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR _arg0) {
 }
 
 _OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_OSSL_PARAM_BLD_PTR _ret = _g_OSSL_PARAM_BLD_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_OSSL_PARAM_BLD_push_BN(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_OSSL_PARAM_BLD_push_int32(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, int32_t _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_OSSL_PARAM_BLD_push_int32(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const void* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_OSSL_PARAM_BLD_push_octet_string(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const char* _arg2, size_t _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_OSSL_PARAM_BLD_push_utf8_string(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 _OSSL_PARAM_PTR _mkcgo_OSSL_PARAM_BLD_to_param(_OSSL_PARAM_BLD_PTR _arg0, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_OSSL_PARAM_PTR _ret = _g_OSSL_PARAM_BLD_to_param(_arg0);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1968,7 +1839,6 @@ void _mkcgo_OSSL_PARAM_free(_OSSL_PARAM_PTR _arg0) {
 }
 
 const _OSSL_PARAM_PTR _mkcgo_OSSL_PARAM_locate_const(const _OSSL_PARAM_PTR _arg0, const char* _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	const _OSSL_PARAM_PTR _ret = _g_OSSL_PARAM_locate_const(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1983,7 +1853,6 @@ const char* _mkcgo_OSSL_PROVIDER_get0_name(const _OSSL_PROVIDER_PTR _arg0) {
 }
 
 _OSSL_PROVIDER_PTR _mkcgo_OSSL_PROVIDER_try_load(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, int _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_OSSL_PROVIDER_PTR _ret = _g_OSSL_PROVIDER_try_load(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -2002,14 +1871,12 @@ unsigned long _mkcgo_OpenSSL_version_num(void) {
 }
 
 int _mkcgo_PKCS5_PBKDF2_HMAC(const char* _arg0, int _arg1, const unsigned char* _arg2, int _arg3, int _arg4, const _EVP_MD_PTR _arg5, int _arg6, unsigned char* _arg7, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_PKCS5_PBKDF2_HMAC(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5, _arg6, _arg7);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_RAND_bytes(unsigned char* _arg0, int _arg1, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_RAND_bytes(_arg0, _arg1);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -2032,28 +1899,24 @@ void _mkcgo_RSA_get0_key(const _RSA_PTR _arg0, const _BIGNUM_PTR* _arg1, const _
 }
 
 _RSA_PTR _mkcgo_RSA_new(mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	_RSA_PTR _ret = _g_RSA_new();
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_RSA_set0_crt_params(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_RSA_set0_crt_params(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_RSA_set0_factors(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_RSA_set0_factors(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }
 
 int _mkcgo_RSA_set0_key(_RSA_PTR _arg0, _BIGNUM_PTR _arg1, _BIGNUM_PTR _arg2, _BIGNUM_PTR _arg3, mkcgo_err_state *_err_state) {
-	mkcgo_err_clear();
 	int _ret = _g_RSA_set0_key(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -90,8 +90,6 @@ enum {
 typedef void* mkcgo_err_state;
 mkcgo_err_state mkcgo_err_retrieve();
 void mkcgo_err_free(mkcgo_err_state);
-void mkcgo_err_clear();
-
 void __mkcgo_load_(void* handle);
 void __mkcgo_unload_();
 void __mkcgo_load_111(void* handle);


### PR DESCRIPTION
Backporting #289.  It fixes an important performance regression introduced in Go 1.25.