### PR TITLE
cipher: swith from ECB to CBC mode for AES lookups

### DIFF
--- a/cipher.go
+++ b/cipher.go
@@ -149,7 +149,7 @@ type evpCipher struct {
 }
 
 func newEVPCipher(key []byte, kind cipherKind) (*evpCipher, error) {
-	cipher := loadCipher(kind, cipherModeECB)
+	cipher := loadCipher(kind, cipherModeCBC)
 	if cipher == nil {
 		return nil, errors.New("crypto/cipher: unsupported cipher: " + kind.String())
 	}


### PR DESCRIPTION
newEVPCipher function returns AES cipher of any supported modes. It
does so by loading an AES cipher with ECB mode.

Pure stand-alone ECB mode (but not as a primitive in other modes) is
deprecated and will be retired by upcoming [NIST SP 800-131A Rev. 3](https://csrc.nist.gov/pubs/sp/800/131/a/r3/ipd).

Separately geomys module upstream blocks ECB mode completely in FIPS
mode.

I think this is a minimal change, which shouldn't affect any existing
matrix of any providers, as far as I can tell CBC is available
everywhere ECB is.

But this change fixes using OpenSSL FIPS providers that make ECB mode
private.
