### PR TITLE
CI: add qemu testing for other arches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.24, 1.25]
-        architecture: [ppc64le, s390x, arm/v7, riscv64]
+        architecture: [ppc64le, s390x, riscv64]
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
-    runs-on: ubuntu-22.04
+        distro: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.distro }}
     steps:
     - name: Install build tools
       run: sudo apt-get install -y build-essential
@@ -154,6 +155,48 @@ jobs:
   #
   # The golang-fips/openssl module can't do any crypto when built without cgo,
   # but it exports a few simple functions and types.
+  ppc64le-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.24.x, 1.25.x]
+        openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1]  # Subset for faster CI
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ppc64le
+    - name: Checkout code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Run tests on ppc64le
+      run: |
+        docker run --rm --platform linux/ppc64le \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          -e GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }} \
+          -e CGO_ENABLED=1 \
+          golang:${{ matrix.go-version }}-bookworm \
+          bash -c "
+            apt-get update && apt-get install -y build-essential &&
+            ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
+            go test -gcflags=all=-d=checkptr -count 5 -v ./...
+          "
+    - name: Run tests CGO disabled on ppc64le
+      run: |
+        docker run --rm --platform linux/ppc64le \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          -e GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }} \
+          -e CGO_ENABLED=0 \
+          -e GOFLAGS="-tags=goexperiment.ms_nocgo_opensslcrypto" \
+          golang:${{ matrix.go-version }}-bookworm \
+          bash -c "
+            apt-get update && apt-get install -y build-essential &&
+            ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
+            go test -count 5 -v ./...
+          "
+
   cgolessbuild:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.24, 1.25]
         openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1]  # Subset for faster CI
     steps:
     - name: Set up QEMU

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
-        distro: [ubuntu-22.04]
-    runs-on: ${{ matrix.distro }}
+    runs-on: ubuntu-22.04
     steps:
     - name: Install build tools
       run: sudo apt-get install -y build-essential
@@ -154,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.24, 1.25]
-        architecture: [ppc64le, s390x, arm32v7, riscv64]
+        architecture: [ppc64le, s390x, arm/v7, riscv64]
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
-        distro: [ubuntu-22.04, ubuntu-22.04-arm]
+        distro: [ubuntu-22.04]
     runs-on: ${{ matrix.distro }}
     steps:
     - name: Install build tools
@@ -148,6 +148,30 @@ jobs:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
 
+  test-qemu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.24, 1.25]
+        architecture: [ppc64le, s390x, arm32v7, riscv64]
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      with:
+        platforms: ${{ matrix.architecture }}
+    - name: Checkout code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Run tests on ${{matrix.architecture}}
+      run: |
+        docker run --rm --platform linux/${{matrix.architecture}} \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          golang:${{ matrix.go-version }} \
+          bash -c "
+            go test ./... -v
+          "
+
   # Verify that golang-fips/openssl builds successfully without cgo enabled.
   #
   # A project can avoid attempting to build the openssl package by only
@@ -160,50 +184,6 @@ jobs:
   #
   # The golang-fips/openssl module can't do any crypto when built without cgo,
   # but it exports a few simple functions and types.
-  ppc64le-test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.24, 1.25]
-        openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1]  # Subset for faster CI
-    steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      with:
-        platforms: ppc64le
-    - name: Checkout code
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - name: Run tests on ppc64le
-      run: |
-        docker run --rm --platform linux/ppc64le \
-          -v ${{ github.workspace }}:/workspace \
-          -w /workspace \
-          -e GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }} \
-          -e CGO_ENABLED=1 \
-          golang:${{ matrix.go-version }}-bookworm \
-          bash -c "
-            apt-get update && apt-get install -y build-essential &&
-            chmod +x ./scripts/openssl.sh &&
-            ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
-            go test -gcflags=all=-d=checkptr -count 5 -v ./...
-          "
-    - name: Run tests CGO disabled on ppc64le
-      run: |
-        docker run --rm --platform linux/ppc64le \
-          -v ${{ github.workspace }}:/workspace \
-          -w /workspace \
-          -e GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }} \
-          -e CGO_ENABLED=0 \
-          -e GOFLAGS="-tags=goexperiment.ms_nocgo_opensslcrypto" \
-          golang:${{ matrix.go-version }}-bookworm \
-          bash -c "
-            apt-get update && apt-get install -y build-essential &&
-            chmod +x ./scripts/openssl.sh &&
-            ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
-            go test -count 5 -v ./...
-          "
-
   cgolessbuild:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,9 @@
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 name: Test
 jobs:
   test:
@@ -164,7 +169,7 @@ jobs:
         openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1]  # Subset for faster CI
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       with:
         platforms: ppc64le
     - name: Checkout code
@@ -179,6 +184,7 @@ jobs:
           golang:${{ matrix.go-version }}-bookworm \
           bash -c "
             apt-get update && apt-get install -y build-essential &&
+            chmod +x ./scripts/openssl.sh &&
             ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
             go test -gcflags=all=-d=checkptr -count 5 -v ./...
           "
@@ -193,6 +199,7 @@ jobs:
           golang:${{ matrix.go-version }}-bookworm \
           bash -c "
             apt-get update && apt-get install -y build-essential &&
+            chmod +x ./scripts/openssl.sh &&
             ./scripts/openssl.sh ${{ matrix.openssl-version }} &&
             go test -count 5 -v ./...
           "


### PR DESCRIPTION
I'll let @qmuntal add arm64 using the official GH actions runners once the CGOless tests are passing