### PR TITLE
Remove old OpenSSL version from Windows CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.24.x, 1.25.x]
-        openssl-version: [libcrypto-1_1-x64.dll, libcrypto-3-x64.dll]
+        openssl-version: [libcrypto-3-x64.dll]
     steps:
     - name: Install Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
The windows-2022 no longer supports OpenSSL 1.1. See [13119](https://github.com/actions/runner-images/pull/13119).