### PR TITLE
Fix syscallN_trampoline for arm64 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
     - name: Run Test with address sanitizer
+      if: ${{ runner.arch == 'X64' }} # arm64 thread sanitizer is flaky, unrelated to this codebase
       run: |
         ok=true
         for t in $(go test ./... -list=. | grep '^Test'); do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
-    runs-on: ubuntu-22.04
+        host: [ubuntu-22.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.host }}
     steps:
     - name: Install build tools
       run: sudo apt-get install -y build-essential

--- a/internal/ossl/asm_arm64.s
+++ b/internal/ossl/asm_arm64.s
@@ -9,7 +9,7 @@
 
 GLOBL ·syscallNABI0(SB), NOPTR|RODATA, $8
 DATA ·syscallNABI0(SB)/8, $syscallN_trampoline(SB)
-TEXT syscallN_trampoline(SB),NOSPLIT,$0
+TEXT syscallN_trampoline(SB),NOSPLIT,$16
 	STP	(R19, R20), 16(RSP) // save old R19, R20
 	MOVD	R0, R19	// save struct pointer
 	MOVD	RSP, R20	// save stack pointer


### PR DESCRIPTION
`syscallN_trampoline` needs 16 bytes of frame pointer to store the R19 and R20 registers.

This hasn't been catch before because we were not testing on arm64.