### PR TITLE
Add CI runner for darwin/arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Run Test CGO disabled
       run: go test -count 10 -v ./...
       env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
     - name: Run Test with address sanitizer
+      if: ${{ runner.arch == 'X64' }} # arm64 thread sanitizer is flaky, unrelated to this codebase
       run: |
         ok=true
         for t in $(go test ./... -list=. | grep '^Test'); do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,8 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [/usr/local/opt/openssl@3/lib/libcrypto.3.dylib]
-    runs-on: macos-13
+        host: [macos-15-intel, macos-15] # the non-intel macOS runners use ARM64
+    runs-on: ${{ matrix.host }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,13 +96,12 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.24.x, 1.25.x]
-        host: [macos-15-intel, macos-15] # the non-intel macOS runners use ARM64
-        include:
-          - host: macos-15-intel
-            openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib
-          - host: macos-15
-            openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib
-    runs-on: ${{ matrix.host }}
+        host: [
+          # the non-intel macOS runners use ARM64
+          {os: macos-15-intel, openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib},
+          {os: macos-15, openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib}
+        ]
+    runs-on: ${{ matrix.host.os }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v5
@@ -113,7 +112,7 @@ jobs:
     - name: Run Test
       run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
       run: go test -count 10 -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,8 +96,12 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.24.x, 1.25.x]
-        openssl-version: [/usr/local/opt/openssl@3/lib/libcrypto.3.dylib]
         host: [macos-15-intel, macos-15] # the non-intel macOS runners use ARM64
+        include:
+          - host: macos-15-intel
+            openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib
+          - host: macos-15
+            openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib
     runs-on: ${{ matrix.host }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         go-version: [1.24.x, 1.25.x]
         openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
-    runs-on: ubuntu-22.04
+        host: [ubuntu-22.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.host }}
     steps:
     - name: Install build tools
       run: sudo apt-get install -y build-essential

--- a/internal/ossl/asm_arm64.s
+++ b/internal/ossl/asm_arm64.s
@@ -9,7 +9,7 @@
 
 GLOBL ·syscallNABI0(SB), NOPTR|RODATA, $8
 DATA ·syscallNABI0(SB)/8, $syscallN_trampoline(SB)
-TEXT syscallN_trampoline(SB),NOSPLIT,$0
+TEXT syscallN_trampoline(SB),NOSPLIT,$16
 	STP	(R19, R20), 16(RSP) // save old R19, R20
 	MOVD	R0, R19	// save struct pointer
 	MOVD	RSP, R20	// save stack pointer


### PR DESCRIPTION
Upgrade the macOS runners. `macos-13` is deprecated, and runs on amd64. `macos-15` supports arm64 and amd64.