### PR TITLE
Shuffle tests and test with optimizations off

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,7 @@ jobs:
           -w /workspace \
           golang:${{ matrix.go-version }} \
           bash -c "
-            go test -shuffle=on ./... -v
+            go test -shuffle=on -v ./...
           "
 
   # Verify that golang-fips/openssl builds successfully without cgo enabled.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,18 @@ jobs:
       # Run each test 10 times so the garbage collector chimes in
       # and exercises the multiple finalizers we use.
       # This can detect use-after-free and double-free issues.
-      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      run: go test -shuffle=on -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
-      run: go test -count 10 -v ./...
+      run: go test -shuffle=on -count 10 -v ./...
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        CGO_ENABLED: 0
+        GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
+    - name: Run Test CGO disabled and optimizations off
+      run: go test -shuffle=on -count 10 -gcflags=all="-N -l" -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 0
@@ -80,12 +86,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run Test
-      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      run: go test -shuffle=on -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
-      run: go test -count 10 -v ./...
+      run: go test -shuffle=on -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 0
@@ -110,12 +116,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run Test
-      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      run: go test -shuffle=on -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
-      run: go test -count 10 -v ./...
+      run: go test -shuffle=on -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
         CGO_ENABLED: 0
@@ -128,11 +134,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run Test
-      run: go test -v ./...
+      run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
-      run: go test -v ./...
+      run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
@@ -144,11 +150,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run Test
-      run: go test -v ./...
+      run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 1
     - name: Run Test CGO disabled
-      run: go test -v ./...
+      run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
@@ -174,7 +180,7 @@ jobs:
           -w /workspace \
           golang:${{ matrix.go-version }} \
           bash -c "
-            go test ./... -v
+            go test -shuffle=on ./... -v
           "
 
   # Verify that golang-fips/openssl builds successfully without cgo enabled.


### PR DESCRIPTION
Randomizing the execution order of tests will make it easier to spot flaky tests related to garbage collection and object finalizers. The Go test framework supports doing so by passing the `-shuffle=on` flag.

While here, add a new testing step that runs nocgo tests with optimizations disabled by passing `-gcflags=all="-N -l"`. These flags are mostly used for debugging with delve, so they are common enough to deserve proper testing.