### PR TITLE
Remove unnecessary runtime.KeepAlive calls

### DIFF
--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -720,6 +720,10 @@ func generateGoNocgo(src *mkcgo.Source, w io.Writer) {
 	fmt.Fprintf(w, "\t\"unsafe\"\n")
 	fmt.Fprintf(w, ")\n\n")
 
+	// Ensure there is at least one reference to runtime package
+	// to avoid "imported and not used" error.
+	fmt.Fprintf(w, "var _ = runtime.GOOS\n\n")
+
 	// Generate cgo_import_dynamic directives for extern variables
 	for _, ext := range src.Externs {
 		extName := ext.Name
@@ -1048,20 +1052,6 @@ func generateNocgoFn(typePtrs map[string]bool, src *mkcgo.Source, fn *mkcgo.Func
 	generateNocgoFnBody(src, fn, errorType, !needsSpecialHandling, w)
 	if needsSpecialHandling {
 		fmt.Fprintf(w, "\t}\n")
-	}
-
-	for _, param := range fn.Params {
-		// Skip void parameters
-		if param.Type == "void" {
-			continue
-		}
-
-		// Convert C types to Go types for nocgo mode
-		goType, _ := cTypeToGo(param.Type, false)
-		_, isPtr := typePtrs[goType]
-		if isPtr || strings.HasPrefix(goType, "*") {
-			fmt.Fprintf(w, "\truntime.KeepAlive(%s)\n", param.Name)
-		}
 	}
 
 	// Generate return statement - only include error for functions that need error wrappers

--- a/internal/ossl/syscall_nocgo.go
+++ b/internal/ossl/syscall_nocgo.go
@@ -46,6 +46,13 @@ func syscallNSystemStack(libcArgs *libcCallInfo) {
 var syscallNSystemStack_trampoline byte
 var syscallNSystemStackABIInternal = uintptr(unsafe.Pointer(&syscallNSystemStack_trampoline))
 
+// syscallN performs a syscall with the given function and arguments.
+//
+// All its parameters and return values must be uintptr in order
+// for the Go compiler to automatically set the //go:uintptrkeepalive
+// directive (which we can't set manually here).
+// See https://github.com/golang/go/blob/9a5a1202f4c4d5a7048b149b65c3e5b82a2de9aa/src/cmd/compile/internal/escape/call.go#L275.
+//
 //go:nosplit
 func syscallN(errType uintptr, fn uintptr, args ...uintptr) (r1, r2 uintptr) {
 	libcArgs := libcCallInfo{

--- a/internal/ossl/zdl_nocgo.go
+++ b/internal/ossl/zdl_nocgo.go
@@ -9,6 +9,8 @@ import (
 	"unsafe"
 )
 
+var _ = runtime.GOOS
+
 //go:cgo_import_dynamic _mkcgo_dlclose dlclose ""
 //go:cgo_import_dynamic _mkcgo_dlerror dlerror ""
 //go:cgo_import_dynamic _mkcgo_dlopen dlopen ""
@@ -32,7 +34,6 @@ var _mkcgo_dlopen_trampoline_addr uintptr
 
 func Dlopen(path *byte, flags int32) unsafe.Pointer {
 	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(unsafe.Pointer(path)), uintptr(flags))
-	runtime.KeepAlive(path)
 	return unsafe.Pointer(r0)
 }
 
@@ -40,6 +41,5 @@ var _mkcgo_dlsym_trampoline_addr uintptr
 
 func Dlsym(handle unsafe.Pointer, symbol *byte) unsafe.Pointer {
 	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(unsafe.Pointer(symbol)))
-	runtime.KeepAlive(symbol)
 	return unsafe.Pointer(r0)
 }

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -9,6 +9,8 @@ import (
 	"unsafe"
 )
 
+var _ = runtime.GOOS
+
 type OPENSSL_INIT_SETTINGS_PTR unsafe.Pointer
 type OSSL_LIB_CTX_PTR unsafe.Pointer
 type OSSL_PROVIDER_PTR unsafe.Pointer
@@ -41,8 +43,6 @@ var _mkcgo_BN_bin2bn uintptr
 func BN_bin2bn(arg0 *byte, arg1 int32, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_BN_bin2bn, uintptr(unsafe.Pointer(arg0)), uintptr(arg1), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg2)
 	return BIGNUM_PTR(r0), newMkcgoErr("BN_bin2bn", &_err)
 }
 
@@ -51,8 +51,6 @@ var _mkcgo_BN_bn2binpad uintptr
 func BN_bn2binpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(2, _mkcgo_BN_bn2binpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(a)
-	runtime.KeepAlive(to)
 	return int32(r0), newMkcgoErr("BN_bn2binpad", &_err)
 }
 
@@ -61,8 +59,6 @@ var _mkcgo_BN_bn2lebinpad uintptr
 func BN_bn2lebinpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(2, _mkcgo_BN_bn2lebinpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(a)
-	runtime.KeepAlive(to)
 	return int32(r0), newMkcgoErr("BN_bn2lebinpad", &_err)
 }
 
@@ -70,21 +66,18 @@ var _mkcgo_BN_clear uintptr
 
 func BN_clear(arg0 BIGNUM_PTR) {
 	syscallN(0, _mkcgo_BN_clear, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_BN_clear_free uintptr
 
 func BN_clear_free(arg0 BIGNUM_PTR) {
 	syscallN(0, _mkcgo_BN_clear_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_BN_free uintptr
 
 func BN_free(arg0 BIGNUM_PTR) {
 	syscallN(0, _mkcgo_BN_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_BN_lebin2bn uintptr
@@ -92,8 +85,6 @@ var _mkcgo_BN_lebin2bn uintptr
 func BN_lebin2bn(s *byte, len int32, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_BN_lebin2bn, uintptr(unsafe.Pointer(s)), uintptr(len), uintptr(ret), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(s)
-	runtime.KeepAlive(ret)
 	return BIGNUM_PTR(r0), newMkcgoErr("BN_lebin2bn", &_err)
 }
 
@@ -109,7 +100,6 @@ var _mkcgo_BN_num_bits uintptr
 
 func BN_num_bits(arg0 BIGNUM_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_BN_num_bits, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 	return int32(r0)
 }
 
@@ -117,7 +107,6 @@ var _mkcgo_CRYPTO_free uintptr
 
 func CRYPTO_free(str unsafe.Pointer, file *byte, line int32) {
 	syscallN(0, _mkcgo_CRYPTO_free, uintptr(str), uintptr(unsafe.Pointer(file)), uintptr(line))
-	runtime.KeepAlive(file)
 }
 
 var _mkcgo_CRYPTO_malloc uintptr
@@ -125,7 +114,6 @@ var _mkcgo_CRYPTO_malloc uintptr
 func CRYPTO_malloc(num int, file *byte, line int32) (unsafe.Pointer, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_CRYPTO_malloc, uintptr(num), uintptr(unsafe.Pointer(file)), uintptr(line), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(file)
 	return unsafe.Pointer(r0), newMkcgoErr("CRYPTO_malloc", &_err)
 }
 
@@ -133,7 +121,6 @@ var _mkcgo_DSA_free uintptr
 
 func DSA_free(r DSA_PTR) {
 	syscallN(0, _mkcgo_DSA_free, uintptr(r))
-	runtime.KeepAlive(r)
 }
 
 var _mkcgo_DSA_generate_key uintptr
@@ -141,7 +128,6 @@ var _mkcgo_DSA_generate_key uintptr
 func DSA_generate_key(a DSA_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_DSA_generate_key, uintptr(a), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(a)
 	return int32(r0), newMkcgoErr("DSA_generate_key", &_err)
 }
 
@@ -149,19 +135,12 @@ var _mkcgo_DSA_get0_key uintptr
 
 func DSA_get0_key(d DSA_PTR, pub_key *BIGNUM_PTR, priv_key *BIGNUM_PTR) {
 	syscallN(0, _mkcgo_DSA_get0_key, uintptr(d), uintptr(unsafe.Pointer(pub_key)), uintptr(unsafe.Pointer(priv_key)))
-	runtime.KeepAlive(d)
-	runtime.KeepAlive(pub_key)
-	runtime.KeepAlive(priv_key)
 }
 
 var _mkcgo_DSA_get0_pqg uintptr
 
 func DSA_get0_pqg(d DSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR, g *BIGNUM_PTR) {
 	syscallN(0, _mkcgo_DSA_get0_pqg, uintptr(d), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)), uintptr(unsafe.Pointer(g)))
-	runtime.KeepAlive(d)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(q)
-	runtime.KeepAlive(g)
 }
 
 var _mkcgo_DSA_new uintptr
@@ -177,9 +156,6 @@ var _mkcgo_DSA_set0_key uintptr
 func DSA_set0_key(d DSA_PTR, pub_key BIGNUM_PTR, priv_key BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_DSA_set0_key, uintptr(d), uintptr(pub_key), uintptr(priv_key), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(d)
-	runtime.KeepAlive(pub_key)
-	runtime.KeepAlive(priv_key)
 	return int32(r0), newMkcgoErr("DSA_set0_key", &_err)
 }
 
@@ -188,10 +164,6 @@ var _mkcgo_DSA_set0_pqg uintptr
 func DSA_set0_pqg(d DSA_PTR, p BIGNUM_PTR, q BIGNUM_PTR, g BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_DSA_set0_pqg, uintptr(d), uintptr(p), uintptr(q), uintptr(g), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(d)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(q)
-	runtime.KeepAlive(g)
 	return int32(r0), newMkcgoErr("DSA_set0_pqg", &_err)
 }
 
@@ -199,7 +171,6 @@ var _mkcgo_EC_GROUP_free uintptr
 
 func EC_GROUP_free(group EC_GROUP_PTR) {
 	syscallN(0, _mkcgo_EC_GROUP_free, uintptr(group))
-	runtime.KeepAlive(group)
 }
 
 var _mkcgo_EC_GROUP_new_by_curve_name uintptr
@@ -215,7 +186,6 @@ var _mkcgo_EC_KEY_check_key uintptr
 func EC_KEY_check_key(key EC_KEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_KEY_check_key, uintptr(key), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(key)
 	return int32(r0), newMkcgoErr("EC_KEY_check_key", &_err)
 }
 
@@ -223,14 +193,12 @@ var _mkcgo_EC_KEY_free uintptr
 
 func EC_KEY_free(arg0 EC_KEY_PTR) {
 	syscallN(0, _mkcgo_EC_KEY_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EC_KEY_get0_group uintptr
 
 func EC_KEY_get0_group(arg0 EC_KEY_PTR) EC_GROUP_PTR {
 	r0, _ := syscallN(0, _mkcgo_EC_KEY_get0_group, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 	return EC_GROUP_PTR(r0)
 }
 
@@ -238,7 +206,6 @@ var _mkcgo_EC_KEY_get0_private_key uintptr
 
 func EC_KEY_get0_private_key(arg0 EC_KEY_PTR) BIGNUM_PTR {
 	r0, _ := syscallN(0, _mkcgo_EC_KEY_get0_private_key, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 	return BIGNUM_PTR(r0)
 }
 
@@ -246,7 +213,6 @@ var _mkcgo_EC_KEY_get0_public_key uintptr
 
 func EC_KEY_get0_public_key(arg0 EC_KEY_PTR) EC_POINT_PTR {
 	r0, _ := syscallN(0, _mkcgo_EC_KEY_get0_public_key, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 	return EC_POINT_PTR(r0)
 }
 
@@ -263,8 +229,6 @@ var _mkcgo_EC_KEY_set_private_key uintptr
 func EC_KEY_set_private_key(arg0 EC_KEY_PTR, arg1 BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_KEY_set_private_key, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("EC_KEY_set_private_key", &_err)
 }
 
@@ -273,8 +237,6 @@ var _mkcgo_EC_KEY_set_public_key uintptr
 func EC_KEY_set_public_key(key EC_KEY_PTR, pub EC_POINT_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_KEY_set_public_key, uintptr(key), uintptr(pub), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(pub)
 	return int32(r0), newMkcgoErr("EC_KEY_set_public_key", &_err)
 }
 
@@ -283,9 +245,6 @@ var _mkcgo_EC_KEY_set_public_key_affine_coordinates uintptr
 func EC_KEY_set_public_key_affine_coordinates(key EC_KEY_PTR, x BIGNUM_PTR, y BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_KEY_set_public_key_affine_coordinates, uintptr(key), uintptr(x), uintptr(y), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(x)
-	runtime.KeepAlive(y)
 	return int32(r0), newMkcgoErr("EC_KEY_set_public_key_affine_coordinates", &_err)
 }
 
@@ -293,7 +252,6 @@ var _mkcgo_EC_POINT_free uintptr
 
 func EC_POINT_free(arg0 EC_POINT_PTR) {
 	syscallN(0, _mkcgo_EC_POINT_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EC_POINT_get_affine_coordinates_GFp uintptr
@@ -301,11 +259,6 @@ var _mkcgo_EC_POINT_get_affine_coordinates_GFp uintptr
 func EC_POINT_get_affine_coordinates_GFp(arg0 EC_GROUP_PTR, arg1 EC_POINT_PTR, arg2 BIGNUM_PTR, arg3 BIGNUM_PTR, arg4 BN_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_POINT_get_affine_coordinates_GFp, uintptr(arg0), uintptr(arg1), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
-	runtime.KeepAlive(arg3)
-	runtime.KeepAlive(arg4)
 	return int32(r0), newMkcgoErr("EC_POINT_get_affine_coordinates_GFp", &_err)
 }
 
@@ -314,12 +267,6 @@ var _mkcgo_EC_POINT_mul uintptr
 func EC_POINT_mul(group EC_GROUP_PTR, r EC_POINT_PTR, n BIGNUM_PTR, q EC_POINT_PTR, m BIGNUM_PTR, ctx BN_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_POINT_mul, uintptr(group), uintptr(r), uintptr(n), uintptr(q), uintptr(m), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(group)
-	runtime.KeepAlive(r)
-	runtime.KeepAlive(n)
-	runtime.KeepAlive(q)
-	runtime.KeepAlive(m)
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EC_POINT_mul", &_err)
 }
 
@@ -328,7 +275,6 @@ var _mkcgo_EC_POINT_new uintptr
 func EC_POINT_new(arg0 EC_GROUP_PTR) (EC_POINT_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EC_POINT_new, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return EC_POINT_PTR(r0), newMkcgoErr("EC_POINT_new", &_err)
 }
 
@@ -337,10 +283,6 @@ var _mkcgo_EC_POINT_oct2point uintptr
 func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf *byte, len int, ctx BN_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_POINT_oct2point, uintptr(group), uintptr(p), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(group)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(buf)
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EC_POINT_oct2point", &_err)
 }
 
@@ -349,10 +291,6 @@ var _mkcgo_EC_POINT_point2oct uintptr
 func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf *byte, len int, ctx BN_CTX_PTR) (int, error) {
 	var _err errState
 	r0, _ := syscallN(4, _mkcgo_EC_POINT_point2oct, uintptr(group), uintptr(p), uintptr(form), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(group)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(buf)
-	runtime.KeepAlive(ctx)
 	return int(r0), newMkcgoErr("EC_POINT_point2oct", &_err)
 }
 
@@ -361,11 +299,6 @@ var _mkcgo_EC_POINT_set_affine_coordinates uintptr
 func EC_POINT_set_affine_coordinates(arg0 EC_GROUP_PTR, arg1 EC_POINT_PTR, arg2 BIGNUM_PTR, arg3 BIGNUM_PTR, arg4 BN_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EC_POINT_set_affine_coordinates, uintptr(arg0), uintptr(arg1), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
-	runtime.KeepAlive(arg3)
-	runtime.KeepAlive(arg4)
 	return int32(r0), newMkcgoErr("EC_POINT_set_affine_coordinates", &_err)
 }
 
@@ -379,7 +312,6 @@ var _mkcgo_ERR_error_string_n uintptr
 
 func ERR_error_string_n(e uint64, buf *byte, len int) {
 	syscallN(0, _mkcgo_ERR_error_string_n, uintptr(e), uintptr(unsafe.Pointer(buf)), uintptr(len))
-	runtime.KeepAlive(buf)
 }
 
 var _mkcgo_ERR_get_error uintptr
@@ -393,11 +325,6 @@ var _mkcgo_ERR_get_error_all uintptr
 
 func ERR_get_error_all(file **byte, line *int32, __func **byte, data **byte, flags *int32) uint64 {
 	r0, _ := syscallN(0, _mkcgo_ERR_get_error_all, uintptr(unsafe.Pointer(file)), uintptr(unsafe.Pointer(line)), uintptr(unsafe.Pointer(__func)), uintptr(unsafe.Pointer(data)), uintptr(unsafe.Pointer(flags)))
-	runtime.KeepAlive(file)
-	runtime.KeepAlive(line)
-	runtime.KeepAlive(__func)
-	runtime.KeepAlive(data)
-	runtime.KeepAlive(flags)
 	return uint64(r0)
 }
 
@@ -405,8 +332,6 @@ var _mkcgo_ERR_get_error_line uintptr
 
 func ERR_get_error_line(file **byte, line *int32) uint64 {
 	r0, _ := syscallN(0, _mkcgo_ERR_get_error_line, uintptr(unsafe.Pointer(file)), uintptr(unsafe.Pointer(line)))
-	runtime.KeepAlive(file)
-	runtime.KeepAlive(line)
 	return uint64(r0)
 }
 
@@ -415,7 +340,6 @@ var _mkcgo_EVP_CIPHER_CTX_ctrl uintptr
 func EVP_CIPHER_CTX_ctrl(ctx EVP_CIPHER_CTX_PTR, __type int32, arg int32, ptr unsafe.Pointer) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_CIPHER_CTX_ctrl, uintptr(ctx), uintptr(__type), uintptr(arg), uintptr(ptr), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_CIPHER_CTX_ctrl", &_err)
 }
 
@@ -423,7 +347,6 @@ var _mkcgo_EVP_CIPHER_CTX_free uintptr
 
 func EVP_CIPHER_CTX_free(arg0 EVP_CIPHER_CTX_PTR) {
 	syscallN(0, _mkcgo_EVP_CIPHER_CTX_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EVP_CIPHER_CTX_new uintptr
@@ -439,7 +362,6 @@ var _mkcgo_EVP_CIPHER_CTX_set_key_length uintptr
 func EVP_CIPHER_CTX_set_key_length(x EVP_CIPHER_CTX_PTR, keylen int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_CIPHER_CTX_set_key_length, uintptr(x), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(x)
 	return int32(r0), newMkcgoErr("EVP_CIPHER_CTX_set_key_length", &_err)
 }
 
@@ -448,7 +370,6 @@ var _mkcgo_EVP_CIPHER_CTX_set_padding uintptr
 func EVP_CIPHER_CTX_set_padding(x EVP_CIPHER_CTX_PTR, padding int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_CIPHER_CTX_set_padding, uintptr(x), uintptr(padding), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(x)
 	return int32(r0), newMkcgoErr("EVP_CIPHER_CTX_set_padding", &_err)
 }
 
@@ -457,9 +378,6 @@ var _mkcgo_EVP_CIPHER_fetch uintptr
 func EVP_CIPHER_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_CIPHER_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_CIPHER_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(algorithm)
-	runtime.KeepAlive(properties)
 	return EVP_CIPHER_PTR(r0), newMkcgoErr("EVP_CIPHER_fetch", &_err)
 }
 
@@ -467,7 +385,6 @@ var _mkcgo_EVP_CIPHER_get0_name uintptr
 
 func EVP_CIPHER_get0_name(cipher EVP_CIPHER_PTR) *byte {
 	r0, _ := syscallN(0, _mkcgo_EVP_CIPHER_get0_name, uintptr(cipher))
-	runtime.KeepAlive(cipher)
 	return (*byte)(unsafe.Pointer(r0))
 }
 
@@ -475,7 +392,6 @@ var _mkcgo_EVP_CIPHER_get_block_size uintptr
 
 func EVP_CIPHER_get_block_size(cipher EVP_CIPHER_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_EVP_CIPHER_get_block_size, uintptr(cipher))
-	runtime.KeepAlive(cipher)
 	return int32(r0)
 }
 
@@ -484,11 +400,6 @@ var _mkcgo_EVP_CipherInit_ex uintptr
 func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte, enc int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(impl)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(iv)
 	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", &_err)
 }
 
@@ -497,10 +408,6 @@ var _mkcgo_EVP_CipherUpdate uintptr
 func EVP_CipherUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_CipherUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(outl)
-	runtime.KeepAlive(in)
 	return int32(r0), newMkcgoErr("EVP_CipherUpdate", &_err)
 }
 
@@ -509,9 +416,6 @@ var _mkcgo_EVP_DecryptFinal_ex uintptr
 func EVP_DecryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, outm *byte, outl *int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DecryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(outm)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(outm)
-	runtime.KeepAlive(outl)
 	return int32(r0), newMkcgoErr("EVP_DecryptFinal_ex", &_err)
 }
 
@@ -520,11 +424,6 @@ var _mkcgo_EVP_DecryptInit_ex uintptr
 func EVP_DecryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DecryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(impl)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(iv)
 	return int32(r0), newMkcgoErr("EVP_DecryptInit_ex", &_err)
 }
 
@@ -533,10 +432,6 @@ var _mkcgo_EVP_DecryptUpdate uintptr
 func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DecryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(outl)
-	runtime.KeepAlive(in)
 	return int32(r0), newMkcgoErr("EVP_DecryptUpdate", &_err)
 }
 
@@ -545,10 +440,6 @@ var _mkcgo_EVP_Digest uintptr
 func EVP_Digest(data unsafe.Pointer, count int, md *byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_Digest, uintptr(data), uintptr(count), uintptr(unsafe.Pointer(md)), uintptr(unsafe.Pointer(size)), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(md)
-	runtime.KeepAlive(size)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(impl)
 	return int32(r0), newMkcgoErr("EVP_Digest", &_err)
 }
 
@@ -557,9 +448,6 @@ var _mkcgo_EVP_DigestFinal_ex uintptr
 func EVP_DigestFinal_ex(ctx EVP_MD_CTX_PTR, md *byte, s *uint32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(md)), uintptr(unsafe.Pointer(s)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(md)
-	runtime.KeepAlive(s)
 	return int32(r0), newMkcgoErr("EVP_DigestFinal_ex", &_err)
 }
 
@@ -568,8 +456,6 @@ var _mkcgo_EVP_DigestInit uintptr
 func EVP_DigestInit(ctx EVP_MD_CTX_PTR, __type EVP_MD_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestInit, uintptr(ctx), uintptr(__type), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(__type)
 	return int32(r0), newMkcgoErr("EVP_DigestInit", &_err)
 }
 
@@ -578,9 +464,6 @@ var _mkcgo_EVP_DigestInit_ex uintptr
 func EVP_DigestInit_ex(ctx EVP_MD_CTX_PTR, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(impl)
 	return int32(r0), newMkcgoErr("EVP_DigestInit_ex", &_err)
 }
 
@@ -589,10 +472,6 @@ var _mkcgo_EVP_DigestSign uintptr
 func EVP_DigestSign(ctx EVP_MD_CTX_PTR, sigret *byte, siglen *int, tbs *byte, tbslen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestSign, uintptr(ctx), uintptr(unsafe.Pointer(sigret)), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(sigret)
-	runtime.KeepAlive(siglen)
-	runtime.KeepAlive(tbs)
 	return int32(r0), newMkcgoErr("EVP_DigestSign", &_err)
 }
 
@@ -601,9 +480,6 @@ var _mkcgo_EVP_DigestSignFinal uintptr
 func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen *int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(sig)
-	runtime.KeepAlive(siglen)
 	return int32(r0), newMkcgoErr("EVP_DigestSignFinal", &_err)
 }
 
@@ -612,11 +488,6 @@ var _mkcgo_EVP_DigestSignInit uintptr
 func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(pctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(pkey)
 	return int32(r0), newMkcgoErr("EVP_DigestSignInit", &_err)
 }
 
@@ -625,7 +496,6 @@ var _mkcgo_EVP_DigestUpdate uintptr
 func EVP_DigestUpdate(ctx EVP_MD_CTX_PTR, d unsafe.Pointer, cnt int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestUpdate, uintptr(ctx), uintptr(d), uintptr(cnt), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_DigestUpdate", &_err)
 }
 
@@ -634,9 +504,6 @@ var _mkcgo_EVP_DigestVerify uintptr
 func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerify, uintptr(ctx), uintptr(unsafe.Pointer(sigret)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(sigret)
-	runtime.KeepAlive(tbs)
 	return int32(r0), newMkcgoErr("EVP_DigestVerify", &_err)
 }
 
@@ -645,8 +512,6 @@ var _mkcgo_EVP_DigestVerifyFinal uintptr
 func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(sig)
 	return int32(r0), newMkcgoErr("EVP_DigestVerifyFinal", &_err)
 }
 
@@ -655,11 +520,6 @@ var _mkcgo_EVP_DigestVerifyInit uintptr
 func EVP_DigestVerifyInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(pctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(pkey)
 	return int32(r0), newMkcgoErr("EVP_DigestVerifyInit", &_err)
 }
 
@@ -668,9 +528,6 @@ var _mkcgo_EVP_EncryptFinal_ex uintptr
 func EVP_EncryptFinal_ex(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_EncryptFinal_ex, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(outl)
 	return int32(r0), newMkcgoErr("EVP_EncryptFinal_ex", &_err)
 }
 
@@ -679,11 +536,6 @@ var _mkcgo_EVP_EncryptInit_ex uintptr
 func EVP_EncryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_EncryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(impl)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(iv)
 	return int32(r0), newMkcgoErr("EVP_EncryptInit_ex", &_err)
 }
 
@@ -692,10 +544,6 @@ var _mkcgo_EVP_EncryptUpdate uintptr
 func EVP_EncryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte, inl int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_EncryptUpdate, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(unsafe.Pointer(in)), uintptr(inl), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(outl)
-	runtime.KeepAlive(in)
 	return int32(r0), newMkcgoErr("EVP_EncryptUpdate", &_err)
 }
 
@@ -703,7 +551,6 @@ var _mkcgo_EVP_KDF_CTX_free uintptr
 
 func EVP_KDF_CTX_free(ctx EVP_KDF_CTX_PTR) {
 	syscallN(0, _mkcgo_EVP_KDF_CTX_free, uintptr(ctx))
-	runtime.KeepAlive(ctx)
 }
 
 var _mkcgo_EVP_KDF_CTX_get_kdf_size uintptr
@@ -711,7 +558,6 @@ var _mkcgo_EVP_KDF_CTX_get_kdf_size uintptr
 func EVP_KDF_CTX_get_kdf_size(ctx EVP_KDF_CTX_PTR) (int, error) {
 	var _err errState
 	r0, _ := syscallN(4, _mkcgo_EVP_KDF_CTX_get_kdf_size, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int(r0), newMkcgoErr("EVP_KDF_CTX_get_kdf_size", &_err)
 }
 
@@ -720,7 +566,6 @@ var _mkcgo_EVP_KDF_CTX_new uintptr
 func EVP_KDF_CTX_new(kdf EVP_KDF_PTR) (EVP_KDF_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_KDF_CTX_new, uintptr(kdf), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(kdf)
 	return EVP_KDF_CTX_PTR(r0), newMkcgoErr("EVP_KDF_CTX_new", &_err)
 }
 
@@ -729,8 +574,6 @@ var _mkcgo_EVP_KDF_CTX_set_params uintptr
 func EVP_KDF_CTX_set_params(ctx EVP_KDF_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_KDF_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_KDF_CTX_set_params", &_err)
 }
 
@@ -739,9 +582,6 @@ var _mkcgo_EVP_KDF_derive uintptr
 func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_KDF_derive, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_KDF_derive", &_err)
 }
 
@@ -750,9 +590,6 @@ var _mkcgo_EVP_KDF_fetch uintptr
 func EVP_KDF_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KDF_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_KDF_fetch, uintptr(libctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(libctx)
-	runtime.KeepAlive(algorithm)
-	runtime.KeepAlive(properties)
 	return EVP_KDF_PTR(r0), newMkcgoErr("EVP_KDF_fetch", &_err)
 }
 
@@ -760,7 +597,6 @@ var _mkcgo_EVP_KDF_free uintptr
 
 func EVP_KDF_free(kdf EVP_KDF_PTR) {
 	syscallN(0, _mkcgo_EVP_KDF_free, uintptr(kdf))
-	runtime.KeepAlive(kdf)
 }
 
 var _mkcgo_EVP_MAC_CTX_dup uintptr
@@ -768,7 +604,6 @@ var _mkcgo_EVP_MAC_CTX_dup uintptr
 func EVP_MAC_CTX_dup(arg0 EVP_MAC_CTX_PTR) (EVP_MAC_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MAC_CTX_dup, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return EVP_MAC_CTX_PTR(r0), newMkcgoErr("EVP_MAC_CTX_dup", &_err)
 }
 
@@ -776,7 +611,6 @@ var _mkcgo_EVP_MAC_CTX_free uintptr
 
 func EVP_MAC_CTX_free(arg0 EVP_MAC_CTX_PTR) {
 	syscallN(0, _mkcgo_EVP_MAC_CTX_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EVP_MAC_CTX_new uintptr
@@ -784,7 +618,6 @@ var _mkcgo_EVP_MAC_CTX_new uintptr
 func EVP_MAC_CTX_new(arg0 EVP_MAC_PTR) (EVP_MAC_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MAC_CTX_new, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return EVP_MAC_CTX_PTR(r0), newMkcgoErr("EVP_MAC_CTX_new", &_err)
 }
 
@@ -793,8 +626,6 @@ var _mkcgo_EVP_MAC_CTX_set_params uintptr
 func EVP_MAC_CTX_set_params(ctx EVP_MAC_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MAC_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_MAC_CTX_set_params", &_err)
 }
 
@@ -803,9 +634,6 @@ var _mkcgo_EVP_MAC_fetch uintptr
 func EVP_MAC_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MAC_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MAC_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(algorithm)
-	runtime.KeepAlive(properties)
 	return EVP_MAC_PTR(r0), newMkcgoErr("EVP_MAC_fetch", &_err)
 }
 
@@ -814,9 +642,6 @@ var _mkcgo_EVP_MAC_final uintptr
 func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MAC_final, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(outsize), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(outl)
 	return int32(r0), newMkcgoErr("EVP_MAC_final", &_err)
 }
 
@@ -825,9 +650,6 @@ var _mkcgo_EVP_MAC_init uintptr
 func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MAC_init, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_MAC_init", &_err)
 }
 
@@ -836,8 +658,6 @@ var _mkcgo_EVP_MAC_update uintptr
 func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data *byte, datalen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MAC_update, uintptr(ctx), uintptr(unsafe.Pointer(data)), uintptr(datalen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(data)
 	return int32(r0), newMkcgoErr("EVP_MAC_update", &_err)
 }
 
@@ -846,8 +666,6 @@ var _mkcgo_EVP_MD_CTX_copy uintptr
 func EVP_MD_CTX_copy(out EVP_MD_CTX_PTR, in EVP_MD_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_copy, uintptr(out), uintptr(in), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(in)
 	return int32(r0), newMkcgoErr("EVP_MD_CTX_copy", &_err)
 }
 
@@ -856,8 +674,6 @@ var _mkcgo_EVP_MD_CTX_copy_ex uintptr
 func EVP_MD_CTX_copy_ex(out EVP_MD_CTX_PTR, in EVP_MD_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_copy_ex, uintptr(out), uintptr(in), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(out)
-	runtime.KeepAlive(in)
 	return int32(r0), newMkcgoErr("EVP_MD_CTX_copy_ex", &_err)
 }
 
@@ -865,7 +681,6 @@ var _mkcgo_EVP_MD_CTX_free uintptr
 
 func EVP_MD_CTX_free(ctx EVP_MD_CTX_PTR) {
 	syscallN(0, _mkcgo_EVP_MD_CTX_free, uintptr(ctx))
-	runtime.KeepAlive(ctx)
 }
 
 var _mkcgo_EVP_MD_CTX_get_params uintptr
@@ -873,8 +688,6 @@ var _mkcgo_EVP_MD_CTX_get_params uintptr
 func EVP_MD_CTX_get_params(ctx EVP_MD_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_get_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_MD_CTX_get_params", &_err)
 }
 
@@ -883,7 +696,6 @@ var _mkcgo_EVP_MD_CTX_gettable_params uintptr
 func EVP_MD_CTX_gettable_params(ctx EVP_MD_CTX_PTR) (OSSL_PARAM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MD_CTX_gettable_params, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return OSSL_PARAM_PTR(r0), newMkcgoErr("EVP_MD_CTX_gettable_params", &_err)
 }
 
@@ -900,8 +712,6 @@ var _mkcgo_EVP_MD_CTX_set_params uintptr
 func EVP_MD_CTX_set_params(ctx EVP_MD_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_MD_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_MD_CTX_set_params", &_err)
 }
 
@@ -910,7 +720,6 @@ var _mkcgo_EVP_MD_CTX_settable_params uintptr
 func EVP_MD_CTX_settable_params(ctx EVP_MD_CTX_PTR) (OSSL_PARAM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MD_CTX_settable_params, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return OSSL_PARAM_PTR(r0), newMkcgoErr("EVP_MD_CTX_settable_params", &_err)
 }
 
@@ -919,9 +728,6 @@ var _mkcgo_EVP_MD_fetch uintptr
 func EVP_MD_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MD_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_MD_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(algorithm)
-	runtime.KeepAlive(properties)
 	return EVP_MD_PTR(r0), newMkcgoErr("EVP_MD_fetch", &_err)
 }
 
@@ -929,14 +735,12 @@ var _mkcgo_EVP_MD_free uintptr
 
 func EVP_MD_free(md EVP_MD_PTR) {
 	syscallN(0, _mkcgo_EVP_MD_free, uintptr(md))
-	runtime.KeepAlive(md)
 }
 
 var _mkcgo_EVP_MD_get0_name uintptr
 
 func EVP_MD_get0_name(md EVP_MD_PTR) *byte {
 	r0, _ := syscallN(0, _mkcgo_EVP_MD_get0_name, uintptr(md))
-	runtime.KeepAlive(md)
 	return (*byte)(unsafe.Pointer(r0))
 }
 
@@ -944,7 +748,6 @@ var _mkcgo_EVP_MD_get0_provider uintptr
 
 func EVP_MD_get0_provider(md EVP_MD_PTR) OSSL_PROVIDER_PTR {
 	r0, _ := syscallN(0, _mkcgo_EVP_MD_get0_provider, uintptr(md))
-	runtime.KeepAlive(md)
 	return OSSL_PROVIDER_PTR(r0)
 }
 
@@ -952,7 +755,6 @@ var _mkcgo_EVP_MD_get_block_size uintptr
 
 func EVP_MD_get_block_size(md EVP_MD_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_EVP_MD_get_block_size, uintptr(md))
-	runtime.KeepAlive(md)
 	return int32(r0)
 }
 
@@ -960,7 +762,6 @@ var _mkcgo_EVP_MD_get_size uintptr
 
 func EVP_MD_get_size(md EVP_MD_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_EVP_MD_get_size, uintptr(md))
-	runtime.KeepAlive(md)
 	return int32(r0)
 }
 
@@ -968,7 +769,6 @@ var _mkcgo_EVP_MD_get_type uintptr
 
 func EVP_MD_get_type(md EVP_MD_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_EVP_MD_get_type, uintptr(md))
-	runtime.KeepAlive(md)
 	return int32(r0)
 }
 
@@ -977,8 +777,6 @@ var _mkcgo_EVP_PKEY_CTX_add1_hkdf_info uintptr
 func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_add1_hkdf_info, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_add1_hkdf_info", &_err)
 }
 
@@ -987,7 +785,6 @@ var _mkcgo_EVP_PKEY_CTX_ctrl uintptr
 func EVP_PKEY_CTX_ctrl(ctx EVP_PKEY_CTX_PTR, keytype int32, optype int32, cmd int32, p1 int32, p2 unsafe.Pointer) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_ctrl, uintptr(ctx), uintptr(keytype), uintptr(optype), uintptr(cmd), uintptr(p1), uintptr(p2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_ctrl", &_err)
 }
 
@@ -995,7 +792,6 @@ var _mkcgo_EVP_PKEY_CTX_free uintptr
 
 func EVP_PKEY_CTX_free(arg0 EVP_PKEY_CTX_PTR) {
 	syscallN(0, _mkcgo_EVP_PKEY_CTX_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EVP_PKEY_CTX_new uintptr
@@ -1003,8 +799,6 @@ var _mkcgo_EVP_PKEY_CTX_new uintptr
 func EVP_PKEY_CTX_new(arg0 EVP_PKEY_PTR, arg1 ENGINE_PTR) (EVP_PKEY_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new", &_err)
 }
 
@@ -1013,9 +807,6 @@ var _mkcgo_EVP_PKEY_CTX_new_from_pkey uintptr
 func EVP_PKEY_CTX_new_from_pkey(libctx OSSL_LIB_CTX_PTR, pkey EVP_PKEY_PTR, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_pkey, uintptr(libctx), uintptr(pkey), uintptr(unsafe.Pointer(propquery)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(libctx)
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(propquery)
 	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new_from_pkey", &_err)
 }
 
@@ -1024,7 +815,6 @@ var _mkcgo_EVP_PKEY_CTX_new_id uintptr
 func EVP_PKEY_CTX_new_id(id int32, e ENGINE_PTR) (EVP_PKEY_CTX_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_id, uintptr(id), uintptr(e), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(e)
 	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new_id", &_err)
 }
 
@@ -1033,7 +823,6 @@ var _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label uintptr
 func EVP_PKEY_CTX_set0_rsa_oaep_label(ctx EVP_PKEY_CTX_PTR, label unsafe.Pointer, len int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set0_rsa_oaep_label, uintptr(ctx), uintptr(label), uintptr(len), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set0_rsa_oaep_label", &_err)
 }
 
@@ -1042,8 +831,6 @@ var _mkcgo_EVP_PKEY_CTX_set1_hkdf_key uintptr
 func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_key, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_key", &_err)
 }
 
@@ -1052,8 +839,6 @@ var _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt uintptr
 func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_salt", &_err)
 }
 
@@ -1062,8 +847,6 @@ var _mkcgo_EVP_PKEY_CTX_set_hkdf_md uintptr
 func EVP_PKEY_CTX_set_hkdf_md(arg0 EVP_PKEY_CTX_PTR, arg1 EVP_MD_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_hkdf_md, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_md", &_err)
 }
 
@@ -1072,7 +855,6 @@ var _mkcgo_EVP_PKEY_CTX_set_hkdf_mode uintptr
 func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_hkdf_mode, uintptr(arg0), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", &_err)
 }
 
@@ -1086,19 +868,12 @@ func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 
 	} else {
 		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(&_err)))
 	}
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(propq)
-	runtime.KeepAlive(__type)
-	runtime.KeepAlive(arg1)
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_EC", &_err)
 }
 
 func EVP_PKEY_Q_keygen_ED25519(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(propq)
-	runtime.KeepAlive(__type)
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_ED25519", &_err)
 }
 
@@ -1110,9 +885,6 @@ func EVP_PKEY_Q_keygen_RSA(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1
 	} else {
 		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 	}
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(propq)
-	runtime.KeepAlive(__type)
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_RSA", &_err)
 }
 
@@ -1121,7 +893,6 @@ var _mkcgo_EVP_PKEY_assign uintptr
 func EVP_PKEY_assign(pkey EVP_PKEY_PTR, __type int32, key unsafe.Pointer) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_assign, uintptr(pkey), uintptr(__type), uintptr(key), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return int32(r0), newMkcgoErr("EVP_PKEY_assign", &_err)
 }
 
@@ -1130,10 +901,6 @@ var _mkcgo_EVP_PKEY_decrypt uintptr
 func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
-	runtime.KeepAlive(arg3)
 	return int32(r0), newMkcgoErr("EVP_PKEY_decrypt", &_err)
 }
 
@@ -1142,7 +909,6 @@ var _mkcgo_EVP_PKEY_decrypt_init uintptr
 func EVP_PKEY_decrypt_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt_init, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("EVP_PKEY_decrypt_init", &_err)
 }
 
@@ -1151,9 +917,6 @@ var _mkcgo_EVP_PKEY_derive uintptr
 func EVP_PKEY_derive(ctx EVP_PKEY_CTX_PTR, key *byte, keylen *int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_derive, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(keylen)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(keylen)
 	return int32(r0), newMkcgoErr("EVP_PKEY_derive", &_err)
 }
 
@@ -1162,7 +925,6 @@ var _mkcgo_EVP_PKEY_derive_init uintptr
 func EVP_PKEY_derive_init(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_derive_init, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_derive_init", &_err)
 }
 
@@ -1171,8 +933,6 @@ var _mkcgo_EVP_PKEY_derive_set_peer uintptr
 func EVP_PKEY_derive_set_peer(ctx EVP_PKEY_CTX_PTR, peer EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_derive_set_peer, uintptr(ctx), uintptr(peer), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(peer)
 	return int32(r0), newMkcgoErr("EVP_PKEY_derive_set_peer", &_err)
 }
 
@@ -1181,10 +941,6 @@ var _mkcgo_EVP_PKEY_encrypt uintptr
 func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
-	runtime.KeepAlive(arg3)
 	return int32(r0), newMkcgoErr("EVP_PKEY_encrypt", &_err)
 }
 
@@ -1193,7 +949,6 @@ var _mkcgo_EVP_PKEY_encrypt_init uintptr
 func EVP_PKEY_encrypt_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt_init, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("EVP_PKEY_encrypt_init", &_err)
 }
 
@@ -1201,7 +956,6 @@ var _mkcgo_EVP_PKEY_free uintptr
 
 func EVP_PKEY_free(arg0 EVP_PKEY_PTR) {
 	syscallN(0, _mkcgo_EVP_PKEY_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_EVP_PKEY_fromdata uintptr
@@ -1209,9 +963,6 @@ var _mkcgo_EVP_PKEY_fromdata uintptr
 func EVP_PKEY_fromdata(ctx EVP_PKEY_CTX_PTR, pkey *EVP_PKEY_PTR, selection int32, params OSSL_PARAM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata, uintptr(ctx), uintptr(unsafe.Pointer(pkey)), uintptr(selection), uintptr(params), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(params)
 	return int32(r0), newMkcgoErr("EVP_PKEY_fromdata", &_err)
 }
 
@@ -1220,7 +971,6 @@ var _mkcgo_EVP_PKEY_fromdata_init uintptr
 func EVP_PKEY_fromdata_init(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata_init, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_fromdata_init", &_err)
 }
 
@@ -1229,7 +979,6 @@ var _mkcgo_EVP_PKEY_get0_DSA uintptr
 func EVP_PKEY_get0_DSA(pkey EVP_PKEY_PTR) (DSA_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_get0_DSA, uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return DSA_PTR(r0), newMkcgoErr("EVP_PKEY_get0_DSA", &_err)
 }
 
@@ -1238,7 +987,6 @@ var _mkcgo_EVP_PKEY_get0_EC_KEY uintptr
 func EVP_PKEY_get0_EC_KEY(pkey EVP_PKEY_PTR) (EC_KEY_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_get0_EC_KEY, uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return EC_KEY_PTR(r0), newMkcgoErr("EVP_PKEY_get0_EC_KEY", &_err)
 }
 
@@ -1247,7 +995,6 @@ var _mkcgo_EVP_PKEY_get1_RSA uintptr
 func EVP_PKEY_get1_RSA(pkey EVP_PKEY_PTR) (RSA_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_get1_RSA, uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return RSA_PTR(r0), newMkcgoErr("EVP_PKEY_get1_RSA", &_err)
 }
 
@@ -1256,8 +1003,6 @@ var _mkcgo_EVP_PKEY_get1_encoded_public_key uintptr
 func EVP_PKEY_get1_encoded_public_key(pkey EVP_PKEY_PTR, ppub **byte) (int, error) {
 	var _err errState
 	r0, _ := syscallN(4, _mkcgo_EVP_PKEY_get1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(ppub)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(ppub)
 	return int(r0), newMkcgoErr("EVP_PKEY_get1_encoded_public_key", &_err)
 }
 
@@ -1266,7 +1011,6 @@ var _mkcgo_EVP_PKEY_get_bits uintptr
 func EVP_PKEY_get_bits(pkey EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_bits, uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_bits", &_err)
 }
 
@@ -1275,9 +1019,6 @@ var _mkcgo_EVP_PKEY_get_bn_param uintptr
 func EVP_PKEY_get_bn_param(pkey EVP_PKEY_PTR, key_name *byte, bn *BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_bn_param, uintptr(pkey), uintptr(unsafe.Pointer(key_name)), uintptr(unsafe.Pointer(bn)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(key_name)
-	runtime.KeepAlive(bn)
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_bn_param", &_err)
 }
 
@@ -1286,9 +1027,6 @@ var _mkcgo_EVP_PKEY_get_raw_private_key uintptr
 func EVP_PKEY_get_raw_private_key(pkey EVP_PKEY_PTR, priv *byte, len *int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_private_key, uintptr(pkey), uintptr(unsafe.Pointer(priv)), uintptr(unsafe.Pointer(len)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(priv)
-	runtime.KeepAlive(len)
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_raw_private_key", &_err)
 }
 
@@ -1297,9 +1035,6 @@ var _mkcgo_EVP_PKEY_get_raw_public_key uintptr
 func EVP_PKEY_get_raw_public_key(pkey EVP_PKEY_PTR, pub *byte, len *int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_raw_public_key, uintptr(pkey), uintptr(unsafe.Pointer(pub)), uintptr(unsafe.Pointer(len)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(pub)
-	runtime.KeepAlive(len)
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_raw_public_key", &_err)
 }
 
@@ -1308,7 +1043,6 @@ var _mkcgo_EVP_PKEY_get_size uintptr
 func EVP_PKEY_get_size(pkey EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_size, uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_size", &_err)
 }
 
@@ -1317,8 +1051,6 @@ var _mkcgo_EVP_PKEY_keygen uintptr
 func EVP_PKEY_keygen(ctx EVP_PKEY_CTX_PTR, ppkey *EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_keygen, uintptr(ctx), uintptr(unsafe.Pointer(ppkey)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(ppkey)
 	return int32(r0), newMkcgoErr("EVP_PKEY_keygen", &_err)
 }
 
@@ -1327,7 +1059,6 @@ var _mkcgo_EVP_PKEY_keygen_init uintptr
 func EVP_PKEY_keygen_init(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_keygen_init, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_keygen_init", &_err)
 }
 
@@ -1344,8 +1075,6 @@ var _mkcgo_EVP_PKEY_new_raw_private_key uintptr
 func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_private_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(key)
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_private_key", &_err)
 }
 
@@ -1354,8 +1083,6 @@ var _mkcgo_EVP_PKEY_new_raw_public_key uintptr
 func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_public_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(key)
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_public_key", &_err)
 }
 
@@ -1364,8 +1091,6 @@ var _mkcgo_EVP_PKEY_paramgen uintptr
 func EVP_PKEY_paramgen(ctx EVP_PKEY_CTX_PTR, ppkey *EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen, uintptr(ctx), uintptr(unsafe.Pointer(ppkey)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(ppkey)
 	return int32(r0), newMkcgoErr("EVP_PKEY_paramgen", &_err)
 }
 
@@ -1374,7 +1099,6 @@ var _mkcgo_EVP_PKEY_paramgen_init uintptr
 func EVP_PKEY_paramgen_init(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen_init, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_paramgen_init", &_err)
 }
 
@@ -1383,7 +1107,6 @@ var _mkcgo_EVP_PKEY_private_check uintptr
 func EVP_PKEY_private_check(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_private_check, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_private_check", &_err)
 }
 
@@ -1392,7 +1115,6 @@ var _mkcgo_EVP_PKEY_public_check_quick uintptr
 func EVP_PKEY_public_check_quick(ctx EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_public_check_quick, uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
 	return int32(r0), newMkcgoErr("EVP_PKEY_public_check_quick", &_err)
 }
 
@@ -1401,8 +1123,6 @@ var _mkcgo_EVP_PKEY_set1_EC_KEY uintptr
 func EVP_PKEY_set1_EC_KEY(pkey EVP_PKEY_PTR, key EC_KEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_EC_KEY, uintptr(pkey), uintptr(key), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(key)
 	return int32(r0), newMkcgoErr("EVP_PKEY_set1_EC_KEY", &_err)
 }
 
@@ -1411,8 +1131,6 @@ var _mkcgo_EVP_PKEY_set1_encoded_public_key uintptr
 func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub *byte, publen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(pub)), uintptr(publen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pkey)
-	runtime.KeepAlive(pub)
 	return int32(r0), newMkcgoErr("EVP_PKEY_set1_encoded_public_key", &_err)
 }
 
@@ -1421,10 +1139,6 @@ var _mkcgo_EVP_PKEY_sign uintptr
 func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
-	runtime.KeepAlive(arg3)
 	return int32(r0), newMkcgoErr("EVP_PKEY_sign", &_err)
 }
 
@@ -1433,7 +1147,6 @@ var _mkcgo_EVP_PKEY_sign_init uintptr
 func EVP_PKEY_sign_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign_init, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("EVP_PKEY_sign_init", &_err)
 }
 
@@ -1442,7 +1155,6 @@ var _mkcgo_EVP_PKEY_up_ref uintptr
 func EVP_PKEY_up_ref(key EVP_PKEY_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_up_ref, uintptr(key), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(key)
 	return int32(r0), newMkcgoErr("EVP_PKEY_up_ref", &_err)
 }
 
@@ -1451,9 +1163,6 @@ var _mkcgo_EVP_PKEY_verify uintptr
 func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(sig)
-	runtime.KeepAlive(tbs)
 	return int32(r0), newMkcgoErr("EVP_PKEY_verify", &_err)
 }
 
@@ -1462,7 +1171,6 @@ var _mkcgo_EVP_PKEY_verify_init uintptr
 func EVP_PKEY_verify_init(arg0 EVP_PKEY_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify_init, uintptr(arg0), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("EVP_PKEY_verify_init", &_err)
 }
 
@@ -1471,9 +1179,6 @@ var _mkcgo_EVP_SIGNATURE_fetch uintptr
 func EVP_SIGNATURE_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_SIGNATURE_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_EVP_SIGNATURE_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(ctx)
-	runtime.KeepAlive(algorithm)
-	runtime.KeepAlive(properties)
 	return EVP_SIGNATURE_PTR(r0), newMkcgoErr("EVP_SIGNATURE_fetch", &_err)
 }
 
@@ -1481,7 +1186,6 @@ var _mkcgo_EVP_SIGNATURE_free uintptr
 
 func EVP_SIGNATURE_free(signature EVP_SIGNATURE_PTR) {
 	syscallN(0, _mkcgo_EVP_SIGNATURE_free, uintptr(signature))
-	runtime.KeepAlive(signature)
 }
 
 var _mkcgo_EVP_aes_128_cbc uintptr
@@ -1573,7 +1277,6 @@ var _mkcgo_EVP_default_properties_enable_fips uintptr
 func EVP_default_properties_enable_fips(libctx OSSL_LIB_CTX_PTR, enable int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_EVP_default_properties_enable_fips, uintptr(libctx), uintptr(enable), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(libctx)
 	return int32(r0), newMkcgoErr("EVP_default_properties_enable_fips", &_err)
 }
 
@@ -1581,7 +1284,6 @@ var _mkcgo_EVP_default_properties_is_fips_enabled uintptr
 
 func EVP_default_properties_is_fips_enabled(libctx OSSL_LIB_CTX_PTR) int32 {
 	r0, _ := syscallN(0, _mkcgo_EVP_default_properties_is_fips_enabled, uintptr(libctx))
-	runtime.KeepAlive(libctx)
 	return int32(r0)
 }
 
@@ -1745,8 +1447,6 @@ var _mkcgo_HMAC_CTX_copy uintptr
 func HMAC_CTX_copy(dest HMAC_CTX_PTR, src HMAC_CTX_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_HMAC_CTX_copy, uintptr(dest), uintptr(src), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(dest)
-	runtime.KeepAlive(src)
 	return int32(r0), newMkcgoErr("HMAC_CTX_copy", &_err)
 }
 
@@ -1754,7 +1454,6 @@ var _mkcgo_HMAC_CTX_free uintptr
 
 func HMAC_CTX_free(arg0 HMAC_CTX_PTR) {
 	syscallN(0, _mkcgo_HMAC_CTX_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_HMAC_CTX_new uintptr
@@ -1770,9 +1469,6 @@ var _mkcgo_HMAC_Final uintptr
 func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_HMAC_Final, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
-	runtime.KeepAlive(arg2)
 	return int32(r0), newMkcgoErr("HMAC_Final", &_err)
 }
 
@@ -1781,9 +1477,6 @@ var _mkcgo_HMAC_Init_ex uintptr
 func HMAC_Init_ex(arg0 HMAC_CTX_PTR, arg1 unsafe.Pointer, arg2 int32, arg3 EVP_MD_PTR, arg4 ENGINE_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_HMAC_Init_ex, uintptr(arg0), uintptr(arg1), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg3)
-	runtime.KeepAlive(arg4)
 	return int32(r0), newMkcgoErr("HMAC_Init_ex", &_err)
 }
 
@@ -1792,8 +1485,6 @@ var _mkcgo_HMAC_Update uintptr
 func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_HMAC_Update, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
-	runtime.KeepAlive(arg1)
 	return int32(r0), newMkcgoErr("HMAC_Update", &_err)
 }
 
@@ -1815,7 +1506,6 @@ var _mkcgo_OPENSSL_init_crypto uintptr
 func OPENSSL_init_crypto(ops uint64, settings OPENSSL_INIT_SETTINGS_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_OPENSSL_init_crypto, uintptr(ops), uintptr(settings), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(settings)
 	return int32(r0), newMkcgoErr("OPENSSL_init_crypto", &_err)
 }
 
@@ -1856,7 +1546,6 @@ var _mkcgo_OSSL_PARAM_BLD_free uintptr
 
 func OSSL_PARAM_BLD_free(bld OSSL_PARAM_BLD_PTR) {
 	syscallN(0, _mkcgo_OSSL_PARAM_BLD_free, uintptr(bld))
-	runtime.KeepAlive(bld)
 }
 
 var _mkcgo_OSSL_PARAM_BLD_new uintptr
@@ -1872,9 +1561,6 @@ var _mkcgo_OSSL_PARAM_BLD_push_BN uintptr
 func OSSL_PARAM_BLD_push_BN(bld OSSL_PARAM_BLD_PTR, key *byte, bn BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_BN, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(bn), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(bld)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(bn)
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_BN", &_err)
 }
 
@@ -1883,8 +1569,6 @@ var _mkcgo_OSSL_PARAM_BLD_push_int32 uintptr
 func OSSL_PARAM_BLD_push_int32(bld OSSL_PARAM_BLD_PTR, key *byte, num int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_int32, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(num), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(bld)
-	runtime.KeepAlive(key)
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_int32", &_err)
 }
 
@@ -1893,8 +1577,6 @@ var _mkcgo_OSSL_PARAM_BLD_push_octet_string uintptr
 func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_octet_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(buf), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(bld)
-	runtime.KeepAlive(key)
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_octet_string", &_err)
 }
 
@@ -1903,9 +1585,6 @@ var _mkcgo_OSSL_PARAM_BLD_push_utf8_string uintptr
 func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_utf8_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(buf)), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(bld)
-	runtime.KeepAlive(key)
-	runtime.KeepAlive(buf)
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_utf8_string", &_err)
 }
 
@@ -1914,7 +1593,6 @@ var _mkcgo_OSSL_PARAM_BLD_to_param uintptr
 func OSSL_PARAM_BLD_to_param(bld OSSL_PARAM_BLD_PTR) (OSSL_PARAM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_BLD_to_param, uintptr(bld), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(bld)
 	return OSSL_PARAM_PTR(r0), newMkcgoErr("OSSL_PARAM_BLD_to_param", &_err)
 }
 
@@ -1922,7 +1600,6 @@ var _mkcgo_OSSL_PARAM_free uintptr
 
 func OSSL_PARAM_free(p OSSL_PARAM_PTR) {
 	syscallN(0, _mkcgo_OSSL_PARAM_free, uintptr(p))
-	runtime.KeepAlive(p)
 }
 
 var _mkcgo_OSSL_PARAM_locate_const uintptr
@@ -1930,8 +1607,6 @@ var _mkcgo_OSSL_PARAM_locate_const uintptr
 func OSSL_PARAM_locate_const(p OSSL_PARAM_PTR, key *byte) (OSSL_PARAM_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_locate_const, uintptr(p), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(key)
 	return OSSL_PARAM_PTR(r0), newMkcgoErr("OSSL_PARAM_locate_const", &_err)
 }
 
@@ -1939,8 +1614,6 @@ var _mkcgo_OSSL_PROVIDER_available uintptr
 
 func OSSL_PROVIDER_available(libctx OSSL_LIB_CTX_PTR, name *byte) int32 {
 	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_available, uintptr(libctx), uintptr(unsafe.Pointer(name)))
-	runtime.KeepAlive(libctx)
-	runtime.KeepAlive(name)
 	return int32(r0)
 }
 
@@ -1948,7 +1621,6 @@ var _mkcgo_OSSL_PROVIDER_get0_name uintptr
 
 func OSSL_PROVIDER_get0_name(prov OSSL_PROVIDER_PTR) *byte {
 	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_get0_name, uintptr(prov))
-	runtime.KeepAlive(prov)
 	return (*byte)(unsafe.Pointer(r0))
 }
 
@@ -1957,8 +1629,6 @@ var _mkcgo_OSSL_PROVIDER_try_load uintptr
 func OSSL_PROVIDER_try_load(libctx OSSL_LIB_CTX_PTR, name *byte, retain_fallbacks int32) (OSSL_PROVIDER_PTR, error) {
 	var _err errState
 	r0, _ := syscallN(1, _mkcgo_OSSL_PROVIDER_try_load, uintptr(libctx), uintptr(unsafe.Pointer(name)), uintptr(retain_fallbacks), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(libctx)
-	runtime.KeepAlive(name)
 	return OSSL_PROVIDER_PTR(r0), newMkcgoErr("OSSL_PROVIDER_try_load", &_err)
 }
 
@@ -1985,10 +1655,6 @@ var _mkcgo_PKCS5_PBKDF2_HMAC uintptr
 func PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest EVP_MD_PTR, keylen int32, out *byte) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_PKCS5_PBKDF2_HMAC, uintptr(unsafe.Pointer(pass)), uintptr(passlen), uintptr(unsafe.Pointer(salt)), uintptr(saltlen), uintptr(iter), uintptr(digest), uintptr(keylen), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(pass)
-	runtime.KeepAlive(salt)
-	runtime.KeepAlive(digest)
-	runtime.KeepAlive(out)
 	return int32(r0), newMkcgoErr("PKCS5_PBKDF2_HMAC", &_err)
 }
 
@@ -1997,7 +1663,6 @@ var _mkcgo_RAND_bytes uintptr
 func RAND_bytes(arg0 *byte, arg1 int32) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_RAND_bytes, uintptr(unsafe.Pointer(arg0)), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(arg0)
 	return int32(r0), newMkcgoErr("RAND_bytes", &_err)
 }
 
@@ -2005,36 +1670,24 @@ var _mkcgo_RSA_free uintptr
 
 func RSA_free(arg0 RSA_PTR) {
 	syscallN(0, _mkcgo_RSA_free, uintptr(arg0))
-	runtime.KeepAlive(arg0)
 }
 
 var _mkcgo_RSA_get0_crt_params uintptr
 
 func RSA_get0_crt_params(r RSA_PTR, dmp1 *BIGNUM_PTR, dmq1 *BIGNUM_PTR, iqmp *BIGNUM_PTR) {
 	syscallN(0, _mkcgo_RSA_get0_crt_params, uintptr(r), uintptr(unsafe.Pointer(dmp1)), uintptr(unsafe.Pointer(dmq1)), uintptr(unsafe.Pointer(iqmp)))
-	runtime.KeepAlive(r)
-	runtime.KeepAlive(dmp1)
-	runtime.KeepAlive(dmq1)
-	runtime.KeepAlive(iqmp)
 }
 
 var _mkcgo_RSA_get0_factors uintptr
 
 func RSA_get0_factors(rsa RSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR) {
 	syscallN(0, _mkcgo_RSA_get0_factors, uintptr(rsa), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)))
-	runtime.KeepAlive(rsa)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(q)
 }
 
 var _mkcgo_RSA_get0_key uintptr
 
 func RSA_get0_key(rsa RSA_PTR, n *BIGNUM_PTR, e *BIGNUM_PTR, d *BIGNUM_PTR) {
 	syscallN(0, _mkcgo_RSA_get0_key, uintptr(rsa), uintptr(unsafe.Pointer(n)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(d)))
-	runtime.KeepAlive(rsa)
-	runtime.KeepAlive(n)
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(d)
 }
 
 var _mkcgo_RSA_new uintptr
@@ -2050,10 +1703,6 @@ var _mkcgo_RSA_set0_crt_params uintptr
 func RSA_set0_crt_params(rsa RSA_PTR, dmp1 BIGNUM_PTR, dmp2 BIGNUM_PTR, iqmp BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_RSA_set0_crt_params, uintptr(rsa), uintptr(dmp1), uintptr(dmp2), uintptr(iqmp), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(rsa)
-	runtime.KeepAlive(dmp1)
-	runtime.KeepAlive(dmp2)
-	runtime.KeepAlive(iqmp)
 	return int32(r0), newMkcgoErr("RSA_set0_crt_params", &_err)
 }
 
@@ -2062,9 +1711,6 @@ var _mkcgo_RSA_set0_factors uintptr
 func RSA_set0_factors(rsa RSA_PTR, p BIGNUM_PTR, q BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_RSA_set0_factors, uintptr(rsa), uintptr(p), uintptr(q), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(rsa)
-	runtime.KeepAlive(p)
-	runtime.KeepAlive(q)
 	return int32(r0), newMkcgoErr("RSA_set0_factors", &_err)
 }
 
@@ -2073,10 +1719,6 @@ var _mkcgo_RSA_set0_key uintptr
 func RSA_set0_key(r RSA_PTR, n BIGNUM_PTR, e BIGNUM_PTR, d BIGNUM_PTR) (int32, error) {
 	var _err errState
 	r0, _ := syscallN(3, _mkcgo_RSA_set0_key, uintptr(r), uintptr(n), uintptr(e), uintptr(d), uintptr(unsafe.Pointer(&_err)))
-	runtime.KeepAlive(r)
-	runtime.KeepAlive(n)
-	runtime.KeepAlive(e)
-	runtime.KeepAlive(d)
 	return int32(r0), newMkcgoErr("RSA_set0_key", &_err)
 }
 


### PR DESCRIPTION
The Go compiler already keeps alive all arguments passed to functions whose all parameters and return values are uintptrs.