### PR TITLE
mkcgo: support marking C parameters as slice pointers

### DIFF
--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -541,12 +541,12 @@ func isVoid(typ string) bool {
 // fnToGoParams returns source code for function f parameters.
 func fnToGoParams(fn *mkcgo.Func) string {
 	return join(fn.Params, func(_ int, p *mkcgo.Param) string {
-		if fn.Slice.Len != "" && fn.Slice.Len == p.Name {
+		if _, ok := fn.SliceFromLen(p.Name); ok {
 			// Skip length parameter for slice.
 			return ""
 		}
 		typ, _ := cTypeToGo(p.Type, false)
-		if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+		if _, ok := fn.SliceFromPtr(p.Name); ok {
 			if typ == "unsafe.Pointer" {
 				typ = "byte"
 			}
@@ -564,10 +564,10 @@ func fnToGoArgs(fn *mkcgo.Func) string {
 		if goType == "" {
 			return ""
 		}
-		if fn.Slice.Len != "" && fn.Slice.Len == p.Name {
-			arg = "len(" + fn.Slice.Ptr + ")"
+		if slice, ok := fn.SliceFromLen(p.Name); ok {
+			arg = "len(" + slice.Ptr + ")"
 			needCast = true
-		} else if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+		} else if _, ok := fn.SliceFromPtr(p.Name); ok {
 			arg = "unsafe.SliceData(" + arg + ")"
 			if goType == "unsafe.Pointer" {
 				goType = "*C.uchar"
@@ -592,7 +592,7 @@ func fnToCArgs(fn *mkcgo.Func, addType, addName bool) string {
 		}
 		var s string
 		if addType {
-			if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+			if _, ok := fn.SliceFromPtr(p.Name); ok {
 				// Use unsigned char* for slice pointer,
 				// else cgoCheckPointer may complain.
 				s = strings.ReplaceAll(p.Type, "void", "unsigned char")
@@ -996,7 +996,7 @@ func generateNocgoFn(typePtrs map[string]bool, src *mkcgo.Source, fn *mkcgo.Func
 		if param.Type == "void" {
 			continue
 		}
-		if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
+		if _, ok := fn.SliceFromLen(param.Name); ok {
 			// Skip length parameter for slice.
 			continue
 		}
@@ -1006,7 +1006,7 @@ func generateNocgoFn(typePtrs map[string]bool, src *mkcgo.Source, fn *mkcgo.Func
 
 		// Convert C types to Go types for nocgo mode
 		goType, _ := cTypeToGo(param.Type, false)
-		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+		if _, ok := fn.SliceFromPtr(param.Name); ok {
 			// Slice parameter
 			if goType == "unsafe.Pointer" {
 				goType = "byte"
@@ -1123,11 +1123,11 @@ func generateNocgoFnBody(src *mkcgo.Source, fn *mkcgo.Func, errorType int, newR0
 		// Convert parameter to uintptr, handling different types correctly
 		goType, _ := cTypeToGo(param.Type, false)
 
-		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+		if _, ok := fn.SliceFromPtr(param.Name); ok {
 			// Slice parameter
 			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
-		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
-			fmt.Fprintf(w, ", uintptr(len(%s))", fn.Slice.Ptr)
+		} else if slice, ok := fn.SliceFromLen(param.Name); ok {
+			fmt.Fprintf(w, ", uintptr(len(%s))", slice.Ptr)
 		} else if strings.HasPrefix(goType, "*") {
 			// Pointer types need to go through unsafe.Pointer
 			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(%s))", param.Name)
@@ -1248,11 +1248,11 @@ func macosDarwinArm64Params(src *mkcgo.Source, fn *mkcgo.Func, w io.Writer) bool
 		}
 		var goParam string
 		goType, _ := cTypeToGo(param.Type, false)
-		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+		if _, ok := fn.SliceFromPtr(param.Name); ok {
 			// Slice parameter
 			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
-		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
-			goParam = fmt.Sprintf("uintptr(len(%s))", fn.Slice.Ptr)
+		} else if slice, ok := fn.SliceFromLen(param.Name); ok {
+			goParam = fmt.Sprintf("uintptr(len(%s))", slice.Ptr)
 		} else if strings.HasPrefix(goType, "*") {
 			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(%s))", param.Name)
 		} else {

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -1011,7 +1011,7 @@ func generateNocgoFn(typePtrs map[string]bool, src *mkcgo.Source, fn *mkcgo.Func
 			if goType == "unsafe.Pointer" {
 				goType = "byte"
 			}
-			goType = "[]" + strings.TrimRight(goType, "*")
+			goType = "[]" + strings.TrimLeft(goType, "*")
 		}
 
 		fmt.Fprintf(w, "%s %s", param.Name, goType)

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -1250,9 +1250,9 @@ func macosDarwinArm64Params(src *mkcgo.Source, fn *mkcgo.Func, w io.Writer) bool
 		goType, _ := cTypeToGo(param.Type, false)
 		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
 			// Slice parameter
-			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+			fmt.Fprintf(w, "uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
 		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
-			fmt.Fprintf(w, ", uintptr(len(%s))", fn.Slice.Ptr)
+			fmt.Fprintf(w, "uintptr(len(%s))", fn.Slice.Ptr)
 		} else if strings.HasPrefix(goType, "*") {
 			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(%s))", param.Name)
 		} else {

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -550,7 +550,7 @@ func fnToGoParams(fn *mkcgo.Func) string {
 			if typ == "unsafe.Pointer" {
 				typ = "byte"
 			}
-			typ = "[]" + strings.TrimRight(typ, "*")
+			typ = "[]" + strings.TrimLeft(typ, "*")
 		}
 		return p.Name + " " + typ
 	}, ", ")

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -439,28 +439,6 @@ func generateCFn(typedefs map[string]string, fn *mkcgo.Func, w io.Writer) {
 	fmt.Fprintf(w, "}\n\n")
 }
 
-// paramToGo converts C parameter p to Go parameter.
-func paramToGo(p *mkcgo.Param, hidden bool) string {
-	goType, needCast := cTypeToGo(p.Type, true)
-	if !needCast {
-		if hidden && goType == "unsafe.Pointer" {
-			// The parameter is not annotated with cgoCheckPointer by cgo
-			// if it has the form unsafe.Pointer(&...).
-			// See https://go-review.googlesource.com/c/go/+/404295.
-			// TODO: support other types.
-			return fmt.Sprintf("unsafe.Pointer(&*(*byte)(%s))", p.Name)
-		}
-		return p.Name
-	}
-	switch {
-	case goType == "":
-		return p.Name
-	case goType[0] == '*':
-		return fmt.Sprintf("(%s)(unsafe.Pointer(%s))", goType, p.Name)
-	}
-	return fmt.Sprintf("%s(%s)", goType, p.Name)
-}
-
 // isStdType reports whether t is a standard C type.
 func isStdType(t string) bool {
 	_, found := cstdTypesToGo[t]
@@ -555,24 +533,6 @@ func cTypeToGo(t string, cgo bool) (string, bool) {
 	return t, true
 }
 
-// paramToC returns C source code of parameter p.
-func paramToC(i int, p *mkcgo.Param, addType, addName bool) string {
-	if p.Type == "..." {
-		return "..."
-	}
-	var s string
-	if addType {
-		s += p.Type
-	}
-	if addName && !isVoid(p.Type) {
-		if len(s) > 0 {
-			s += " "
-		}
-		s += "_arg" + strconv.Itoa(i)
-	}
-	return s
-}
-
 // isVoid reports whether typ is a void type.
 func isVoid(typ string) bool {
 	return typ == "void"
@@ -581,7 +541,17 @@ func isVoid(typ string) bool {
 // fnToGoParams returns source code for function f parameters.
 func fnToGoParams(fn *mkcgo.Func) string {
 	return join(fn.Params, func(_ int, p *mkcgo.Param) string {
+		if fn.Slice.Len != "" && fn.Slice.Len == p.Name {
+			// Skip length parameter for slice.
+			return ""
+		}
 		typ, _ := cTypeToGo(p.Type, false)
+		if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+			if typ == "unsafe.Pointer" {
+				typ = "byte"
+			}
+			typ = "[]" + strings.TrimRight(typ, "*")
+		}
 		return p.Name + " " + typ
 	}, ", ")
 }
@@ -589,14 +559,54 @@ func fnToGoParams(fn *mkcgo.Func) string {
 // argList returns source code for C parameters for function f.
 func fnToGoArgs(fn *mkcgo.Func) string {
 	return join(fn.Params, func(_ int, p *mkcgo.Param) string {
-		return paramToGo(p, slices.Contains(fn.NoCheckPtrParams, p.Name))
+		arg := p.Name
+		goType, needCast := cTypeToGo(p.Type, true)
+		if goType == "" {
+			return ""
+		}
+		if fn.Slice.Len != "" && fn.Slice.Len == p.Name {
+			arg = "len(" + fn.Slice.Ptr + ")"
+			needCast = true
+		} else if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+			arg = "unsafe.SliceData(" + arg + ")"
+			if goType == "unsafe.Pointer" {
+				goType = "*C.uchar"
+			}
+			needCast = true
+		}
+		if !needCast {
+			return arg
+		}
+		if goType[0] == '*' {
+			return fmt.Sprintf("(%s)(unsafe.Pointer(%s))", goType, arg)
+		}
+		return fmt.Sprintf("%s(%s)", goType, arg)
 	}, ", ")
 }
 
 // fnToCArgs returns source code for C parameters for function f.
 func fnToCArgs(fn *mkcgo.Func, addType, addName bool) string {
 	return join(fn.Params, func(i int, p *mkcgo.Param) string {
-		return paramToC(i, p, addType, addName)
+		if p.Type == "..." {
+			return "..."
+		}
+		var s string
+		if addType {
+			if fn.Slice.Ptr != "" && fn.Slice.Ptr == p.Name {
+				// Use unsigned char* for slice pointer,
+				// else cgoCheckPointer may complain.
+				s = strings.ReplaceAll(p.Type, "void", "unsigned char")
+			} else {
+				s = p.Type
+			}
+		}
+		if addName && !isVoid(p.Type) {
+			if len(s) > 0 {
+				s += " "
+			}
+			s += "_arg" + strconv.Itoa(i)
+		}
+		return s
 	}, ", ")
 }
 
@@ -981,23 +991,30 @@ func generateNocgoFn(typePtrs map[string]bool, src *mkcgo.Source, fn *mkcgo.Func
 
 	// Generate parameters
 	paramCount := 0
-	for i, param := range fn.Params {
+	for _, param := range fn.Params {
 		// Skip void parameters
 		if param.Type == "void" {
 			continue
 		}
-
+		if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
+			// Skip length parameter for slice.
+			continue
+		}
 		if paramCount > 0 {
 			fmt.Fprintf(w, ", ")
 		}
 
 		// Convert C types to Go types for nocgo mode
 		goType, _ := cTypeToGo(param.Type, false)
-		paramName := param.Name
-		if paramName == "" {
-			paramName = fmt.Sprintf("arg%d", i)
+		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+			// Slice parameter
+			if goType == "unsafe.Pointer" {
+				goType = "byte"
+			}
+			goType = "[]" + strings.TrimRight(goType, "*")
 		}
-		fmt.Fprintf(w, "%s %s", paramName, goType)
+
+		fmt.Fprintf(w, "%s %s", param.Name, goType)
 		paramCount++
 	}
 	fmt.Fprintf(w, ")")
@@ -1098,24 +1115,24 @@ func generateNocgoFnBody(src *mkcgo.Source, fn *mkcgo.Func, errorType int, newR0
 	}
 
 	// Add actual parameters
-	for i, param := range fn.Params {
+	for _, param := range fn.Params {
 		// Skip void parameters
 		if param.Type == "void" {
 			continue
 		}
-
-		paramName := param.Name
-		if paramName == "" {
-			paramName = fmt.Sprintf("arg%d", i)
-		}
-
 		// Convert parameter to uintptr, handling different types correctly
 		goType, _ := cTypeToGo(param.Type, false)
-		if strings.HasPrefix(goType, "*") {
+
+		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+			// Slice parameter
+			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
+			fmt.Fprintf(w, ", uintptr(len(%s))", fn.Slice.Ptr)
+		} else if strings.HasPrefix(goType, "*") {
 			// Pointer types need to go through unsafe.Pointer
-			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(%s))", paramName)
+			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(%s))", param.Name)
 		} else {
-			fmt.Fprintf(w, ", uintptr(%s)", paramName)
+			fmt.Fprintf(w, ", uintptr(%s)", param.Name)
 		}
 	}
 	if errorType != 0 {
@@ -1230,7 +1247,13 @@ func macosDarwinArm64Params(src *mkcgo.Source, fn *mkcgo.Func, w io.Writer) bool
 			}
 		}
 		var goParam string
-		if goType, _ := cTypeToGo(param.Type, false); strings.HasPrefix(goType, "*") {
+		goType, _ := cTypeToGo(param.Type, false)
+		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
+			// Slice parameter
+			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
+			fmt.Fprintf(w, ", uintptr(len(%s))", fn.Slice.Ptr)
+		} else if strings.HasPrefix(goType, "*") {
 			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(%s))", param.Name)
 		} else {
 			goParam = fmt.Sprintf("uintptr(%s)", param.Name)

--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -1250,9 +1250,9 @@ func macosDarwinArm64Params(src *mkcgo.Source, fn *mkcgo.Func, w io.Writer) bool
 		goType, _ := cTypeToGo(param.Type, false)
 		if fn.Slice.Ptr != "" && fn.Slice.Ptr == param.Name {
 			// Slice parameter
-			fmt.Fprintf(w, "uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
 		} else if fn.Slice.Len != "" && fn.Slice.Len == param.Name {
-			fmt.Fprintf(w, "uintptr(len(%s))", fn.Slice.Ptr)
+			goParam = fmt.Sprintf("uintptr(len(%s))", fn.Slice.Ptr)
 		} else if strings.HasPrefix(goType, "*") {
 			goParam = fmt.Sprintf("uintptr(unsafe.Pointer(%s))", param.Name)
 		} else {

--- a/evp.go
+++ b/evp.go
@@ -479,7 +479,7 @@ func evpHashSign(withKey withKeyFunc, h crypto.Hash, msg []byte) ([]byte, error)
 		return nil, err
 	}
 	if len(msg) > 0 {
-		if _, err := ossl.EVP_DigestUpdate(ctx, pbase(msg), len(msg)); err != nil {
+		if _, err := ossl.EVP_DigestUpdate(ctx, msg); err != nil {
 			return nil, err
 		}
 	}
@@ -512,7 +512,7 @@ func evpHashVerify(withKey withKeyFunc, h crypto.Hash, msg, sig []byte) error {
 		return err
 	}
 	if len(msg) > 0 {
-		if _, err := ossl.EVP_DigestUpdate(ctx, pbase(msg), len(msg)); err != nil {
+		if _, err := ossl.EVP_DigestUpdate(ctx, msg); err != nil {
 			return err
 		}
 	}

--- a/hash.go
+++ b/hash.go
@@ -34,7 +34,7 @@ const (
 const maxHashSize = 64
 
 func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
-	_, err := ossl.EVP_Digest(pbaseNeverEmpty(p), len(p), base(sum), nil, loadHash(ch).md, nil)
+	_, err := ossl.EVP_Digest(p, base(sum), nil, loadHash(ch).md, nil)
 	return err == nil
 }
 
@@ -298,7 +298,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 		return 0, nil
 	}
 	h.init()
-	if _, err := ossl.EVP_DigestUpdate(h.ctx, pbase(p), len(p)); err != nil {
+	if _, err := ossl.EVP_DigestUpdate(h.ctx, p); err != nil {
 		panic(err)
 	}
 	runtime.KeepAlive(h)
@@ -310,7 +310,7 @@ func (h *evpHash) WriteString(s string) (int, error) {
 		return 0, nil
 	}
 	h.init()
-	if _, err := ossl.EVP_DigestUpdate(h.ctx, unsafe.Pointer(unsafe.StringData(s)), len(s)); err != nil {
+	if _, err := ossl.EVP_DigestUpdate(h.ctx, unsafe.Slice(unsafe.StringData(s), len(s))); err != nil {
 		panic(err)
 	}
 	runtime.KeepAlive(h)
@@ -319,7 +319,7 @@ func (h *evpHash) WriteString(s string) (int, error) {
 
 func (h *evpHash) WriteByte(c byte) error {
 	h.init()
-	if _, err := ossl.EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1); err != nil {
+	if _, err := ossl.EVP_DigestUpdate(h.ctx, unsafe.Slice(&c, 1)); err != nil {
 		panic(err)
 	}
 	runtime.KeepAlive(h)

--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -70,7 +70,27 @@ type Attrs struct {
 	NoCallback     bool
 	Framework      Framework
 	Static         bool
-	Slice          Slice
+	Slice          []Slice
+}
+
+func (attrs *Attrs) SliceFromPtr(name string) (Slice, bool) {
+	idx := slices.IndexFunc(attrs.Slice, func(s Slice) bool {
+		return s.Ptr == name
+	})
+	if idx == -1 {
+		return Slice{}, false
+	}
+	return attrs.Slice[idx], true
+}
+
+func (attrs *Attrs) SliceFromLen(name string) (Slice, bool) {
+	idx := slices.IndexFunc(attrs.Slice, func(s Slice) bool {
+		return s.Len == name
+	})
+	if idx == -1 {
+		return Slice{}, false
+	}
+	return attrs.Slice[idx], true
 }
 
 func (attrs *Attrs) String() string {
@@ -107,14 +127,16 @@ func (attrs *Attrs) String() string {
 		bld.WriteString(attrs.Framework.Version)
 		bld.WriteByte(')')
 	}
-	if attrs.Slice.Ptr != "" {
-		bld.WriteString(", slice(")
-		bld.WriteString(attrs.Slice.Ptr)
-		if attrs.Slice.Len != "" {
-			bld.WriteString(", ")
-			bld.WriteString(attrs.Slice.Len)
+	for _, slice := range attrs.Slice {
+		if slice.Ptr != "" {
+			bld.WriteString(", slice(")
+			bld.WriteString(slice.Ptr)
+			if slice.Len != "" {
+				bld.WriteString(", ")
+				bld.WriteString(slice.Len)
+			}
+			bld.WriteByte(')')
 		}
-		bld.WriteByte(')')
 	}
 	return strings.TrimPrefix(bld.String(), ", ")
 }
@@ -303,10 +325,11 @@ var attributes = [...]attribute{
 			if len(s) == 0 || len(s) > 2 {
 				return errors.New("requires 1 or 2 arguments")
 			}
-			opts.Slice = Slice{Ptr: s[0]}
+			slice := Slice{Ptr: s[0]}
 			if len(s) == 2 {
-				opts.Slice.Len = s[1]
+				slice.Len = s[1]
 			}
+			opts.Slice = append(opts.Slice, slice)
 			return nil
 		},
 	},

--- a/internal/mkcgo/mkcgo.go
+++ b/internal/mkcgo/mkcgo.go
@@ -53,18 +53,24 @@ type Framework struct {
 	Version string
 }
 
+// Slice describes a Go slice parameter.
+type Slice struct {
+	Ptr string
+	Len string
+}
+
 // Attrs contains attributes of a C symbol.
 type Attrs struct {
-	Tags             []TagAttr
-	VariadicTarget   string
-	Optional         bool
-	NoError          bool
-	ErrCond          string
-	NoEscape         bool
-	NoCallback       bool
-	NoCheckPtrParams []string
-	Framework        Framework
-	Static           bool
+	Tags           []TagAttr
+	VariadicTarget string
+	Optional       bool
+	NoError        bool
+	ErrCond        string
+	NoEscape       bool
+	NoCallback     bool
+	Framework      Framework
+	Static         bool
+	Slice          Slice
 }
 
 func (attrs *Attrs) String() string {
@@ -94,21 +100,20 @@ func (attrs *Attrs) String() string {
 	if attrs.NoCallback {
 		bld.WriteString(", nocallback")
 	}
-	if len(attrs.NoCheckPtrParams) != 0 {
-		bld.WriteString(", nocheckptr(")
-		for i, p := range attrs.NoCheckPtrParams {
-			if i > 0 {
-				bld.WriteString(", ")
-			}
-			bld.WriteString(p)
-		}
-		bld.WriteByte(')')
-	}
 	if len(attrs.Framework.Name) != 0 {
 		bld.WriteString(", framework(")
 		bld.WriteString(attrs.Framework.Name)
 		bld.WriteString(", ")
 		bld.WriteString(attrs.Framework.Version)
+		bld.WriteByte(')')
+	}
+	if attrs.Slice.Ptr != "" {
+		bld.WriteString(", slice(")
+		bld.WriteString(attrs.Slice.Ptr)
+		if attrs.Slice.Len != "" {
+			bld.WriteString(", ")
+			bld.WriteString(attrs.Slice.Len)
+		}
 		bld.WriteByte(')')
 	}
 	return strings.TrimPrefix(bld.String(), ", ")
@@ -273,14 +278,6 @@ var attributes = [...]attribute{
 		},
 	},
 	{
-		name:        "nocheckptr",
-		description: "The parameter will be hidden from the Go compiler.",
-		handle: func(opts *Attrs, s ...string) error {
-			opts.NoCheckPtrParams = append(opts.NoCheckPtrParams, s[0])
-			return nil
-		},
-	},
-	{
 		name:        "static",
 		description: "Use static cgo import for this symbol.",
 		handle: func(opts *Attrs, s ...string) error {
@@ -296,6 +293,20 @@ var attributes = [...]attribute{
 				return errors.New("requires 2 arguments")
 			}
 			opts.Framework = Framework{Name: s[0], Version: s[1]}
+			return nil
+		},
+	},
+	{
+		name:        "slice",
+		description: "The parameter corresponds to a Go slice.",
+		handle: func(opts *Attrs, s ...string) error {
+			if len(s) == 0 || len(s) > 2 {
+				return errors.New("requires 1 or 2 arguments")
+			}
+			opts.Slice = Slice{Ptr: s[0]}
+			if len(s) == 2 {
+				opts.Slice.Len = s[1]
+			}
 			return nil
 		},
 	},

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -177,17 +177,17 @@ func TestFuncString(t *testing.T) {
 			name: "Function with attributes",
 			function: &mkcgo.Func{Name: "TestFunc", Ret: "void", Params: []*mkcgo.Param{{Type: "int", Name: "param1"}},
 				Attrs: mkcgo.Attrs{
-					Tags:             []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2", Name: "name"}},
-					Optional:         true,
-					NoError:          true,
-					ErrCond:          "error_condition",
-					NoEscape:         true,
-					NoCallback:       true,
-					NoCheckPtrParams: []string{"param1"},
-					Framework:        mkcgo.Framework{Name: "CoreFoundation", Version: "A"},
+					Tags:       []mkcgo.TagAttr{{Tag: "tag1"}, {Tag: "tag2", Name: "name"}},
+					Optional:   true,
+					NoError:    true,
+					ErrCond:    "error_condition",
+					NoEscape:   true,
+					NoCallback: true,
+					Framework:  mkcgo.Framework{Name: "CoreFoundation", Version: "A"},
+					Slice:      mkcgo.Slice{Ptr: "a", Len: "b"},
 				},
 			},
-			want: "void TestFunc(int param1) [{tag1 } {tag2 name}], optional, noerror, errcond(error_condition), noescape, nocallback, nocheckptr(param1), framework(CoreFoundation, A)",
+			want: "void TestFunc(int param1) [{tag1 } {tag2 name}], optional, noerror, errcond(error_condition), noescape, nocallback, framework(CoreFoundation, A), slice(a, b)",
 		},
 	}
 
@@ -253,7 +253,7 @@ enum {
 		}, {
 			content: `
 void F0(void) __attribute__((tag("t0"),noerror,tag("t1","tn0")));
-int F1(int p1) __attribute__((errcond("ec0"),  noescape,    nocallback, nocheckptr(p1)));
+int F1(int p1) __attribute__((errcond("ec0"),  noescape,    nocallback));
 int * F2(int **p1, void  * p2);
 int *F3(int p1, void***) __attribute__((optional));
 unsigned   long F4(int func, int type, ...);
@@ -262,7 +262,7 @@ void F6() __attribute__(());`,
 			want: &mkcgo.Source{
 				Funcs: []*mkcgo.Func{
 					{Name: "F0", Ret: "void", Params: []*mkcgo.Param{{"void", ""}}, Attrs: mkcgo.Attrs{Tags: []mkcgo.TagAttr{{Tag: "t0"}, {Tag: "t1", Name: "tn0"}}, NoError: true}},
-					{Name: "F1", Ret: "int", Params: []*mkcgo.Param{{"int", "p1"}}, Attrs: mkcgo.Attrs{ErrCond: "ec0", NoEscape: true, NoCallback: true, NoCheckPtrParams: []string{"p1"}}},
+					{Name: "F1", Ret: "int", Params: []*mkcgo.Param{{"int", "p1"}}, Attrs: mkcgo.Attrs{ErrCond: "ec0", NoEscape: true, NoCallback: true}},
 					{Name: "F2", Ret: "int*", Params: []*mkcgo.Param{{"int**", "p1"}, {"void*", "p2"}}},
 					{Name: "F3", Ret: "int*", Params: []*mkcgo.Param{{"int", "p1"}, {"void***", ""}}, Attrs: mkcgo.Attrs{Optional: true}},
 					{Name: "F4", Ret: "unsigned long", Params: []*mkcgo.Param{{"int", "__func"}, {"int", "__type"}, {"...", ""}}},
@@ -372,6 +372,16 @@ void E2(void);
 void F1(void) __attribute__((framework("t1")));
 `,
 			want: `can't extract function attributes: error parsing attribute framework: requires 2 arguments`,
+		}, {
+			content: `
+void F1(void * p, int l) __attribute__((slice));
+`,
+			want: `can't extract function attributes: error parsing attribute slice: requires 1 or 2 arguments`,
+		}, {
+			content: `
+void F1(void * p, int l, int m) __attribute__((slice("p", "l", "m")));
+`,
+			want: `can't extract function attributes: error parsing attribute slice: requires 1 or 2 arguments`,
 		},
 	}
 	for i, tt := range tests {

--- a/internal/mkcgo/mkcgo_test.go
+++ b/internal/mkcgo/mkcgo_test.go
@@ -184,7 +184,7 @@ func TestFuncString(t *testing.T) {
 					NoEscape:   true,
 					NoCallback: true,
 					Framework:  mkcgo.Framework{Name: "CoreFoundation", Version: "A"},
-					Slice:      mkcgo.Slice{Ptr: "a", Len: "b"},
+					Slice:      []mkcgo.Slice{{Ptr: "a", Len: "b"}},
 				},
 			},
 			want: "void TestFunc(int param1) [{tag1 } {tag2 name}], optional, noerror, errcond(error_condition), noescape, nocallback, framework(CoreFoundation, A), slice(a, b)",

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -198,10 +198,10 @@ const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribut
 const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
-int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,nocheckptr("data")));
+int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count")));
 int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);
-int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute__((noescape,nocallback,nocheckptr("d")));
+int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute__((noescape,nocallback,slice("d","cnt")));
 int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback));
 int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),noescape,nocallback));
 int EVP_DigestSignInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -67,14 +67,14 @@ int (*_g_EVP_CipherUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsi
 int (*_g_EVP_DecryptFinal_ex)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*);
 int (*_g_EVP_DecryptInit_ex)(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*);
 int (*_g_EVP_DecryptUpdate)(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int);
-int (*_g_EVP_Digest)(const void*, size_t, unsigned char*, unsigned int*, const _EVP_MD_PTR, _ENGINE_PTR);
+int (*_g_EVP_Digest)(const unsigned char*, size_t, unsigned char*, unsigned int*, const _EVP_MD_PTR, _ENGINE_PTR);
 int (*_g_EVP_DigestFinal_ex)(_EVP_MD_CTX_PTR, unsigned char*, unsigned int*);
 int (*_g_EVP_DigestInit)(_EVP_MD_CTX_PTR, const _EVP_MD_PTR);
 int (*_g_EVP_DigestInit_ex)(_EVP_MD_CTX_PTR, const _EVP_MD_PTR, _ENGINE_PTR);
 int (*_g_EVP_DigestSign)(_EVP_MD_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
 int (*_g_EVP_DigestSignFinal)(_EVP_MD_CTX_PTR, unsigned char*, size_t*);
 int (*_g_EVP_DigestSignInit)(_EVP_MD_CTX_PTR, _EVP_PKEY_CTX_PTR*, const _EVP_MD_PTR, _ENGINE_PTR, _EVP_PKEY_PTR);
-int (*_g_EVP_DigestUpdate)(_EVP_MD_CTX_PTR, const void*, size_t);
+int (*_g_EVP_DigestUpdate)(_EVP_MD_CTX_PTR, const unsigned char*, size_t);
 int (*_g_EVP_DigestVerify)(_EVP_MD_CTX_PTR, const unsigned char*, size_t, const unsigned char*, size_t);
 int (*_g_EVP_DigestVerifyFinal)(_EVP_MD_CTX_PTR, const unsigned char*, size_t);
 int (*_g_EVP_DigestVerifyInit)(_EVP_MD_CTX_PTR, _EVP_PKEY_CTX_PTR*, const _EVP_MD_PTR, _ENGINE_PTR, _EVP_PKEY_PTR);
@@ -1031,7 +1031,7 @@ int _mkcgo_EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR _arg0, unsigned char* _arg1, in
 	return _ret;
 }
 
-int _mkcgo_EVP_Digest(const void* _arg0, size_t _arg1, unsigned char* _arg2, unsigned int* _arg3, const _EVP_MD_PTR _arg4, _ENGINE_PTR _arg5, mkcgo_err_state *_err_state) {
+int _mkcgo_EVP_Digest(const unsigned char* _arg0, size_t _arg1, unsigned char* _arg2, unsigned int* _arg3, const _EVP_MD_PTR _arg4, _ENGINE_PTR _arg5, mkcgo_err_state *_err_state) {
 	int _ret = _g_EVP_Digest(_arg0, _arg1, _arg2, _arg3, _arg4, _arg5);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
@@ -1073,7 +1073,7 @@ int _mkcgo_EVP_DigestSignInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, c
 	return _ret;
 }
 
-int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR _arg0, const void* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
+int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR _arg0, const unsigned char* _arg1, size_t _arg2, mkcgo_err_state *_err_state) {
 	int _ret = _g_EVP_DigestUpdate(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -164,14 +164,14 @@ int _mkcgo_EVP_CipherUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const uns
 int _mkcgo_EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, mkcgo_err_state *);
 int _mkcgo_EVP_DecryptInit_ex(_EVP_CIPHER_CTX_PTR, const _EVP_CIPHER_PTR, _ENGINE_PTR, const unsigned char*, const unsigned char*, mkcgo_err_state *);
 int _mkcgo_EVP_DecryptUpdate(_EVP_CIPHER_CTX_PTR, unsigned char*, int*, const unsigned char*, int, mkcgo_err_state *);
-int _mkcgo_EVP_Digest(const void*, size_t, unsigned char*, unsigned int*, const _EVP_MD_PTR, _ENGINE_PTR, mkcgo_err_state *);
+int _mkcgo_EVP_Digest(const unsigned char*, size_t, unsigned char*, unsigned int*, const _EVP_MD_PTR, _ENGINE_PTR, mkcgo_err_state *);
 int _mkcgo_EVP_DigestFinal_ex(_EVP_MD_CTX_PTR, unsigned char*, unsigned int*, mkcgo_err_state *);
 int _mkcgo_EVP_DigestInit(_EVP_MD_CTX_PTR, const _EVP_MD_PTR, mkcgo_err_state *);
 int _mkcgo_EVP_DigestInit_ex(_EVP_MD_CTX_PTR, const _EVP_MD_PTR, _ENGINE_PTR, mkcgo_err_state *);
 int _mkcgo_EVP_DigestSign(_EVP_MD_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t, mkcgo_err_state *);
 int _mkcgo_EVP_DigestSignFinal(_EVP_MD_CTX_PTR, unsigned char*, size_t*, mkcgo_err_state *);
 int _mkcgo_EVP_DigestSignInit(_EVP_MD_CTX_PTR, _EVP_PKEY_CTX_PTR*, const _EVP_MD_PTR, _ENGINE_PTR, _EVP_PKEY_PTR, mkcgo_err_state *);
-int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR, const void*, size_t, mkcgo_err_state *);
+int _mkcgo_EVP_DigestUpdate(_EVP_MD_CTX_PTR, const unsigned char*, size_t, mkcgo_err_state *);
 int _mkcgo_EVP_DigestVerify(_EVP_MD_CTX_PTR, const unsigned char*, size_t, const unsigned char*, size_t, mkcgo_err_state *);
 int _mkcgo_EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR, const unsigned char*, size_t, mkcgo_err_state *);
 int _mkcgo_EVP_DigestVerifyInit(_EVP_MD_CTX_PTR, _EVP_PKEY_CTX_PTR*, const _EVP_MD_PTR, _ENGINE_PTR, _EVP_PKEY_PTR, mkcgo_err_state *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -380,9 +380,9 @@ func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte,
 	return int32(_ret), newMkcgoErr("EVP_DecryptUpdate", _err)
 }
 
-func EVP_Digest(data unsafe.Pointer, count int, md *byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
+func EVP_Digest(data []byte, md *byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
 	var _err C.mkcgo_err_state
-	_ret := C._mkcgo_EVP_Digest(unsafe.Pointer(&*(*byte)(data)), C.size_t(count), (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(size)), __type, impl, mkcgoNoEscape(&_err))
+	_ret := C._mkcgo_EVP_Digest((*C.uchar)(unsafe.Pointer(unsafe.SliceData(data))), C.size_t(len(data)), (*C.uchar)(unsafe.Pointer(md)), (*C.uint)(unsafe.Pointer(size)), __type, impl, mkcgoNoEscape(&_err))
 	return int32(_ret), newMkcgoErr("EVP_Digest", _err)
 }
 
@@ -422,9 +422,9 @@ func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_M
 	return int32(_ret), newMkcgoErr("EVP_DigestSignInit", _err)
 }
 
-func EVP_DigestUpdate(ctx EVP_MD_CTX_PTR, d unsafe.Pointer, cnt int) (int32, error) {
+func EVP_DigestUpdate(ctx EVP_MD_CTX_PTR, d []byte) (int32, error) {
 	var _err C.mkcgo_err_state
-	_ret := C._mkcgo_EVP_DigestUpdate(ctx, unsafe.Pointer(&*(*byte)(d)), C.size_t(cnt), mkcgoNoEscape(&_err))
+	_ret := C._mkcgo_EVP_DigestUpdate(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(d))), C.size_t(len(d)), mkcgoNoEscape(&_err))
 	return int32(_ret), newMkcgoErr("EVP_DigestUpdate", _err)
 }
 

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -437,9 +437,9 @@ func EVP_DecryptUpdate(ctx EVP_CIPHER_CTX_PTR, out *byte, outl *int32, in *byte,
 
 var _mkcgo_EVP_Digest uintptr
 
-func EVP_Digest(data unsafe.Pointer, count int, md *byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
+func EVP_Digest(data []byte, md *byte, size *uint32, __type EVP_MD_PTR, impl ENGINE_PTR) (int32, error) {
 	var _err errState
-	r0, _ := syscallN(3, _mkcgo_EVP_Digest, uintptr(data), uintptr(count), uintptr(unsafe.Pointer(md)), uintptr(unsafe.Pointer(size)), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_Digest, uintptr(unsafe.Pointer(unsafe.SliceData(data))), uintptr(len(data)), uintptr(unsafe.Pointer(md)), uintptr(unsafe.Pointer(size)), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_Digest", &_err)
 }
 
@@ -493,9 +493,9 @@ func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_M
 
 var _mkcgo_EVP_DigestUpdate uintptr
 
-func EVP_DigestUpdate(ctx EVP_MD_CTX_PTR, d unsafe.Pointer, cnt int) (int32, error) {
+func EVP_DigestUpdate(ctx EVP_MD_CTX_PTR, d []byte) (int32, error) {
 	var _err errState
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestUpdate, uintptr(ctx), uintptr(d), uintptr(cnt), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestUpdate, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(d))), uintptr(len(d)), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestUpdate", &_err)
 }
 

--- a/openssl.go
+++ b/openssl.go
@@ -232,12 +232,6 @@ func baseNeverEmpty(b []byte) *byte {
 	return unsafe.SliceData(b)
 }
 
-// pbaseNeverEmpty returns the address of the underlying array in b.
-// If b has zero length, it returns a pointer to a zero byte.
-func pbaseNeverEmpty(b []byte) unsafe.Pointer {
-	return unsafe.Pointer(baseNeverEmpty(b))
-}
-
 // pbase returns the address of the underlying array in b,
 // being careful not to panic when b has zero length.
 func pbase(b []byte) unsafe.Pointer {


### PR DESCRIPTION
Some pointers passed to C code are pointers to the start of a Go slice. This PR updates mkcgo to accept the new attribute `slice`, which marking a given parameter as a pointer to the start of a Go slice, and optionally the associated length parameter.

This makes the Go wrappers easier to use (and more difficult to misuse). Also, it supersedes the `nocheckptr` attribute, given that mkcgo now generates code that avoids `cgoCheckPointer` false positives for Go slices, and that attribute was primarily used for that.

For simplicity, this PR only uses the `slice` attribute on those C functions that were previously using `nocheckptr`. A follow-up PR will migrate the rest.