### PR TITLE
mkcgo: Add missing error symbols to {load,unload}_init_3

### DIFF
--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -132,10 +132,10 @@ typedef int point_conversion_form_t;
 
 // ERR API
 unsigned long ERR_get_error(void) __attribute__((noerror));
-void ERR_error_string_n(unsigned long e, char *buf, size_t len);
+void ERR_error_string_n(unsigned long e, char *buf, size_t len) __attribute__((tag(""),tag("init_3"),noerror));
 void ERR_clear_error(void) __attribute__((tag(""),tag("init_3")));
 unsigned long ERR_get_error_line(const char **file, int *line) __attribute__((tag("legacy_1"),noerror));
-unsigned long ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags) __attribute__((tag("3"),noerror));
+unsigned long ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags) __attribute__((tag("3"),tag("init_3"),noerror));
 
 // OPENSSL API
 const char *OpenSSL_version(int type) __attribute__((noerror));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -629,6 +629,8 @@ void __mkcgo_unload_init_1() {
 
 void __mkcgo_load_init_3(void* handle) {
 	__mkcgo__dlsym(ERR_clear_error)
+	__mkcgo__dlsym(ERR_error_string_n)
+	__mkcgo__dlsym(ERR_get_error_all)
 	__mkcgo__dlsym(EVP_MD_fetch)
 	__mkcgo__dlsym(EVP_MD_free)
 	__mkcgo__dlsym(EVP_MD_get0_provider)
@@ -637,6 +639,8 @@ void __mkcgo_load_init_3(void* handle) {
 
 void __mkcgo_unload_init_3() {
 	_g_ERR_clear_error = NULL;
+	_g_ERR_error_string_n = NULL;
+	_g_ERR_get_error_all = NULL;
 	_g_EVP_MD_fetch = NULL;
 	_g_EVP_MD_free = NULL;
 	_g_EVP_MD_get0_provider = NULL;

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -2127,6 +2127,8 @@ func MkcgoUnload_init_1() {
 
 func MkcgoLoad_init_3(handle unsafe.Pointer) {
 	_mkcgo_ERR_clear_error = dlsym(handle, "ERR_clear_error\x00", false)
+	_mkcgo_ERR_error_string_n = dlsym(handle, "ERR_error_string_n\x00", false)
+	_mkcgo_ERR_get_error_all = dlsym(handle, "ERR_get_error_all\x00", false)
 	_mkcgo_EVP_MD_fetch = dlsym(handle, "EVP_MD_fetch\x00", false)
 	_mkcgo_EVP_MD_free = dlsym(handle, "EVP_MD_free\x00", false)
 	_mkcgo_EVP_MD_get0_provider = dlsym(handle, "EVP_MD_get0_provider\x00", false)
@@ -2135,6 +2137,8 @@ func MkcgoLoad_init_3(handle unsafe.Pointer) {
 
 func MkcgoUnload_init_3() {
 	_mkcgo_ERR_clear_error = 0
+	_mkcgo_ERR_error_string_n = 0
+	_mkcgo_ERR_get_error_all = 0
 	_mkcgo_EVP_MD_fetch = 0
 	_mkcgo_EVP_MD_free = 0
 	_mkcgo_EVP_MD_get0_provider = 0


### PR DESCRIPTION
When `initForCheckVersion` is called, and if there is an error in openssl's initialization, the codepath can reach `mkcgo_err_retrieve` which may invoke `_mkcgo_ERR_get_error_all`.  This will make the program segfault because the symbol for `ERR_get_error_all` is NULL.

We need to load a couple more symbols from openssl in order to properly handle the error and display a sane message to the user.