### PR TITLE
Make newEvpHash inlinable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,11 @@ jobs:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
     - name: Run Test CGO disabled and optimizations off
-      run: go test -shuffle=on -count 10 -gcflags=all="-N -l" -tags noopt -v ./...
+      run: go test -shuffle=on -count 10 -gcflags=all="-N -l" -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 0
-        GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
+        GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto,noopt
     - name: Run Test with address sanitizer
       if: ${{ runner.arch == 'X64' }} # arm64 thread sanitizer is flaky, unrelated to this codebase
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         CGO_ENABLED: 0
         GOFLAGS: -tags=goexperiment.ms_nocgo_opensslcrypto
     - name: Run Test CGO disabled and optimizations off
-      run: go test -shuffle=on -count 10 -gcflags=all="-N -l" -v ./...
+      run: go test -shuffle=on -count 10 -gcflags=all="-N -l" -tags noopt -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
         CGO_ENABLED: 0

--- a/evp.go
+++ b/evp.go
@@ -84,7 +84,12 @@ type hashAlgorithm struct {
 }
 
 // loadHash converts a crypto.Hash to a EVP_MD.
-func loadHash(ch crypto.Hash) *hashAlgorithm {
+func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
+	defer func() {
+		if h == nil && must {
+			panic("openssl: unsupported hash function: " + strconv.Itoa(int(ch)))
+		}
+	}()
 	if v, ok := cacheMD.Load(ch); ok {
 		return v.(*hashAlgorithm)
 	}
@@ -332,7 +337,7 @@ func setupEVP(withKey withKeyFunc, padding int32,
 			}
 		}
 	case ossl.RSA_PKCS1_PSS_PADDING:
-		alg := loadHash(ch)
+		alg := loadHash(ch, false)
 		if alg == nil {
 			return nil, errors.New("crypto/rsa: unsupported hash function")
 		}
@@ -352,7 +357,7 @@ func setupEVP(withKey withKeyFunc, padding int32,
 	case ossl.RSA_PKCS1_PADDING:
 		if ch != 0 {
 			// We support unhashed messages.
-			alg := loadHash(ch)
+			alg := loadHash(ch, false)
 			if alg == nil {
 				return nil, errors.New("crypto/rsa: unsupported hash function")
 			}
@@ -461,7 +466,7 @@ func evpVerify(withKey withKeyFunc, padding int32, saltLen int32, h crypto.Hash,
 }
 
 func evpHashSign(withKey withKeyFunc, h crypto.Hash, msg []byte) ([]byte, error) {
-	alg := loadHash(h)
+	alg := loadHash(h, false)
 	if alg == nil {
 		return nil, errors.New("unsupported hash function: " + strconv.Itoa(int(h)))
 	}
@@ -496,7 +501,7 @@ func evpHashSign(withKey withKeyFunc, h crypto.Hash, msg []byte) ([]byte, error)
 }
 
 func evpHashVerify(withKey withKeyFunc, h crypto.Hash, msg, sig []byte) error {
-	alg := loadHash(h)
+	alg := loadHash(h, false)
 	if alg == nil {
 		return errors.New("unsupported hash function: " + strconv.Itoa(int(h)))
 	}

--- a/hash.go
+++ b/hash.go
@@ -34,7 +34,7 @@ const (
 const maxHashSize = 64
 
 func hashOneShot(ch crypto.Hash, p []byte, sum []byte) bool {
-	_, err := ossl.EVP_Digest(p, base(sum), nil, loadHash(ch).md, nil)
+	_, err := ossl.EVP_Digest(p, base(sum), nil, loadHash(ch, true).md, nil)
 	return err == nil
 }
 
@@ -109,7 +109,7 @@ func SupportsHash(h crypto.Hash) bool {
 	if v, ok := cacheHashSupported.Load(h); ok {
 		return v.(bool)
 	}
-	alg := loadHash(h)
+	alg := loadHash(h, false)
 	if alg == nil {
 		cacheHashSupported.Store(h, false)
 		return false
@@ -237,17 +237,12 @@ type evpHash struct {
 }
 
 func newEvpHash(ch crypto.Hash) *evpHash {
-	alg := loadHash(ch)
-	if alg == nil {
-		panic("openssl: unsupported hash function: " + strconv.Itoa(int(ch)))
-	}
-	h := &evpHash{alg: alg}
 	// Don't call init() yet, it would be wasteful
 	// if the caller only wants to know the hash type. This
 	// is a common pattern in this package, as some functions
 	// accept a `func() hash.Hash` parameter and call it just
 	// to know the hash type.
-	return h
+	return &evpHash{alg: loadHash(ch, true)}
 }
 
 func (h *evpHash) finalize() {
@@ -382,7 +377,7 @@ func (e errMarshallUnsupported) Unwrap() error {
 }
 
 func (d *evpHash) MarshalBinary() ([]byte, error) {
-	if !d.alg.marshallable {
+	if d.alg == nil || !d.alg.marshallable {
 		return nil, errMarshallUnsupported{}
 	}
 	buf := make([]byte, 0, d.alg.marshalledSize)
@@ -391,7 +386,7 @@ func (d *evpHash) MarshalBinary() ([]byte, error) {
 
 func (d *evpHash) AppendBinary(buf []byte) ([]byte, error) {
 	defer runtime.KeepAlive(d)
-	if !d.alg.marshallable {
+	if d.alg == nil || !d.alg.marshallable {
 		return nil, errMarshallUnsupported{}
 	}
 	d.init()
@@ -408,7 +403,7 @@ func (d *evpHash) AppendBinary(buf []byte) ([]byte, error) {
 func (d *evpHash) UnmarshalBinary(b []byte) error {
 	defer runtime.KeepAlive(d)
 	d.init()
-	if !d.alg.marshallable {
+	if d.alg == nil || !d.alg.marshallable {
 		return errMarshallUnsupported{}
 	}
 	if len(b) < len(d.alg.magic) || string(b[:len(d.alg.magic)]) != d.alg.magic {

--- a/hash_test.go
+++ b/hash_test.go
@@ -462,7 +462,7 @@ func TestHashAllocations(t *testing.T) {
 	msg := []byte("testing")
 
 	sha1Hash := openssl.NewSHA1()
-	sha224Hash := openssl.NewSHA1()
+	sha224Hash := openssl.NewSHA224()
 	sha256Hash := openssl.NewSHA256()
 	sha512Hash := openssl.NewSHA512()
 
@@ -495,12 +495,12 @@ func TestHashAllocations(t *testing.T) {
 }
 
 func TestHashNewAllocations(t *testing.T) {
-	if Asan() {
+	if Asan() || OptimizationOff() {
 		t.Skip("skipping allocations test with sanitizers")
 	}
 	n := int(testing.AllocsPerRun(10, func() {
 		sha1Hash := openssl.NewSHA1()
-		sha224Hash := openssl.NewSHA1()
+		sha224Hash := openssl.NewSHA224()
 		sha256Hash := openssl.NewSHA256()
 		sha512Hash := openssl.NewSHA512()
 

--- a/hash_test.go
+++ b/hash_test.go
@@ -433,7 +433,7 @@ func TestIssue71943(t *testing.T) {
 	}
 }
 
-func TestHashAllocations(t *testing.T) {
+func TestHashOneShotAllocations(t *testing.T) {
 	if Asan() {
 		t.Skip("skipping allocations test with sanitizers")
 	}
@@ -455,7 +455,7 @@ func TestHashAllocations(t *testing.T) {
 	}
 }
 
-func TestHashStructAllocations(t *testing.T) {
+func TestHashAllocations(t *testing.T) {
 	if Asan() {
 		t.Skip("skipping allocations test with sanitizers")
 	}
@@ -477,6 +477,32 @@ func TestHashStructAllocations(t *testing.T) {
 		sha224Hash.Sum(sum[:0])
 		sha256Hash.Sum(sum[:0])
 		sha512Hash.Sum(sum[:0])
+
+		sha1Hash.Reset()
+		sha224Hash.Reset()
+		sha256Hash.Reset()
+		sha512Hash.Reset()
+	}))
+	want := 4
+	if compareCurrentVersion("go1.24") >= 0 {
+		// The go1.24 compiler is able to optimize the allocation away.
+		// See cgo_go124.go for more information.
+		want = 0
+	}
+	if n > want {
+		t.Errorf("allocs = %d, want %d", n, want)
+	}
+}
+
+func TestHashNewAllocations(t *testing.T) {
+	if Asan() {
+		t.Skip("skipping allocations test with sanitizers")
+	}
+	n := int(testing.AllocsPerRun(10, func() {
+		sha1Hash := openssl.NewSHA1()
+		sha224Hash := openssl.NewSHA1()
+		sha256Hash := openssl.NewSHA256()
+		sha512Hash := openssl.NewSHA512()
 
 		sha1Hash.Reset()
 		sha224Hash.Reset()

--- a/opt_off_test.go
+++ b/opt_off_test.go
@@ -1,0 +1,8 @@
+//go:build noopt
+
+package openssl_test
+
+// OptimizationOff reports whether optimization is disabled.
+func OptimizationOff() bool {
+	return true
+}

--- a/opt_on_test.go
+++ b/opt_on_test.go
@@ -1,0 +1,8 @@
+//go:build !noopt
+
+package openssl_test
+
+// OptimizationOff reports whether optimization is disabled.
+func OptimizationOff() bool {
+	return false
+}

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -387,7 +387,7 @@ func fromBase36(base36 string) *big.Int {
 	return i
 }
 
-func BenchmarkEncryptRSAPKCS1(b *testing.B) {
+func BenchmarkEncryptRSA(b *testing.B) {
 	b.StopTimer()
 	// Public key length should be at least of 2048 bits, else OpenSSL will report an error when running in FIPS mode.
 	n := fromBase36("14314132931241006650998084889274020608918049032671858325988396851334124245188214251956198731333464217832226406088020736932173064754214329009979944037640912127943488972644697423190955557435910767690712778463524983667852819010259499695177313115447116110358524558307947613422897787329221478860907963827160223559690523660574329011927531289655711860504630573766609239332569210831325633840174683944553667352219670930408593321661375473885147973879086994006440025257225431977751512374815915392249179976902953721486040787792801849818254465486633791826766873076617116727073077821584676715609985777563958286637185868165868520557")
@@ -396,12 +396,22 @@ func BenchmarkEncryptRSAPKCS1(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.StartTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		if _, err := openssl.EncryptRSAPKCS1(test2048PubKey, []byte("testing")); err != nil {
-			b.Fatal(err)
+	b.Run("PKCS1", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := openssl.EncryptRSAPKCS1(test2048PubKey, []byte("testing")); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
+	})
+	b.Run("OAEP", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := openssl.EncryptRSAOAEP(openssl.NewSHA256(), nil, test2048PubKey, []byte("testing"), nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func BenchmarkGenerateKeyRSA(b *testing.B) {

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -35,7 +35,7 @@ func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
 		// that the caller wants to use TLS 1.0/1.1 PRF.
 		// OpenSSL detects this case by checking if the hash
 		// function is MD5SHA1.
-		md = loadHash(crypto.MD5SHA1).md
+		md = loadHash(crypto.MD5SHA1, false).md
 	} else {
 		h, err := hashFuncHash(fh)
 		if err != nil {


### PR DESCRIPTION
If `newEvpHash` is inlinable, then calls to `NewSHA256` (and friends) won't allocate. The allocation will still be there once the hash is initialized when calling `Write` or `Sum`. At least it will be avoided for cases when `New` is only called to pass the hash type down the line, which is a common pattern when using this backend.

For example, the following call has now one allocation less: `EncryptRSAOAEP(NewSHA256(), nil, key, msg, nil)`

```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: AMD EPYC 7763 64-Core Processor                
                   │   old.txt   │           new.txt            │
                   │   sec/op    │   sec/op     vs base         │
EncryptRSA/OAEP-16   32.97µ ± 1%   32.79µ ± 1%  ~ (p=0.165 n=7)

                   │  old.txt   │              new.txt              │
                   │    B/op    │    B/op     vs base               │
EncryptRSA/OAEP-16   600.0 ± 0%   504.0 ± 0%  -16.00% (p=0.001 n=7)

                   │  old.txt   │              new.txt              │
                   │ allocs/op  │ allocs/op   vs base               │
EncryptRSA/OAEP-16   9.000 ± 0%   8.000 ± 0%  -11.11% (p=0.001 n=7)
```