### PR TITLE
Use EVP_MD_CTX_copy_ex instead of EVP_MD_CTX_copy

### DIFF
--- a/hash_test.go
+++ b/hash_test.go
@@ -520,39 +520,53 @@ func TestHashNewAllocations(t *testing.T) {
 	}
 }
 
-func BenchmarkSHA256(b *testing.B) {
-	b.StopTimer()
-	h := openssl.NewSHA256()
-	sum := make([]byte, h.Size())
-	size := 8
-	buf := make([]byte, size)
-	b.StartTimer()
-	b.SetBytes(int64(size))
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		h.Reset()
-		h.Write(buf)
-		h.Sum(sum[:0])
-	}
-}
-
-func BenchmarkSHA256OneShot(b *testing.B) {
-	b.StopTimer()
-	size := 8
-	buf := make([]byte, size)
-	b.StartTimer()
-	b.SetBytes(int64(size))
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		openssl.SHA256(buf)
-	}
-}
-
 func BenchmarkNewSHA256(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		openssl.NewSHA256()
 	}
+}
+
+func BenchmarkHash8Bytes(b *testing.B) {
+	benchmarkSize(b, 8)
+}
+
+func BenchmarkHash1K(b *testing.B) {
+	benchmarkSize(b, 1024)
+}
+
+func BenchmarkHash8K(b *testing.B) {
+	benchmarkSize(b, 8192)
+}
+
+func BenchmarkHash256K(b *testing.B) {
+	benchmarkSize(b, 256*1024)
+}
+
+func BenchmarkHash1M(b *testing.B) {
+	benchmarkSize(b, 1024*1024)
+}
+
+func benchmarkSize(b *testing.B, size int) {
+	var bench = openssl.NewSHA256()
+	buf := make([]byte, size)
+	sum := make([]byte, bench.Size())
+	b.Run("New", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		for i := 0; i < b.N; i++ {
+			bench.Reset()
+			bench.Write(buf)
+			bench.Sum(sum[:0])
+		}
+	})
+	b.Run("Sum256", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		for i := 0; i < b.N; i++ {
+			openssl.SHA256(buf)
+		}
+	})
 }
 
 // stubHash is a hash.Hash implementation that does nothing.

--- a/internal/ossl/ossl_cgo.go
+++ b/internal/ossl/ossl_cgo.go
@@ -11,7 +11,7 @@ package ossl
 static inline int
 go_hash_sum(const _EVP_MD_CTX_PTR ctx, _EVP_MD_CTX_PTR ctx2, unsigned char *out, uintptr_t *_err_state)
 {
-	if (_mkcgo_EVP_MD_CTX_copy(ctx2, ctx, _err_state) != 1)
+	if (_mkcgo_EVP_MD_CTX_copy_ex(ctx2, ctx, _err_state) != 1)
 		return -1;
 	if (_mkcgo_EVP_DigestFinal_ex(ctx2, out, NULL, _err_state) <= 0)
 		return -2;
@@ -29,7 +29,7 @@ func HashSum(ctx1, ctx2 EVP_MD_CTX_PTR, out []byte) error {
 		msg := "go_hash_sum"
 		switch code {
 		case -1:
-			msg = "EVP_MD_CTX_copy"
+			msg = "EVP_MD_CTX_copy_ex"
 		case -2:
 			msg = "EVP_DigestFinal_ex"
 		}


### PR DESCRIPTION
The cgo variant uses `EVP_MD_CTX_copy` to copy the hash context in each `Sum` call. `EVP_MD_CTX_copy_ex` is slightly more performance and have the same result, so we better use it. Note that the nocgo variant already uses that, which explains part of the performance gains when running nocgo.

There are how the new benchmarks look like
```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: AMD EPYC 7763 64-Core Processor                
                     │   old.txt    │              new.txt               │
                     │    sec/op    │    sec/op     vs base              │
Hash8Bytes/New-16       390.6n ± 2%   370.3n ±  1%  -5.20% (p=0.001 n=7)
Hash8Bytes/Sum256-16    256.6n ± 1%   264.3n ± 32%       ~ (p=0.710 n=7)
Hash1K/New-16          1029.0n ± 1%   997.6n ±  1%  -3.05% (p=0.001 n=7)
Hash1K/Sum256-16        897.8n ± 1%   893.9n ±  4%       ~ (p=0.733 n=7)
Hash8K/New-16           5.553µ ± 0%   5.539µ ±  1%       ~ (p=0.220 n=7)
Hash8K/Sum256-16        5.414µ ± 0%   5.416µ ±  0%       ~ (p=0.784 n=7)
Hash256K/New-16         168.0µ ± 0%   167.8µ ±  1%       ~ (p=0.383 n=7)
Hash256K/Sum256-16      167.8µ ± 1%   167.9µ ±  0%       ~ (p=0.456 n=7)
Hash1M/New-16           664.1µ ± 0%   663.9µ ±  0%       ~ (p=0.383 n=7)
Hash1M/Sum256-16        664.5µ ± 1%   663.7µ ±  0%       ~ (p=0.259 n=7)
geomean                 11.32µ        11.25µ        -0.63%
```