### PR TITLE
Support ExpandHKDF with zero-length keys

### DIFF
--- a/hkdf.go
+++ b/hkdf.go
@@ -209,8 +209,9 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 		}
 		defer ossl.EVP_PKEY_CTX_free(ctx)
 		if len(out) == 0 {
-			// Nothing to do, and some engines may error on zero-length output.
-			// Call newHKDFCtx1, tought, to validate parameters.
+			// Nothing to do, so exit early.
+			// We also can't call EVP_PKEY_derive because some engines error on zero-length output.
+			// We can only exit after calling newHKDFCtx1 because we still need it to validate the parameters.
 			return out, nil
 		}
 		keylen := keyLength
@@ -224,8 +225,9 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 		}
 		defer ossl.EVP_KDF_CTX_free(ctx)
 		if len(out) == 0 {
-			// Nothing to do, and some providers may error on zero-length output.
-			// Call newHKDFCtx3, tought, to validate parameters.
+			// Nothing to do, so exit early.
+			// We also can't call EVP_PKEY_derive because some engines error on zero-length output.
+			// We can only exit after calling newHKDFCtx3 because we still need it to validate the parameters.
 			return out, nil
 		}
 		if _, err := ossl.EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {

--- a/hkdf.go
+++ b/hkdf.go
@@ -208,6 +208,11 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 			return nil, err
 		}
 		defer ossl.EVP_PKEY_CTX_free(ctx)
+		if len(out) == 0 {
+			// Nothing to do, and some engines may error on zero-length output.
+			// Call newHKDFCtx1, tought, to validate parameters.
+			return out, nil
+		}
 		keylen := keyLength
 		if _, err := ossl.EVP_PKEY_derive(ctx, base(out), &keylen); err != nil {
 			return nil, err
@@ -218,6 +223,11 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 			return nil, err
 		}
 		defer ossl.EVP_KDF_CTX_free(ctx)
+		if len(out) == 0 {
+			// Nothing to do, and some providers may error on zero-length output.
+			// Call newHKDFCtx3, tought, to validate parameters.
+			return out, nil
+		}
 		if _, err := ossl.EVP_KDF_derive(ctx, base(out), keyLength, nil); err != nil {
 			return nil, err
 		}

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -646,3 +646,23 @@ func TestExpandTLS13KDF(t *testing.T) {
 		}
 	}
 }
+
+func TestExpandHKDFZeroLengthKey(t *testing.T) {
+	if !openssl.SupportsHKDF() {
+		t.Skip("HKDF is not supported")
+	}
+	hash := openssl.NewSHA256
+	master := []byte{0x00, 0x01, 0x02, 0x03}
+	info := []byte{}
+	prk, err := openssl.ExtractHKDF(hash, master, nil)
+	if err != nil {
+		t.Fatalf("error extracting HKDF: %v.", err)
+	}
+	out, err := openssl.ExpandHKDFOneShot(hash, prk, info, 0)
+	if err != nil {
+		t.Errorf("error expanding HKDF zero-length key: %v.", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("incorrect output length for zero-length key: have %d, need 0.", len(out))
+	}
+}


### PR DESCRIPTION
Upstream Go supports passing `0` as key length in `hkdf.Expand`, and a test exercising this case has been recently added to .

OpenSSL doesn't like zero-length inputs, so we better don't call OpenSSL in this case and directly return an empty slice (which is the correct result).

While here, remove an unused parameter.