### PR TITLE
README.md: Update go.mod badge to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go OpenSSL bindings for FIPS compliance
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/golang-fips/openssl.svg)](https://pkg.go.dev/github.com/golang-fips/openssl)
+[![Go Reference](https://pkg.go.dev/badge/github.com/golang-fips/openssl/v2.svg)](https://pkg.go.dev/github.com/golang-fips/openssl/v2)
 
 The `openssl` package implements Go crypto primitives using OpenSSL shared libraries and cgo. When configured correctly, OpenSSL can be executed in FIPS mode, making the `openssl` package FIPS compliant.
 


### PR DESCRIPTION
I noticed the badge currently links to https://pkg.go.dev/github.com/golang-fips/openssl, which has a red banner linking to https://pkg.go.dev/vuln/GO-2024-3167. Update the badge to the correct v2 module, https://pkg.go.dev/github.com/golang-fips/openssl/v2.