### PR TITLE
Move OSSL setup functions to the new osslsetup package

### DIFF
--- a/const.go
+++ b/const.go
@@ -30,14 +30,6 @@ func (s cString) ptr() *byte {
 }
 
 const ( //checkheader:ignore
-	// Provider names
-	_ProviderNameFips    cString = "fips\x00"
-	_ProviderNameDefault cString = "default\x00"
-
-	// Property strings
-	_PropFIPSYes cString = "fips=yes\x00"
-	_PropFIPSNo  cString = "-fips\x00"
-
 	// Key types
 	_KeyTypeRSA       cString = "RSA\x00"
 	_KeyTypeEC        cString = "EC\x00"
@@ -45,9 +37,6 @@ const ( //checkheader:ignore
 	_KeyTypeX25519    cString = "X25519\x00"
 	_KeyTypeMLKEM768  cString = "ML-KEM-768\x00"
 	_KeyTypeMLKEM1024 cString = "ML-KEM-1024\x00"
-
-	// Digest Names
-	_DigestNameSHA2_256 cString = "SHA2-256\x00"
 
 	// KDF names
 	_OSSL_KDF_NAME_HKDF      cString = "HKDF\x00"

--- a/export_test.go
+++ b/export_test.go
@@ -1,20 +1,6 @@
 package openssl
 
-import "sync"
-
 var ErrOpen = errOpen
-
-var SymCryptProviderAvailable = sync.OnceValue(func() bool {
-	return isProviderAvailable("symcryptprovider")
-})
-
-var FIPSProviderAvailable = sync.OnceValue(func() bool {
-	return isProviderAvailable("fips")
-})
-
-var DefaultProviderAvailable = sync.OnceValue(func() bool {
-	return isProviderAvailable("default")
-})
 
 // MLKEM constants for testing against the stdlib
 var (
@@ -27,3 +13,5 @@ var (
 )
 
 var HashBufSize = hashBufSize
+
+var Major = vMajor

--- a/export_test.go
+++ b/export_test.go
@@ -13,5 +13,3 @@ var (
 )
 
 var HashBufSize = hashBufSize
-
-var Major = vMajor

--- a/openssl.go
+++ b/openssl.go
@@ -68,7 +68,7 @@ func errUnsupportedVersion() error {
 // checkMajorVersion panics if the current major version is not expected.
 func checkMajorVersion(expected int) {
 	if vMajor != expected {
-		panic("openssl: incorrect major version (" + strconv.Itoa(int(vMajor)) + "), expected " + strconv.Itoa(int(expected)))
+		panic("openssl: incorrect major version (" + strconv.Itoa(vMajor) + "), expected " + strconv.Itoa(expected))
 	}
 }
 

--- a/openssl.go
+++ b/openssl.go
@@ -7,37 +7,27 @@ import (
 	"errors"
 	"math/bits"
 	"strconv"
-	"sync"
 	"unsafe"
 
 	"github.com/golang-fips/openssl/v2/internal/ossl"
+	"github.com/golang-fips/openssl/v2/osslsetup"
 )
 
 var (
 	// vMajor and vMinor hold the major/minor OpenSSL version.
 	// It is only populated if Init has been called.
-	vMajor, vMinor, vPatch uint
+	vMajor, vMinor, vPatch int
 )
-
-var (
-	initOnce sync.Once
-	initErr  error
-)
-
-var isBigEndian bool
 
 // CheckVersion checks if the OpenSSL version can be loaded
 // and if the FIPS mode is enabled.
 // This function can be called before Init.
 // All OpenSSL functions used in here should be tagged with "init_1" or "init_3" in shims.h.
 func CheckVersion(version string) (exists, fips bool) {
-	close, err := initForCheckVersion(version)
-	if err != nil {
-		return false, false
-	}
-	defer close()
-	return true, FIPS()
+	return osslsetup.CheckVersion(version)
 }
+
+var isBigEndian bool
 
 // Init loads and initializes OpenSSL from the shared library at path.
 // It must be called before any other OpenSSL call, except CheckVersion.
@@ -49,24 +39,25 @@ func CheckVersion(version string) (exists, fips bool) {
 // For example, `file=libcrypto.so.1.1.1k-fips` makes Init look for the shared
 // library libcrypto.so.1.1.1k-fips.
 func Init(file string) error {
-	initOnce.Do(func() {
-		buf := [2]byte{}
-		*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
+	buf := [2]byte{}
+	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
 
-		switch buf {
-		case [2]byte{0xCD, 0xAB}:
-			isBigEndian = false
-		case [2]byte{0xAB, 0xCD}:
-			isBigEndian = true
-		default:
-			panic("Could not determine native endianness.")
-		}
-		initErr = opensslInit(file)
-	})
-	return initErr
+	switch buf {
+	case [2]byte{0xCD, 0xAB}:
+		isBigEndian = false
+	case [2]byte{0xAB, 0xCD}:
+		isBigEndian = true
+	default:
+		panic("Could not determine native endianness.")
+	}
+	if err := osslsetup.Init(file); err != nil {
+		return err
+	}
+	vMajor, vMinor, vPatch = osslsetup.Version()
+	return nil
 }
 
-func utoa(n uint) string {
+func utoa(n int) string {
 	return strconv.FormatUint(uint64(n), 10)
 }
 
@@ -75,7 +66,7 @@ func errUnsupportedVersion() error {
 }
 
 // checkMajorVersion panics if the current major version is not expected.
-func checkMajorVersion(expected uint) {
+func checkMajorVersion(expected int) {
 	if vMajor != expected {
 		panic("openssl: incorrect major version (" + strconv.Itoa(int(vMajor)) + "), expected " + strconv.Itoa(int(expected)))
 	}
@@ -86,137 +77,37 @@ type fail string
 func (e fail) Error() string { return "openssl: " + string(e) + " failed" }
 
 // VersionText returns the version text of the OpenSSL currently loaded.
+//
+//go:fix inline
 func VersionText() string {
-	return goString(ossl.OpenSSL_version(0))
+	return osslsetup.VersionText()
 }
 
 // FIPS returns true if OpenSSL is running in FIPS mode and there is
 // a provider available that supports FIPS. It returns false otherwise.
 // All OpenSSL functions used in here should be tagged with "init_1" or "init_3" in shims.h.
+//
+//go:fix inline
 func FIPS() bool {
-	switch vMajor {
-	case 1:
-		return ossl.FIPS_mode() == 1
-	case 3:
-		// Check if the default properties contain `fips=1`.
-		if ossl.EVP_default_properties_is_fips_enabled(nil) != 1 {
-			// Note that it is still possible that the provider used by default is FIPS-compliant,
-			// but that wouldn't be a system or user requirement.
-			return false
-		}
-		// Check if the SHA-256 algorithm is available. If it is, then we can be sure that there is a provider available that matches
-		// the `fips=1` query. Most notably, this works for the common case of using the built-in FIPS provider.
-		//
-		// Note that this approach has a small chance of false negative if the FIPS provider doesn't provide the SHA-256 algorithm,
-		// but that is highly unlikely because SHA-256 is one of the most common algorithms and fundamental to many cryptographic operations.
-		// It also has a small chance of false positive if the FIPS provider implements the SHA-256 algorithm but not the other algorithms
-		// used by the caller application, but that is also unlikely because the FIPS provider should provide all common algorithms.
-		return proveSHA256("")
-	default:
-		panic(errUnsupportedVersion())
-	}
+	return osslsetup.FIPS()
 }
 
 // FIPSCapable returns true if the provider used by default matches the `fips=yes` query.
-// It is useful for checking whether OpenSSL is capable of running in FIPS mode regardless
-// of whether FIPS mode is explicitly enabled. For example, Azure Linux 3 doesn't set the
-// `fips=yes` query in the default properties, but sets the default provider to be SCOSSL,
-// which is FIPS-capable.
+// See [osslsetup.FIPSCapable] for details.
 //
-// Considerations:
-//   - Multiple calls to FIPSCapable can return different values if [SetFIPS] is called in between.
-//   - Can return true even if [FIPS] returns false, because [FIPS] also checks whether
-//     the default properties contain `fips=yes`.
-//   - When using OpenSSL 3, will always return true if [FIPS] returns true.
-//   - When using OpenSSL 1, Will always return the same value as [FIPS].
-//   - OpenSSL 3 doesn't provide a way to know if a provider is FIPS-capable. This function uses
-//     some heuristics that should be treated as an implementation detail that may change in the future.
+//go:fix inline
 func FIPSCapable() bool {
-	if FIPS() {
-		return true
-	}
-	if vMajor == 3 {
-		// Load the provider with and without the `fips=yes` query.
-		// If the providers are the same, then the default provider is FIPS-capable.
-		provFIPS := sha256Provider(_ProviderNameFips)
-		if provFIPS == nil {
-			return false
-		}
-		provDefault := sha256Provider("")
-		return provFIPS == provDefault
-	}
-	return false
-}
-
-// isProviderAvailable checks if the provider with the given name is available.
-// This function is used in export_test.go, but must be defined here as test files can't access C functions.
-func isProviderAvailable(name string) bool {
-	if vMajor == 1 {
-		return false
-	}
-	return ossl.OSSL_PROVIDER_available(nil, unsafe.StringData(name+"\x00")) == 1
+	return osslsetup.FIPSCapable()
 }
 
 // SetFIPS enables or disables FIPS mode.
 //
 // For OpenSSL 3, if there is no provider available that supports FIPS mode,
 // SetFIPS will try to load a built-in provider that supports FIPS mode.
+//
+//go:fix inline
 func SetFIPS(enable bool) error {
-	if FIPS() == enable {
-		// Already in the desired state.
-		return nil
-	}
-	var mode int32
-	if enable {
-		mode = int32(1)
-	} else {
-		mode = int32(0)
-	}
-	switch vMajor {
-	case 1:
-		if _, err := ossl.FIPS_mode_set(mode); err != nil {
-			return err
-		}
-		return nil
-	case 3:
-		var shaProps, provName cString
-		if enable {
-			shaProps = _PropFIPSYes
-			provName = _ProviderNameFips
-		} else {
-			shaProps = _PropFIPSNo
-			provName = _ProviderNameDefault
-		}
-		if !proveSHA256(shaProps) {
-			// There is no provider available that supports the desired FIPS mode.
-			// Try to load the built-in provider associated with the given mode.
-			if p, _ := ossl.OSSL_PROVIDER_try_load(nil, provName.ptr(), 1); p == nil {
-				// The built-in provider was not loaded successfully, we can't enable FIPS mode.
-				return errors.New("openssl: FIPS mode not supported by any provider")
-			}
-		}
-		_, err := ossl.EVP_default_properties_enable_fips(nil, mode)
-		return err
-	default:
-		panic(errUnsupportedVersion())
-	}
-}
-
-// sha256Provider returns the provider for the SHA-256 algorithm
-// using the given properties.
-func sha256Provider(props cString) ossl.OSSL_PROVIDER_PTR {
-	md, _ := ossl.EVP_MD_fetch(nil, _DigestNameSHA2_256.ptr(), props.ptr())
-	if md == nil {
-		return nil
-	}
-	defer ossl.EVP_MD_free(md)
-	return ossl.EVP_MD_get0_provider(md)
-}
-
-// proveSHA256 checks if the SHA-256 algorithm is available
-// using the given properties.
-func proveSHA256(props cString) bool {
-	return sha256Provider(props) != nil
+	return osslsetup.SetFIPS(enable)
 }
 
 var zero byte
@@ -344,7 +235,7 @@ func bnToBinPad(bn ossl.BIGNUM_PTR, to []byte) error {
 // versionAtOrAbove returns true when
 // (vMajor, vMinor, vPatch) >= (major, minor, patch),
 // compared lexicographically.
-func versionAtOrAbove(major, minor, patch uint) bool {
+func versionAtOrAbove(major, minor, patch int) bool {
 	return vMajor > major || (vMajor == major && vMinor > minor) || (vMajor == major && vMinor == minor && vPatch >= patch)
 }
 

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -260,7 +260,8 @@ var defaultProviderAvailable = sync.OnceValue(func() bool {
 })
 
 // isProviderAvailable checks if the provider with the given name is available.
-// This function is used in export_test.go, but must be defined here as test files can't access C functions.
+// This helper is used within openssl_test.go to check provider availability for tests,
+// and must be defined here as test files can't access C functions directly.
 func isProviderAvailable(name string) bool {
 	if major, _, _ := osslsetup.Version(); major == 1 {
 		return false

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -166,7 +166,7 @@ func TestSetFIPS(t *testing.T) {
 	}
 
 	if fipsEnabled &&
-		openssl.DefaultProviderAvailable() {
+		defaultProviderAvailable() {
 		// Test that we can disable FIPS mode if it was enabled
 		// when the built-in provider is available.
 		err := openssl.SetFIPS(false)
@@ -174,7 +174,7 @@ func TestSetFIPS(t *testing.T) {
 			t.Fatalf("SetFIPS(false) failed: %v", err)
 		}
 	} else if !fipsEnabled &&
-		(openssl.SymCryptProviderAvailable() || openssl.FIPSProviderAvailable()) {
+		(symCryptProviderAvailable() || fipsProviderAvailable()) {
 		// Test that we can enable FIPS mode if it was disabled
 		// when the provider is known to support FIPS mode.
 		err := openssl.SetFIPS(true)
@@ -189,7 +189,7 @@ func TestSetFIPS(t *testing.T) {
 func TestFIPSCapable(t *testing.T) {
 	got := openssl.FIPSCapable()
 	want := openssl.FIPS()
-	if !want && openssl.SymCryptProviderAvailable() {
+	if !want && symCryptProviderAvailable() {
 		// The SymCrypt provider is FIPS-capable.
 		want = true
 	}
@@ -244,4 +244,25 @@ func BenchmarkError(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		openssl.GenerateKeyRSA(1)
 	}
+}
+
+var symCryptProviderAvailable = sync.OnceValue(func() bool {
+	return isProviderAvailable("symcryptprovider")
+})
+
+var fipsProviderAvailable = sync.OnceValue(func() bool {
+	return isProviderAvailable("fips")
+})
+
+var defaultProviderAvailable = sync.OnceValue(func() bool {
+	return isProviderAvailable("default")
+})
+
+// isProviderAvailable checks if the provider with the given name is available.
+// This function is used in export_test.go, but must be defined here as test files can't access C functions.
+func isProviderAvailable(name string) bool {
+	if openssl.Major == 1 {
+		return false
+	}
+	return ossl.OSSL_PROVIDER_available(nil, unsafe.StringData(name+"\x00")) == 1
 }

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang-fips/openssl/v2"
 	"github.com/golang-fips/openssl/v2/internal/ossl"
+	"github.com/golang-fips/openssl/v2/osslsetup"
 )
 
 // sink is used to prevent the compiler from optimizing out the allocations.
@@ -64,10 +65,10 @@ func TestMain(m *testing.M) {
 		// or that there is a bug in the Init code.
 		panic(err)
 	}
-	_ = openssl.SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
-	fmt.Println("OpenSSL version:", openssl.VersionText())
-	fmt.Println("FIPS enabled:", openssl.FIPS())
-	fmt.Println("FIPS capable:", openssl.FIPSCapable())
+	_ = osslsetup.SetFIPS(true) // Skip the error as we still want to run the tests on machines without FIPS support.
+	fmt.Println("OpenSSL version:", osslsetup.VersionText())
+	fmt.Println("FIPS enabled:", osslsetup.FIPS())
+	fmt.Println("FIPS capable:", osslsetup.FIPSCapable())
 	status := m.Run()
 	for range 5 {
 		// Run GC a few times to avoid false positives in leak detection.
@@ -127,11 +128,11 @@ func errorStack() string {
 
 func TestCheckVersion(t *testing.T) {
 	v := getVersion()
-	exists, fips := openssl.CheckVersion(v)
+	exists, fips := osslsetup.CheckVersion(v)
 	if !exists {
 		t.Fatalf("OpenSSL version %q not found", v)
 	}
-	if want := openssl.FIPS(); want != fips {
+	if want := osslsetup.FIPS(); want != fips {
 		t.Fatalf("FIPS mismatch: want %v, got %v", want, fips)
 	}
 }
@@ -145,21 +146,21 @@ func compareCurrentVersion(v string) int {
 }
 
 func TestSetFIPS(t *testing.T) {
-	fipsEnabled := openssl.FIPS()
+	fipsEnabled := osslsetup.FIPS()
 	t.Cleanup(func() {
 		// Restore the previous FIPS mode.
-		err := openssl.SetFIPS(fipsEnabled)
+		err := osslsetup.SetFIPS(fipsEnabled)
 		if err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	if err := openssl.SetFIPS(fipsEnabled); err != nil {
+	if err := osslsetup.SetFIPS(fipsEnabled); err != nil {
 		// Test that we can set FIPS mode to the current state
 		// without error.
 		t.Fatalf("SetFIPS(%v) failed: %v", fipsEnabled, err)
 	}
-	if got := openssl.FIPS(); got != fipsEnabled {
+	if got := osslsetup.FIPS(); got != fipsEnabled {
 		// Test that the FIPS mode hasn't been changed by the
 		// previous SetFIPS call.
 		t.Fatalf("FIPS mode mismatch: want %v, got %v", fipsEnabled, got)
@@ -169,7 +170,7 @@ func TestSetFIPS(t *testing.T) {
 		defaultProviderAvailable() {
 		// Test that we can disable FIPS mode if it was enabled
 		// when the built-in provider is available.
-		err := openssl.SetFIPS(false)
+		err := osslsetup.SetFIPS(false)
 		if err != nil {
 			t.Fatalf("SetFIPS(false) failed: %v", err)
 		}
@@ -177,7 +178,7 @@ func TestSetFIPS(t *testing.T) {
 		(symCryptProviderAvailable() || fipsProviderAvailable()) {
 		// Test that we can enable FIPS mode if it was disabled
 		// when the provider is known to support FIPS mode.
-		err := openssl.SetFIPS(true)
+		err := osslsetup.SetFIPS(true)
 		if err != nil {
 			t.Fatalf("SetFIPS(true) failed: %v", err)
 		}
@@ -187,8 +188,8 @@ func TestSetFIPS(t *testing.T) {
 }
 
 func TestFIPSCapable(t *testing.T) {
-	got := openssl.FIPSCapable()
-	want := openssl.FIPS()
+	got := osslsetup.FIPSCapable()
+	want := osslsetup.FIPS()
 	if !want && symCryptProviderAvailable() {
 		// The SymCrypt provider is FIPS-capable.
 		want = true
@@ -261,7 +262,7 @@ var defaultProviderAvailable = sync.OnceValue(func() bool {
 // isProviderAvailable checks if the provider with the given name is available.
 // This function is used in export_test.go, but must be defined here as test files can't access C functions.
 func isProviderAvailable(name string) bool {
-	if openssl.Major == 1 {
+	if major, _, _ := osslsetup.Version(); major == 1 {
 		return false
 	}
 	return ossl.OSSL_PROVIDER_available(nil, unsafe.StringData(name+"\x00")) == 1

--- a/osslsetup/fips.go
+++ b/osslsetup/fips.go
@@ -82,7 +82,7 @@ func FIPS() bool {
 //   - Can return true even if [FIPS] returns false, because [FIPS] also checks whether
 //     the default properties contain `fips=yes`.
 //   - When using OpenSSL 3, will always return true if [FIPS] returns true.
-//   - When using OpenSSL 1, Will always return the same value as [FIPS].
+//   - When using OpenSSL 1, will always return the same value as [FIPS].
 //   - OpenSSL 3 doesn't provide a way to know if a provider is FIPS-capable. This function uses
 //     some heuristics that should be treated as an implementation detail that may change in the future.
 func FIPSCapable() bool {

--- a/osslsetup/fips.go
+++ b/osslsetup/fips.go
@@ -1,0 +1,165 @@
+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
+
+package osslsetup
+
+import (
+	"errors"
+	"unsafe"
+
+	"github.com/golang-fips/openssl/v2/internal/ossl"
+)
+
+// cString is a null-terminated string,
+// akin to C's char*.
+type cString string
+
+// ptr returns a pointer to the string data.
+// It panics if the string is not null-terminated.
+//
+// The memory pointed to by the returned pointer should
+// not be modified and it must only be passed to
+// "const char*" parameters. Any attempt to modify it
+// will result in a runtime panic, as Go strings are
+// allocated in read-only memory.
+func (s cString) ptr() *byte {
+	if len(s) == 0 {
+		return nil
+	}
+	if s[len(s)-1] != 0 {
+		panic("must be null-terminated")
+	}
+	return unsafe.StringData(string(s))
+}
+
+const (
+	// Provider names
+	_ProviderNameFips    cString = "fips\x00"
+	_ProviderNameDefault cString = "default\x00"
+
+	// Property strings
+	_PropFIPSYes cString = "fips=yes\x00"
+	_PropFIPSNo  cString = "-fips\x00"
+
+	// Digest Names
+	_DigestNameSHA2_256 cString = "SHA2-256\x00"
+)
+
+// FIPS returns true if OpenSSL is running in FIPS mode and there is
+// a provider available that supports FIPS. It returns false otherwise.
+// All OpenSSL functions used in here should be tagged with "init_1" or "init_3" in shims.h.
+func FIPS() bool {
+	switch vMajor {
+	case 1:
+		return ossl.FIPS_mode() == 1
+	case 3:
+		// Check if the default properties contain `fips=1`.
+		if ossl.EVP_default_properties_is_fips_enabled(nil) != 1 {
+			// Note that it is still possible that the provider used by default is FIPS-compliant,
+			// but that wouldn't be a system or user requirement.
+			return false
+		}
+		// Check if the SHA-256 algorithm is available. If it is, then we can be sure that there is a provider available that matches
+		// the `fips=1` query. Most notably, this works for the common case of using the built-in FIPS provider.
+		//
+		// Note that this approach has a small chance of false negative if the FIPS provider doesn't provide the SHA-256 algorithm,
+		// but that is highly unlikely because SHA-256 is one of the most common algorithms and fundamental to many cryptographic operations.
+		// It also has a small chance of false positive if the FIPS provider implements the SHA-256 algorithm but not the other algorithms
+		// used by the caller application, but that is also unlikely because the FIPS provider should provide all common algorithms.
+		return proveSHA256("")
+	default:
+		panic(errUnsupportedVersion())
+	}
+}
+
+// FIPSCapable returns true if the provider used by default matches the `fips=yes` query.
+// It is useful for checking whether OpenSSL is capable of running in FIPS mode regardless
+// of whether FIPS mode is explicitly enabled. For example, Azure Linux 3 doesn't set the
+// `fips=yes` query in the default properties, but sets the default provider to be SCOSSL,
+// which is FIPS-capable.
+//
+// Considerations:
+//   - Multiple calls to FIPSCapable can return different values if [SetFIPS] is called in between.
+//   - Can return true even if [FIPS] returns false, because [FIPS] also checks whether
+//     the default properties contain `fips=yes`.
+//   - When using OpenSSL 3, will always return true if [FIPS] returns true.
+//   - When using OpenSSL 1, Will always return the same value as [FIPS].
+//   - OpenSSL 3 doesn't provide a way to know if a provider is FIPS-capable. This function uses
+//     some heuristics that should be treated as an implementation detail that may change in the future.
+func FIPSCapable() bool {
+	if FIPS() {
+		return true
+	}
+	if vMajor == 3 {
+		// Load the provider with and without the `fips=yes` query.
+		// If the providers are the same, then the default provider is FIPS-capable.
+		provFIPS := sha256Provider(_ProviderNameFips)
+		if provFIPS == nil {
+			return false
+		}
+		provDefault := sha256Provider("")
+		return provFIPS == provDefault
+	}
+	return false
+}
+
+// SetFIPS enables or disables FIPS mode.
+//
+// For OpenSSL 3, if there is no provider available that supports FIPS mode,
+// SetFIPS will try to load a built-in provider that supports FIPS mode.
+func SetFIPS(enable bool) error {
+	if FIPS() == enable {
+		// Already in the desired state.
+		return nil
+	}
+	var mode int32
+	if enable {
+		mode = int32(1)
+	} else {
+		mode = int32(0)
+	}
+	switch vMajor {
+	case 1:
+		if _, err := ossl.FIPS_mode_set(mode); err != nil {
+			return err
+		}
+		return nil
+	case 3:
+		var shaProps, provName cString
+		if enable {
+			shaProps = _PropFIPSYes
+			provName = _ProviderNameFips
+		} else {
+			shaProps = _PropFIPSNo
+			provName = _ProviderNameDefault
+		}
+		if !proveSHA256(shaProps) {
+			// There is no provider available that supports the desired FIPS mode.
+			// Try to load the built-in provider associated with the given mode.
+			if p, _ := ossl.OSSL_PROVIDER_try_load(nil, provName.ptr(), 1); p == nil {
+				// The built-in provider was not loaded successfully, we can't enable FIPS mode.
+				return errors.New("openssl: FIPS mode not supported by any provider")
+			}
+		}
+		_, err := ossl.EVP_default_properties_enable_fips(nil, mode)
+		return err
+	default:
+		panic(errUnsupportedVersion())
+	}
+}
+
+// sha256Provider returns the provider for the SHA-256 algorithm
+// using the given properties.
+func sha256Provider(props cString) ossl.OSSL_PROVIDER_PTR {
+	md, _ := ossl.EVP_MD_fetch(nil, _DigestNameSHA2_256.ptr(), props.ptr())
+	if md == nil {
+		return nil
+	}
+	defer ossl.EVP_MD_free(md)
+	return ossl.EVP_MD_get0_provider(md)
+}
+
+// proveSHA256 checks if the SHA-256 algorithm is available
+// using the given properties.
+func proveSHA256(props cString) bool {
+	return sha256Provider(props) != nil
+}

--- a/osslsetup/init.go
+++ b/osslsetup/init.go
@@ -130,22 +130,23 @@ func openLibrary(file string) (handle unsafe.Pointer, close func(), err error) {
 		ossl.OPENSSL_version_minor_Available() &&
 		ossl.OPENSSL_version_patch_Available() {
 		// Likely OpenSSL 3 or later.
-		vMajor = uint(ossl.OPENSSL_version_major())
-		vMinor = uint(ossl.OPENSSL_version_minor())
-		vPatch = uint(ossl.OPENSSL_version_patch())
+		vMajor = int(ossl.OPENSSL_version_major())
+		vMinor = int(ossl.OPENSSL_version_minor())
+		vPatch = int(ossl.OPENSSL_version_patch())
 	} else if ossl.OpenSSL_version_num_Available() {
 		// Likely OpenSSL 1.
 		ver := ossl.OpenSSL_version_num()
-		vMajor = uint(ver >> 28)
-		vMinor = uint(ver >> 20 & 0xFF)
-		vPatch = uint(ver >> 12 & 0xFF)
+		vMajor = int(ver >> 28)
+		vMinor = int(ver >> 20 & 0xFF)
+		vPatch = int(ver >> 12 & 0xFF)
 	} else {
 		return handle, nil, errors.New("openssl: version not available")
 	}
 	var supported bool
-	if vMajor == 1 {
+	switch vMajor {
+	case 1:
 		supported = vMinor == 1
-	} else if vMajor == 3 {
+	case 3:
 		// OpenSSL guarantees API and ABI compatibility within the same major version since OpenSSL 3.
 		supported = true
 	}

--- a/osslsetup/init.go
+++ b/osslsetup/init.go
@@ -1,6 +1,6 @@
 //go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
 
-package openssl
+package osslsetup
 
 import (
 	"errors"

--- a/osslsetup/init_cgo_unix.go
+++ b/osslsetup/init_cgo_unix.go
@@ -1,6 +1,6 @@
 //go:build unix && !cmd_go_bootstrap
 
-package openssl
+package osslsetup
 
 // #cgo LDFLAGS: -ldl
 // #include <stdlib.h>

--- a/osslsetup/init_nocgo_unix.go
+++ b/osslsetup/init_nocgo_unix.go
@@ -1,6 +1,6 @@
 //go:build unix && !cmd_go_bootstrap && !cgo && goexperiment.ms_nocgo_opensslcrypto
 
-package openssl
+package osslsetup
 
 import (
 	"errors"
@@ -18,7 +18,7 @@ func dlopen(file string) (handle unsafe.Pointer, err error) {
 	}
 	handle = ossl.Dlopen(unsafe.StringData(file+"\x00"), int32(RTLD_LAZY|RTLD_LOCAL))
 	if handle == nil {
-		return nil, errors.New(goString(ossl.Dlerror()))
+		return nil, errors.New("openssl: can't load " + file + ": " + goString(ossl.Dlerror()))
 	}
 	return handle, nil
 }

--- a/osslsetup/init_windows.go
+++ b/osslsetup/init_windows.go
@@ -1,6 +1,6 @@
 //go:build !cmd_go_bootstrap
 
-package openssl
+package osslsetup
 
 import (
 	"syscall"

--- a/osslsetup/osslsetup.go
+++ b/osslsetup/osslsetup.go
@@ -1,0 +1,66 @@
+//go:build !cmd_go_bootstrap && (cgo || goexperiment.ms_nocgo_opensslcrypto)
+
+package osslsetup
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+
+	"github.com/golang-fips/openssl/v2/internal/ossl"
+)
+
+var (
+	vMajor, vMinor, vPatch uint
+)
+
+func Version() (major, minor, patch int) {
+	return int(vMajor), int(vMinor), int(vPatch)
+}
+
+func utoa(n uint) string {
+	return strconv.FormatUint(uint64(n), 10)
+}
+
+func errUnsupportedVersion() error {
+	return errors.New("openssl: OpenSSL version: " + utoa(vMajor) + "." + utoa(vMinor) + "." + utoa(vPatch))
+}
+
+var (
+	initOnce sync.Once
+	initErr  error
+)
+
+// Init loads and initializes OpenSSL from the shared library at path.
+// It must be called before any other OpenSSL call, except CheckVersion.
+//
+// Only the first call to Init is effective.
+// Subsequent calls will return the same error result as the one from the first call.
+//
+// The file is passed to dlopen() verbatim to load the OpenSSL shared library.
+// For example, `file=libcrypto.so.1.1.1k-fips` makes Init look for the shared
+// library libcrypto.so.1.1.1k-fips.
+func Init(file string) error {
+	initOnce.Do(func() {
+		initErr = opensslInit(file)
+	})
+	return initErr
+}
+
+// VersionText returns the version text of the OpenSSL currently loaded.
+func VersionText() string {
+	return goString(ossl.OpenSSL_version(0))
+}
+
+// CheckVersion checks if the OpenSSL version can be loaded
+// and if the FIPS mode is enabled.
+// This function can be called before Init.
+// All OpenSSL functions used in here should be tagged with "init_1" or "init_3" in shims.h.
+func CheckVersion(version string) (exists, fips bool) {
+	close, err := initForCheckVersion(version)
+	if err != nil {
+		return false, false
+	}
+	defer close()
+	return true, FIPS()
+}

--- a/osslsetup/osslsetup.go
+++ b/osslsetup/osslsetup.go
@@ -11,14 +11,14 @@ import (
 )
 
 var (
-	vMajor, vMinor, vPatch uint
+	vMajor, vMinor, vPatch int
 )
 
 func Version() (major, minor, patch int) {
-	return int(vMajor), int(vMinor), int(vPatch)
+	return vMajor, vMinor, vPatch
 }
 
-func utoa(n uint) string {
+func utoa(n int) string {
 	return strconv.FormatUint(uint64(n), 10)
 }
 

--- a/osslsetup/osslsetup_cgo.go
+++ b/osslsetup/osslsetup_cgo.go
@@ -1,0 +1,11 @@
+//go:build !cmd_go_bootstrap
+
+package osslsetup
+
+import "C"
+import "unsafe"
+
+// goString converts a C string pointer to a Go string for cgo mode
+func goString(ptr *byte) string {
+	return C.GoString((*C.char)(unsafe.Pointer(ptr)))
+}

--- a/osslsetup/osslsetup_nocgo.go
+++ b/osslsetup/osslsetup_nocgo.go
@@ -1,0 +1,21 @@
+//go:build !cgo && goexperiment.ms_nocgo_opensslcrypto
+
+package osslsetup
+
+import "unsafe"
+
+// goString converts a C string pointer to a Go string for nocgo mode
+func goString(ptr *byte) string {
+	if ptr == nil {
+		return ""
+	}
+	var result []byte
+	for i := 0; ; i++ {
+		b := *(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + uintptr(i)))
+		if b == 0 {
+			break
+		}
+		result = append(result, b)
+	}
+	return string(result)
+}

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -151,7 +151,7 @@ func TestRSAEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
 }
 
 func TestRSAEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
-	if openssl.SymCryptProviderAvailable() {
+	if symCryptProviderAvailable() {
 		t.Skip("SymCrypt provider does not support MGF1 hash")
 	}
 


### PR DESCRIPTION
The `crypto/cipher` package started depending on the crypto backends, and the OpenSSL backend depends on `crypto/cipher`, so the toolchain complains a dependency loop.

To break the loop, move the OpenSSL setup functions to their own package.