### PR TITLE
take openssl version from osslsetup

### DIFF
--- a/cipher.go
+++ b/cipher.go
@@ -79,7 +79,7 @@ func loadCipher(k cipherKind, mode cipherMode) (cipher ossl.EVP_CIPHER_PTR) {
 		return v.(ossl.EVP_CIPHER_PTR)
 	}
 	defer func() {
-		if cipher != nil && vMajor == 3 {
+		if cipher != nil && major() == 3 {
 			// On OpenSSL 3, directly operating on a EVP_CIPHER object
 			// not created by EVP_CIPHER has negative performance
 			// implications, as cipher operations will have

--- a/cshake.go
+++ b/cshake.go
@@ -54,7 +54,7 @@ func SumSHAKE256(data []byte, length int) []byte {
 // SupportsSHAKE returns true if the SHAKE extendable output functions
 // with the given securityBits are supported.
 func SupportsSHAKE(securityBits int) bool {
-	if vMajor == 1 || (vMajor == 3 && vMinor < 3) {
+	if major() == 1 || (major() == 3 && minor() < 3) {
 		// SHAKE MD's are supported since OpenSSL 1.1.1,
 		// but EVP_DigestSqueeze is only supported since 3.3,
 		// and we need it to implement [sha3.SHAKE].

--- a/dsa.go
+++ b/dsa.go
@@ -88,7 +88,7 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 
 	// Extract the domain parameters from the generated key.
 	var p, q, g ossl.BIGNUM_PTR
-	switch vMajor {
+	switch major() {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_pqg(dsa, &p, &q, &g)
@@ -154,7 +154,7 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 	}
 	defer ossl.EVP_PKEY_free(pkey)
 	var bx, by ossl.BIGNUM_PTR
-	switch vMajor {
+	switch major() {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_key(dsa, &by, &bx)
@@ -186,7 +186,7 @@ func VerifyDSA(pub *PublicKeyDSA, hash []byte, sig []byte) bool {
 }
 
 func newDSA(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
-	switch vMajor {
+	switch major() {
 	case 1:
 		return newDSA1(params, x, y)
 	case 3:

--- a/ecdh.go
+++ b/ecdh.go
@@ -87,7 +87,7 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			return nil, err
 		}
 	} else {
-		switch vMajor {
+		switch major() {
 		case 1:
 			var err error
 			pkey, err = ossl.EVP_PKEY_new()
@@ -137,7 +137,7 @@ func newECDHPkey(curve string, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR,
 		}
 	}
 	nid := curveNID(curve)
-	switch vMajor {
+	switch major() {
 	case 1:
 		return newECDHPkey1(nid, bytes, isPrivate)
 	case 3:
@@ -308,7 +308,7 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 		}
 	} else {
 		var priv ossl.BIGNUM_PTR
-		switch vMajor {
+		switch major() {
 		case 1:
 			key := getECKey(pkey)
 			priv = ossl.EC_KEY_get0_private_key(key)

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -73,7 +73,7 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 		ossl.BN_free(bx)
 		ossl.BN_free(by)
 	}()
-	switch vMajor {
+	switch major() {
 	case 1:
 		// Retrieve the internal EC_KEY, which holds the X, Y, and D coordinates.
 		key := getECKey(pkey)
@@ -149,7 +149,7 @@ func newECDSAKey(curve string, x, y, d BigInt) (ossl.EVP_PKEY_PTR, error) {
 		}
 		defer ossl.BN_clear_free(bd)
 	}
-	switch vMajor {
+	switch major() {
 	case 1:
 		return newECDSAKey1(nid, bx, by, bd)
 	case 3:

--- a/ed25519.go
+++ b/ed25519.go
@@ -26,7 +26,7 @@ const (
 // which will probably be in 3.2.0 (https://github.com/openssl/openssl/issues/20418).
 
 var supportsEd25519 = sync.OnceValue(func() bool {
-	switch vMajor {
+	switch major() {
 	case 1:
 		if versionAtOrAbove(1, 1, 1) {
 			ctx, _ := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_ED25519, nil)

--- a/evp.go
+++ b/evp.go
@@ -162,7 +162,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	hash.ch = ch
 	hash.size = int(ossl.EVP_MD_get_size(hash.md))
 	hash.blockSize = int(ossl.EVP_MD_get_block_size(hash.md))
-	if vMajor == 3 {
+	if major() == 3 {
 		// On OpenSSL 3, directly operating on a EVP_MD object
 		// not created by EVP_MD_fetch has negative performance
 		// implications, as digest operations will have
@@ -180,7 +180,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 		}
 	}
 
-	switch vMajor {
+	switch major() {
 	case 1:
 		hash.provider = providerOSSLDefault
 	case 3:
@@ -212,7 +212,7 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 		return nil, fail("incorrect generateEVPPKey parameters")
 	}
 	var pkey ossl.EVP_PKEY_PTR
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx, err := ossl.EVP_PKEY_CTX_new_id(id, nil)
 		if err != nil {
@@ -332,7 +332,7 @@ func setupEVP(withKey withKeyFunc, padding int32,
 			clabel = (*byte)(cryptoMalloc(len(label)))
 			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 			var err error
-			if vMajor == 3 {
+			if major() == 3 {
 				_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Pointer(clabel), int32(len(label)))
 			} else {
 				_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
@@ -567,7 +567,7 @@ func newEvpFromParams(id int32, selection int32, params ossl.OSSL_PARAM_PTR) (os
 	}
 	var pkey ossl.EVP_PKEY_PTR
 	if _, err := ossl.EVP_PKEY_fromdata(ctx, &pkey, selection, params); err != nil {
-		if vMajor == 3 && vMinor <= 2 {
+		if major() == 3 && minor() <= 2 {
 			// OpenSSL 3.0.1 and 3.0.2 have a bug where EVP_PKEY_fromdata
 			// does not free the internally allocated EVP_PKEY on error.
 			// See https://github.com/openssl/openssl/issues/17407.

--- a/hkdf.go
+++ b/hkdf.go
@@ -15,7 +15,7 @@ import (
 
 // SupprtHKDF reports whether the current OpenSSL version supports HKDF.
 func SupportsHKDF() bool {
-	switch vMajor {
+	switch major() {
 	case 1:
 		return versionAtOrAbove(1, 1, 1)
 	case 3:
@@ -28,7 +28,7 @@ func SupportsHKDF() bool {
 
 // SupprtsTLS13KDF reports whether the current OpenSSL version supports TLS13-KDF.
 func SupportsTLS13KDF() bool {
-	switch vMajor {
+	switch major() {
 	case 1:
 		return false
 	case 3:
@@ -153,7 +153,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 		}
 	}
 
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx, err := newHKDFCtx1(md, ossl.EVP_KDF_HKDF_MODE_EXTRACT_ONLY, secret, salt, nil, nil)
 		if err != nil {
@@ -201,7 +201,7 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 	}
 
 	out := make([]byte, keyLength)
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx, err := newHKDFCtx1(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 		if err != nil {
@@ -276,7 +276,7 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, er
 
 	size := int(ossl.EVP_MD_get_size(md))
 
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx, err := newHKDFCtx1(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 		if err != nil {

--- a/hmac.go
+++ b/hmac.go
@@ -37,7 +37,7 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 		blockSize: h.BlockSize(),
 	}
 
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx := newHMAC1(key, md)
 		if ctx.ctx == nil {
@@ -153,7 +153,7 @@ func newHMAC3(key []byte, md ossl.EVP_MD_PTR) hmacCtx3 {
 		panic(err)
 	}
 	var hkey []byte
-	if vMinor == 0 && vPatch <= 2 {
+	if minor() == 0 && patch() <= 2 {
 		// EVP_MAC_init only resets the ctx internal state if a key is passed
 		// when using OpenSSL 3.0.0, 3.0.1, and 3.0.2. Save a copy of the key
 		// in the context so Reset can use it later. New OpenSSL versions
@@ -166,7 +166,7 @@ func newHMAC3(key []byte, md ossl.EVP_MD_PTR) hmacCtx3 {
 }
 
 func (h *opensslHMAC) Reset() {
-	switch vMajor {
+	switch major() {
 	case 1:
 		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, 0, nil, nil); err != nil {
 			panic(err)
@@ -193,7 +193,7 @@ func (h *opensslHMAC) finalize() {
 
 func (h *opensslHMAC) Write(p []byte) (int, error) {
 	if len(p) > 0 {
-		switch vMajor {
+		switch major() {
 		case 1:
 			ossl.HMAC_Update(h.ctx1.ctx, base(p), len(p))
 		case 3:
@@ -219,7 +219,7 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 	// that Sum has no effect on the underlying stream.
 	// In particular it is OK to Sum, then Write more, then Sum again,
 	// and the second Sum acts as if the first didn't happen.
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx2, err := ossl.HMAC_CTX_new()
 		if err != nil {
@@ -244,7 +244,7 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 }
 
 func (h *opensslHMAC) Clone() (HashCloner, error) {
-	switch vMajor {
+	switch major() {
 	case 1:
 		ctx2, err := ossl.HMAC_CTX_new()
 		if err != nil {

--- a/mlkem.go
+++ b/mlkem.go
@@ -32,7 +32,7 @@ const (
 
 // SupportsMLKEM768 returns true if ML-KEM-768 is supported on this platform.
 func SupportsMLKEM768() bool {
-	if vMajor >= 3 && vMinor >= 5 {
+	if major() >= 3 && minor() >= 5 {
 		return supportsMLKEM768()
 	}
 	return false
@@ -40,7 +40,7 @@ func SupportsMLKEM768() bool {
 
 // SupportsMLKEM1024 returns true if ML-KEM-1024 is supported on this platform.
 func SupportsMLKEM1024() bool {
-	if vMajor >= 3 && vMinor >= 5 {
+	if major() >= 3 && minor() >= 5 {
 		return supportsMLKEM1024()
 	}
 	return false

--- a/openssl.go
+++ b/openssl.go
@@ -7,16 +7,11 @@ import (
 	"errors"
 	"math/bits"
 	"strconv"
+	"sync"
 	"unsafe"
 
 	"github.com/golang-fips/openssl/v2/internal/ossl"
 	"github.com/golang-fips/openssl/v2/osslsetup"
-)
-
-var (
-	// vMajor and vMinor hold the major/minor OpenSSL version.
-	// It is only populated if Init has been called.
-	vMajor, vMinor, vPatch int
 )
 
 // CheckVersion checks if the OpenSSL version can be loaded
@@ -27,7 +22,31 @@ func CheckVersion(version string) (exists, fips bool) {
 	return osslsetup.CheckVersion(version)
 }
 
-var isBigEndian bool
+var isBigEndian = sync.OnceValue(func() bool {
+	buf := [2]byte{}
+	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
+
+	switch buf {
+	case [2]byte{0xCD, 0xAB}:
+		return false
+	case [2]byte{0xAB, 0xCD}:
+		return true
+	default:
+		panic("Could not determine native endianness.")
+	}
+})
+
+func major() int {
+	return osslsetup.VersionMajor()
+}
+
+func minor() int {
+	return osslsetup.VersionMinor()
+}
+
+func patch() int {
+	return osslsetup.VersionPatch()
+}
 
 // Init loads and initializes OpenSSL from the shared library at path.
 // It must be called before any other OpenSSL call, except CheckVersion.
@@ -39,21 +58,9 @@ var isBigEndian bool
 // For example, `file=libcrypto.so.1.1.1k-fips` makes Init look for the shared
 // library libcrypto.so.1.1.1k-fips.
 func Init(file string) error {
-	buf := [2]byte{}
-	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
-
-	switch buf {
-	case [2]byte{0xCD, 0xAB}:
-		isBigEndian = false
-	case [2]byte{0xAB, 0xCD}:
-		isBigEndian = true
-	default:
-		panic("Could not determine native endianness.")
-	}
 	if err := osslsetup.Init(file); err != nil {
 		return err
 	}
-	vMajor, vMinor, vPatch = osslsetup.Version()
 	return nil
 }
 
@@ -62,13 +69,13 @@ func utoa(n int) string {
 }
 
 func errUnsupportedVersion() error {
-	return errors.New("openssl: OpenSSL version: " + utoa(vMajor) + "." + utoa(vMinor) + "." + utoa(vPatch))
+	return errors.New("openssl: OpenSSL version: " + utoa(major()) + "." + utoa(minor()) + "." + utoa(patch()))
 }
 
 // checkMajorVersion panics if the current major version is not expected.
 func checkMajorVersion(expected int) {
-	if vMajor != expected {
-		panic("openssl: incorrect major version (" + strconv.Itoa(vMajor) + "), expected " + strconv.Itoa(expected))
+	if major() != expected {
+		panic("openssl: incorrect major version (" + strconv.Itoa(major()) + "), expected " + strconv.Itoa(expected))
 	}
 }
 
@@ -192,7 +199,7 @@ func bigToBN(x BigInt) (ossl.BIGNUM_PTR, error) {
 	if len(x) == 0 {
 		return nil, nil
 	}
-	if isBigEndian {
+	if isBigEndian() {
 		z := make(BigInt, len(x))
 		copy(z, x)
 		z.byteSwap()
@@ -218,7 +225,7 @@ func bnToBig(bn ossl.BIGNUM_PTR) BigInt {
 	if _, err := ossl.BN_bn2lebinpad(bn, wbase(x), int32(len(x)*wordBytes)); err != nil {
 		panic(err)
 	}
-	if isBigEndian {
+	if isBigEndian() {
 		x.byteSwap()
 	}
 	return x
@@ -235,8 +242,8 @@ func bnToBinPad(bn ossl.BIGNUM_PTR, to []byte) error {
 // versionAtOrAbove returns true when
 // (vMajor, vMinor, vPatch) >= (major, minor, patch),
 // compared lexicographically.
-func versionAtOrAbove(major, minor, patch int) bool {
-	return vMajor > major || (vMajor == major && vMinor > minor) || (vMajor == major && vMinor == minor && vPatch >= patch)
+func versionAtOrAbove(vmajor, vminor, vpatch int) bool {
+	return major() > vmajor || (major() == vmajor && minor() > vminor) || (major() == vmajor && minor() == vminor && patch() >= vpatch)
 }
 
 func bigEndianUint64(b []byte) uint64 {

--- a/openssl.go
+++ b/openssl.go
@@ -240,7 +240,7 @@ func bnToBinPad(bn ossl.BIGNUM_PTR, to []byte) error {
 }
 
 // versionAtOrAbove returns true when
-// (vMajor, vMinor, vPatch) >= (major, minor, patch),
+// (major(), minor(), patch()) >= (vmajor, vminor, vpatch),
 // compared lexicographically.
 func versionAtOrAbove(vmajor, vminor, vpatch int) bool {
 	return major() > vmajor || (major() == vmajor && minor() > vminor) || (major() == vmajor && minor() == vminor && patch() >= vpatch)

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -263,7 +263,7 @@ var defaultProviderAvailable = sync.OnceValue(func() bool {
 // This helper is used within openssl_test.go to check provider availability for tests,
 // and must be defined here as test files can't access C functions directly.
 func isProviderAvailable(name string) bool {
-	if major, _, _ := osslsetup.Version(); major == 1 {
+	if osslsetup.VersionMajor() == 1 {
 		return false
 	}
 	return ossl.OSSL_PROVIDER_available(nil, unsafe.StringData(name+"\x00")) == 1

--- a/osslsetup/osslsetup.go
+++ b/osslsetup/osslsetup.go
@@ -14,8 +14,16 @@ var (
 	vMajor, vMinor, vPatch int
 )
 
-func Version() (major, minor, patch int) {
-	return vMajor, vMinor, vPatch
+func VersionMajor() int {
+	return vMajor
+}
+
+func VersionMinor() int {
+	return vMinor
+}
+
+func VersionPatch() int {
+	return vPatch
 }
 
 func utoa(n int) string {

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -12,7 +12,7 @@ import (
 
 // SupportsPBKDF2 reports whether the current OpenSSL version supports PBKDF2.
 func SupportsPBKDF2() bool {
-	switch vMajor {
+	switch major() {
 	case 1:
 		return true
 	case 3:

--- a/provideropenssl.go
+++ b/provideropenssl.go
@@ -163,7 +163,7 @@ func (d *_OSSL_SHA512_CTX) AppendBinary(buf []byte) ([]byte, error) {
 }
 
 func getOSSLDigetsContext(ctx ossl.EVP_MD_CTX_PTR) unsafe.Pointer {
-	switch vMajor {
+	switch major() {
 	case 1:
 		// https://github.com/openssl/openssl/blob/0418e993c717a6863f206feaa40673a261de7395/crypto/evp/evp_local.h#L12.
 		type mdCtx struct {

--- a/providersymcrypt.go
+++ b/providersymcrypt.go
@@ -61,7 +61,7 @@ type _UINT64 [2]uint32
 
 func newUINT64(v uint64) _UINT64 {
 	var u _UINT64
-	if isBigEndian {
+	if isBigEndian() {
 		u[0], u[1] = uint32(v>>32), uint32(v)
 	} else {
 		u[0], u[1] = uint32(v), uint32(v>>32)
@@ -70,7 +70,7 @@ func newUINT64(v uint64) _UINT64 {
 }
 
 func (u *_UINT64) uint64() uint64 {
-	if isBigEndian {
+	if isBigEndian() {
 		return uint64(u[0])<<32 | (uint64(u[1]))
 	}
 	return uint64(u[0]) | (uint64(u[1]) << 32)

--- a/rsa.go
+++ b/rsa.go
@@ -22,7 +22,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		return bad(err)
 	}
 	defer ossl.EVP_PKEY_free(pkey)
-	switch vMajor {
+	switch major() {
 	case 1:
 		key, err := ossl.EVP_PKEY_get1_RSA(pkey)
 		if err != nil {
@@ -78,7 +78,7 @@ type PublicKeyRSA struct {
 
 func NewPublicKeyRSA(n, e BigInt) (*PublicKeyRSA, error) {
 	var pkey ossl.EVP_PKEY_PTR
-	switch vMajor {
+	switch major() {
 	case 1:
 		key, err := ossl.RSA_new()
 		if err != nil {
@@ -136,7 +136,7 @@ type PrivateKeyRSA struct {
 
 func NewPrivateKeyRSA(n, e, d, p, q, dp, dq, qinv BigInt) (*PrivateKeyRSA, error) {
 	var pkey ossl.EVP_PKEY_PTR
-	switch vMajor {
+	switch major() {
 	case 1:
 		key, err := ossl.RSA_new()
 		if err != nil {
@@ -262,7 +262,7 @@ func saltLength(saltLen int, sign bool) (int32, error) {
 	// but the values don't fully match for rsa.PSSSaltLengthAuto (0).
 	if saltLen == 0 {
 		if sign {
-			if vMajor == 1 {
+			if major() == 1 {
 				// OpenSSL 1.x uses -2 to mean maximal size when signing where Go crypto uses 0.
 				return ossl.RSA_PSS_SALTLEN_MAX_SIGN, nil
 			}
@@ -341,7 +341,7 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (ossl.EVP_PKEY_
 		//
 		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
 		// value is missing. See https://github.com/openssl/openssl/pull/22334
-		if vMinor >= 2 || allPrecomputedExists {
+		if minor() >= 2 || allPrecomputedExists {
 			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR1, p, true)
 			bld.addBigInt(_OSSL_PKEY_PARAM_RSA_FACTOR2, q, true)
 		}

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -13,9 +13,9 @@ import (
 )
 
 func SupportsTLS1PRF() bool {
-	switch vMajor {
+	switch major() {
 	case 1:
-		return vMinor >= 1
+		return minor() >= 1
 	case 3:
 		_, err := fetchTLS1PRF3()
 		return err == nil
@@ -47,7 +47,7 @@ func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
 		return errors.New("unsupported hash function")
 	}
 
-	switch vMajor {
+	switch major() {
 	case 1:
 		return tls1PRF1(result, secret, label, seed, md)
 	case 3:


### PR DESCRIPTION
If the caller calls `osslsetup.Init` instead of `openssl.Init` then the `openssl` package won't have the version numbers correctly set, as it keeps its own copies.

Fix that by making `openssl` always query the version from `osslsetup`.