### PR TITLE
Reduce hash marshaling allocations when using SCOSSL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,8 @@ jobs:
       fail-fast: false
       matrix:
         image: [
-          mcr.microsoft.com/oss/go/microsoft/golang:1.24-azurelinux3.0,
-          mcr.microsoft.com/oss/go/microsoft/golang:1.24-cbl-mariner2.0,
+          mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0,
+          mcr.microsoft.com/oss/go/microsoft/golang:1.25-cbl-mariner2.0,
           fedora:latest,
         ]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,11 +121,12 @@ jobs:
       run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 1
+        MS_GO_NOSYSTEMCRYPTO: 1 # Avoid duplicated symbol errors when running the MS toolchain
     - name: Run Test CGO disabled
       run: go test -shuffle=on -v ./...
       env:
         CGO_ENABLED: 0
-
+        MS_GO_NOSYSTEMCRYPTO: 1
   test-qemu:
     runs-on: ${{ matrix.architecture == 'arm/v7' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:

--- a/hash_test.go
+++ b/hash_test.go
@@ -520,6 +520,23 @@ func TestHashNewAllocations(t *testing.T) {
 	}
 }
 
+func TestHashAllocationsWithTypeAsserts(t *testing.T) {
+	if Asan() || OptimizationOff() {
+		t.Skip("skipping allocations test with sanitizers")
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		h := openssl.NewSHA256()
+		h.Write([]byte{1, 2, 3})
+		marshaled, _ := h.(encoding.BinaryMarshaler).MarshalBinary()
+		marshaled, _ = h.(encoding.BinaryAppender).AppendBinary(marshaled[:0])
+		h.(encoding.BinaryUnmarshaler).UnmarshalBinary(marshaled)
+	})
+	const maxAllocs = 2
+	if allocs > float64(maxAllocs) {
+		t.Fatalf("allocs = %v; want <= %v", allocs, maxAllocs)
+	}
+}
+
 func BenchmarkNewSHA256(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -216,7 +216,7 @@ int EVP_MD_CTX_ctrl(_EVP_MD_CTX_PTR ctx, int cmd, int p1, void *p2) __attribute_
 int EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
 const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
-int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3")));
+int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md")));
 int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -217,7 +217,7 @@ int EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
 const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 int EVP_MD_CTX_get_params(_EVP_MD_CTX_PTR ctx, _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
-int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
+int EVP_MD_CTX_set_params(_EVP_MD_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 int EVP_Digest(const void *data, size_t count, unsigned char *md, unsigned int *size, const _EVP_MD_PTR type, _ENGINE_PTR impl) __attribute__((noescape,nocallback,slice("data","count"),slice("md")));
 int EVP_DigestInit_ex(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type, _ENGINE_PTR impl);
 int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);

--- a/internal/ossl/zossl_cgo_go124.go
+++ b/internal/ossl/zossl_cgo_go124.go
@@ -31,6 +31,8 @@ package ossl
 #cgo nocallback _mkcgo_EVP_EncryptUpdate
 #cgo noescape _mkcgo_EVP_MD_CTX_get_params
 #cgo nocallback _mkcgo_EVP_MD_CTX_get_params
+#cgo noescape _mkcgo_EVP_MD_CTX_set_params
+#cgo nocallback _mkcgo_EVP_MD_CTX_set_params
 #cgo noescape _mkcgo_EVP_PKEY_derive
 #cgo nocallback _mkcgo_EVP_PKEY_derive
 #cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key

--- a/internal/ossl/zossl_cgo_go124.go
+++ b/internal/ossl/zossl_cgo_go124.go
@@ -29,6 +29,8 @@ package ossl
 #cgo nocallback _mkcgo_EVP_EncryptFinal_ex
 #cgo noescape _mkcgo_EVP_EncryptUpdate
 #cgo nocallback _mkcgo_EVP_EncryptUpdate
+#cgo noescape _mkcgo_EVP_MD_CTX_get_params
+#cgo nocallback _mkcgo_EVP_MD_CTX_get_params
 #cgo noescape _mkcgo_EVP_PKEY_derive
 #cgo nocallback _mkcgo_EVP_PKEY_derive
 #cgo noescape _mkcgo_EVP_PKEY_get_raw_private_key

--- a/providersymcrypt.go
+++ b/providersymcrypt.go
@@ -193,9 +193,6 @@ func (b *_SYMCRYPT_SHA512_STATE_EXPORT_BLOB) unmarshalBinary(d []byte) {
 func symCryptHashAppendBinary(ctx ossl.EVP_MD_CTX_PTR, ch crypto.Hash, magic string, buf []byte) ([]byte, error) {
 	size, typ := symCryptHashStateInfo(ch)
 	state := make([]byte, size, _SYMCRYPT_SHA512_STATE_EXPORT_SIZE) // 512 is the largest size
-	var pinner runtime.Pinner
-	pinner.Pin(&state[0])
-	defer pinner.Unpin()
 	params := [2]ossl.OSSL_PARAM{
 		ossl.OSSL_PARAM_construct_octet_string(_SCOSSL_DIGEST_PARAM_STATE.ptr(), unsafe.Pointer(&state[0]), len(state)),
 		ossl.OSSL_PARAM_construct_end(),

--- a/providersymcrypt.go
+++ b/providersymcrypt.go
@@ -5,7 +5,6 @@ package openssl
 import (
 	"crypto"
 	"errors"
-	"runtime"
 	"unsafe"
 
 	"github.com/golang-fips/openssl/v2/internal/ossl"
@@ -268,10 +267,6 @@ func symCryptHashUnmarshalBinary(ctx ossl.EVP_MD_CTX_PTR, ch crypto.Hash, magic 
 		panic("unsupported hash " + ch.String())
 	}
 	var checksum int32 = 1
-	var pinner runtime.Pinner
-	pinner.Pin(blobPtr)
-	pinner.Pin(&checksum)
-	defer pinner.Unpin()
 	params := [3]ossl.OSSL_PARAM{
 		ossl.OSSL_PARAM_construct_octet_string(_SCOSSL_DIGEST_PARAM_STATE.ptr(), blobPtr, int(hdr.size)),
 		ossl.OSSL_PARAM_construct_int32(_SCOSSL_DIGEST_PARAM_RECOMPUTE_CHECKSUM.ptr(), &checksum),


### PR DESCRIPTION
There is an upstream test that fails due hash marshaling allocation too much when using SCOSSL:

```
--- FAIL: TestAllocatonsWithTypeAsserts (0.00s)
    sha256_test.go:503: allocs = 9; want <= 2
FAIL
FAIL    crypto/sha256   0.025s
```