### PR TITLE
Refactor S390X trampoline assembly code

### DIFF
--- a/internal/fakecgo/trampolines_s390x.s
+++ b/internal/fakecgo/trampolines_s390x.s
@@ -6,35 +6,31 @@
 #include "textflag.h"
 #include "go_asm.h"
 
-// S390X ELF ABI: args R2-R6, return R2, callee-save R6-R13/R15/F8-F15, R14=LR, R15=SP
-// CRITICAL: R0 as base register means "no base" (literal 0), not R0's value!
+// these trampolines map the gcc ABI to Go ABI and then calls into the Go equivalent functions.
+// Note that C arguments are passed in R2-R6, which matches Go ABIInternal for the first five arguments.
+// R1 is used as a temporary register.
 
-// x_cgo_init_trampoline must preserve R9 for Go runtime
 TEXT x_cgo_init_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-	MOVD R14, R0
 	MOVD R15, R1
 	SUB  $192, R15
-	MOVD R1, 0(R15)   // backchain
-	MOVD R0, 160(R15) // save R14
-	MOVD R1, 168(R15) // save old R15
-	MOVD R9, 176(R15) // save R9 (Go runtime needs this preserved)
+	MOVD R1, 0(R15)    // backchain
+	MOVD R14, 160(R15) // save R14
+	MOVD R9, 168(R15)  // save R9 (Go runtime needs this preserved)
 
 	MOVD ·x_cgo_init_call(SB), R1
 	MOVD (R1), R1
 	BL   R1
 
-	MOVD 176(R15), R9
+	MOVD 168(R15), R9
 	MOVD 160(R15), R14
-	MOVD 168(R15), R15
+	ADD  $192, R15
 	BR   R14
 
-// Standard trampoline pattern: save R14/R15, call via pointer, restore
 TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-	MOVD R14, R0
 	MOVD R15, R1
 	SUB  $176, R15
-	MOVD R1, 0(R15)
-	MOVD R0, 152(R15)
+	MOVD R1, 0(R15)    // backchain
+	MOVD R14, 152(R15) // save R14
 
 	MOVD ·x_cgo_thread_start_call(SB), R1
 	MOVD (R1), R1
@@ -45,11 +41,10 @@ TEXT x_cgo_thread_start_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 	BR   R14
 
 TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-	MOVD R14, R0
 	MOVD R15, R1
 	SUB  $176, R15
-	MOVD R1, 0(R15)
-	MOVD R0, 152(R15)
+	MOVD R1, 0(R15)    // backchain
+	MOVD R14, 152(R15) // save R14
 
 	MOVD ·x_cgo_setenv_call(SB), R1
 	MOVD (R1), R1
@@ -60,11 +55,10 @@ TEXT x_cgo_setenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 	BR   R14
 
 TEXT x_cgo_unsetenv_trampoline(SB), NOSPLIT|NOFRAME, $0-0
-	MOVD R14, R0
 	MOVD R15, R1
 	SUB  $176, R15
-	MOVD R1, 0(R15)
-	MOVD R0, 152(R15)
+	MOVD R1, 0(R15)    // backchain
+	MOVD R14, 152(R15) // save R14
 
 	MOVD ·x_cgo_unsetenv_call(SB), R1
 	MOVD (R1), R1
@@ -84,7 +78,7 @@ TEXT x_cgo_bindm_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 // setg_trampoline(setg uintptr, g uintptr) - called from Go
 TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
 	MOVD 8(R15), R1  // setg function pointer
-	MOVD 16(R15), R2 // g pointer → C arg
+	MOVD 16(R15), R2 // g pointer -> C arg
 
 	MOVD R14, R0
 	MOVD R15, R3
@@ -99,13 +93,11 @@ TEXT ·setg_trampoline(SB), NOSPLIT|NOFRAME, $0-16
 	ADD  $160, R15
 	BR   R14
 
-// threadentry_trampoline - called FROM C (pthread_create), arg in R2
 TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 	STMG R6, R15, 48(R15) // C save area
 	MOVD R15, R1
 	SUB  $176, R15
 	MOVD R1, 0(R15)       // backchain
-	MOVD R2, 8(R15)       // pthread arg → Go arg
 
 	MOVD ·threadentry_call(SB), R1
 	MOVD (R1), R1
@@ -115,7 +107,6 @@ TEXT threadentry_trampoline(SB), NOSPLIT|NOFRAME, $0-0
 	LMG 48(R15), R6, R15
 	RET
 
-// call5(fn, a1, a2, a3, a4, a5 uintptr) uintptr - Go calling C
 TEXT ·call5(SB), NOSPLIT|NOFRAME, $0-56
 	// Load Go args before modifying R15
 	MOVD 8(R15), R1   // fn
@@ -131,7 +122,7 @@ TEXT ·call5(SB), NOSPLIT|NOFRAME, $0-56
 	ADD  $-128, R15
 
 	// Set up C frame with backchain
-	MOVD R0, 0(R15) // backchain → original R15
+	MOVD R0, 0(R15) // backchain -> original R15
 	MOVD R0, R3     // R3 = original R15 (can't use R0 as base!)
 	MOVD 0(R3), R7  // save 0(original R15)
 	MOVD $0, 0(R3)  // terminate backchain


### PR DESCRIPTION
Refactor trampoline assembly code for S390X architecture to improve clarity and maintainability. Adjust register handling and comments for better understanding of ABI mappings.