### PR TITLE
Default escape variables for nocgo

### DIFF
--- a/cmd/mkcgo/generate.go
+++ b/cmd/mkcgo/generate.go
@@ -1163,6 +1163,10 @@ func generateNocgoFnBody(src *mkcgo.Source, fn *mkcgo.Func, errorType int, newR0
 		fmt.Fprintf(w, "\tsyscallN(%d, %s", errorType, fnArg)
 	}
 
+	// Determine if we need to force escape for pointer parameters.
+	// If the function has both noescape and nocallback, we can skip escaping.
+	needEscape := !(fn.NoEscape && fn.NoCallback)
+
 	// Add actual parameters
 	for _, param := range fn.Params {
 		// Skip void parameters
@@ -1173,13 +1177,21 @@ func generateNocgoFnBody(src *mkcgo.Source, fn *mkcgo.Func, errorType int, newR0
 		goType, _ := cTypeToGo(param.Type, false)
 
 		if _, ok := fn.SliceFromPtr(param.Name); ok {
-			// Slice parameter
-			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+			// Slice parameter - force escape if needed
+			if needEscape {
+				fmt.Fprintf(w, ", uintptr(escapePtr(unsafe.Pointer(unsafe.SliceData(%s))))", param.Name)
+			} else {
+				fmt.Fprintf(w, ", uintptr(unsafe.Pointer(unsafe.SliceData(%s)))", param.Name)
+			}
 		} else if slice, ok := fn.SliceFromLen(param.Name); ok {
 			fmt.Fprintf(w, ", uintptr(len(%s))", slice.Ptr)
 		} else if strings.HasPrefix(goType, "*") {
-			// Pointer types need to go through unsafe.Pointer
-			fmt.Fprintf(w, ", uintptr(unsafe.Pointer(%s))", param.Name)
+			// Pointer types need to go through unsafe.Pointer - force escape if needed
+			if needEscape {
+				fmt.Fprintf(w, ", uintptr(escapePtr(unsafe.Pointer(%s)))", param.Name)
+			} else {
+				fmt.Fprintf(w, ", uintptr(unsafe.Pointer(%s))", param.Name)
+			}
 		} else {
 			fmt.Fprintf(w, ", uintptr(%s)", param.Name)
 		}

--- a/internal/ossl/syscall_nocgo.go
+++ b/internal/ossl/syscall_nocgo.go
@@ -21,6 +21,9 @@ func noescape(p unsafe.Pointer) unsafe.Pointer {
 var alwaysFalse bool
 var escapeSink unsafe.Pointer
 
+// escapePtr forces p to escape to the heap.
+// This implementation is also used in the standard library:
+// https://github.com/golang/go/blob/go1.26.0/src/internal/abi/escape.go#L24-L33
 func escapePtr(p unsafe.Pointer) unsafe.Pointer {
 	if alwaysFalse {
 		escapeSink = p

--- a/internal/ossl/syscall_nocgo.go
+++ b/internal/ossl/syscall_nocgo.go
@@ -18,6 +18,17 @@ func noescape(p unsafe.Pointer) unsafe.Pointer {
 	return unsafe.Pointer(x ^ 0)
 }
 
+// escapePtr forces p to escape to the heap.
+// By assigning to a global sink, the compiler must assume the pointer escapes.
+//
+//go:noinline
+func escapePtr(p unsafe.Pointer) unsafe.Pointer {
+	escapeSink = p
+	return p
+}
+
+var escapeSink unsafe.Pointer
+
 type libcCallInfo struct {
 	fn      uintptr
 	n       uintptr // number of parameters

--- a/internal/ossl/syscall_nocgo.go
+++ b/internal/ossl/syscall_nocgo.go
@@ -18,16 +18,15 @@ func noescape(p unsafe.Pointer) unsafe.Pointer {
 	return unsafe.Pointer(x ^ 0)
 }
 
-// escapePtr forces p to escape to the heap.
-// By assigning to a global sink, the compiler must assume the pointer escapes.
-//
-//go:noinline
+var alwaysFalse bool
+var escapeSink unsafe.Pointer
+
 func escapePtr(p unsafe.Pointer) unsafe.Pointer {
-	escapeSink = p
+	if alwaysFalse {
+		escapeSink = p
+	}
 	return p
 }
-
-var escapeSink unsafe.Pointer
 
 type libcCallInfo struct {
 	fn      uintptr

--- a/internal/ossl/syscall_nocgo.go
+++ b/internal/ossl/syscall_nocgo.go
@@ -23,7 +23,7 @@ var escapeSink unsafe.Pointer
 
 // escapePtr forces p to escape to the heap.
 // This implementation is also used in the standard library:
-// https://github.com/golang/go/blob/go1.26.0/src/internal/abi/escape.go#L24-L33
+// https://github.com/golang/go/blob/f71432d223eeb2139b460957817400750fd13655/src/internal/abi/escape.go#L24-L33
 func escapePtr(p unsafe.Pointer) unsafe.Pointer {
 	if alwaysFalse {
 		escapeSink = p

--- a/internal/ossl/zdl_nocgo.go
+++ b/internal/ossl/zdl_nocgo.go
@@ -33,13 +33,13 @@ func Dlerror() *byte {
 var _mkcgo_dlopen_trampoline_addr uintptr
 
 func Dlopen(path *byte, flags int32) unsafe.Pointer {
-	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(unsafe.Pointer(path)), uintptr(flags))
+	r0, _ := syscallN(0, _mkcgo_dlopen_trampoline_addr, uintptr(escapePtr(unsafe.Pointer(path))), uintptr(flags))
 	return unsafe.Pointer(r0)
 }
 
 var _mkcgo_dlsym_trampoline_addr uintptr
 
 func Dlsym(handle unsafe.Pointer, symbol *byte) unsafe.Pointer {
-	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(unsafe.Pointer(symbol)))
+	r0, _ := syscallN(0, _mkcgo_dlsym_trampoline_addr, uintptr(handle), uintptr(escapePtr(unsafe.Pointer(symbol))))
 	return unsafe.Pointer(r0)
 }

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -74,7 +74,7 @@ var _mkcgo_BN_bin2bn uintptr
 
 func BN_bin2bn(arg0 *byte, arg1 int32, arg2 BIGNUM_PTR) (BIGNUM_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_BN_bin2bn, uintptr(unsafe.Pointer(arg0)), uintptr(arg1), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_BN_bin2bn, uintptr(escapePtr(unsafe.Pointer(arg0))), uintptr(arg1), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 	return BIGNUM_PTR(r0), newMkcgoErr("BN_bin2bn", _err)
 }
 
@@ -82,7 +82,7 @@ var _mkcgo_BN_bn2binpad uintptr
 
 func BN_bn2binpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(2, _mkcgo_BN_bn2binpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(2, _mkcgo_BN_bn2binpad, uintptr(a), uintptr(escapePtr(unsafe.Pointer(to))), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("BN_bn2binpad", _err)
 }
 
@@ -90,7 +90,7 @@ var _mkcgo_BN_bn2lebinpad uintptr
 
 func BN_bn2lebinpad(a BIGNUM_PTR, to *byte, tolen int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(2, _mkcgo_BN_bn2lebinpad, uintptr(a), uintptr(unsafe.Pointer(to)), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(2, _mkcgo_BN_bn2lebinpad, uintptr(a), uintptr(escapePtr(unsafe.Pointer(to))), uintptr(tolen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("BN_bn2lebinpad", _err)
 }
 
@@ -116,7 +116,7 @@ var _mkcgo_BN_lebin2bn uintptr
 
 func BN_lebin2bn(s *byte, len int32, ret BIGNUM_PTR) (BIGNUM_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_BN_lebin2bn, uintptr(unsafe.Pointer(s)), uintptr(len), uintptr(ret), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_BN_lebin2bn, uintptr(escapePtr(unsafe.Pointer(s))), uintptr(len), uintptr(ret), uintptr(unsafe.Pointer(&_err)))
 	return BIGNUM_PTR(r0), newMkcgoErr("BN_lebin2bn", _err)
 }
 
@@ -138,14 +138,14 @@ func BN_num_bits(arg0 BIGNUM_PTR) int32 {
 var _mkcgo_CRYPTO_free uintptr
 
 func CRYPTO_free(str unsafe.Pointer, file *byte, line int32) {
-	syscallN(0, _mkcgo_CRYPTO_free, uintptr(str), uintptr(unsafe.Pointer(file)), uintptr(line))
+	syscallN(0, _mkcgo_CRYPTO_free, uintptr(str), uintptr(escapePtr(unsafe.Pointer(file))), uintptr(line))
 }
 
 var _mkcgo_CRYPTO_malloc uintptr
 
 func CRYPTO_malloc(num int, file *byte, line int32) (unsafe.Pointer, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_CRYPTO_malloc, uintptr(num), uintptr(unsafe.Pointer(file)), uintptr(line), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_CRYPTO_malloc, uintptr(num), uintptr(escapePtr(unsafe.Pointer(file))), uintptr(line), uintptr(unsafe.Pointer(&_err)))
 	return unsafe.Pointer(r0), newMkcgoErr("CRYPTO_malloc", _err)
 }
 
@@ -166,13 +166,13 @@ func DSA_generate_key(a DSA_PTR) (int32, error) {
 var _mkcgo_DSA_get0_key uintptr
 
 func DSA_get0_key(d DSA_PTR, pub_key *BIGNUM_PTR, priv_key *BIGNUM_PTR) {
-	syscallN(0, _mkcgo_DSA_get0_key, uintptr(d), uintptr(unsafe.Pointer(pub_key)), uintptr(unsafe.Pointer(priv_key)))
+	syscallN(0, _mkcgo_DSA_get0_key, uintptr(d), uintptr(escapePtr(unsafe.Pointer(pub_key))), uintptr(escapePtr(unsafe.Pointer(priv_key))))
 }
 
 var _mkcgo_DSA_get0_pqg uintptr
 
 func DSA_get0_pqg(d DSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR, g *BIGNUM_PTR) {
-	syscallN(0, _mkcgo_DSA_get0_pqg, uintptr(d), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)), uintptr(unsafe.Pointer(g)))
+	syscallN(0, _mkcgo_DSA_get0_pqg, uintptr(d), uintptr(escapePtr(unsafe.Pointer(p))), uintptr(escapePtr(unsafe.Pointer(q))), uintptr(escapePtr(unsafe.Pointer(g))))
 }
 
 var _mkcgo_DSA_new uintptr
@@ -314,7 +314,7 @@ var _mkcgo_EC_POINT_oct2point uintptr
 
 func EC_POINT_oct2point(group EC_GROUP_PTR, p EC_POINT_PTR, buf *byte, len int, ctx BN_CTX_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EC_POINT_oct2point, uintptr(group), uintptr(p), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EC_POINT_oct2point, uintptr(group), uintptr(p), uintptr(escapePtr(unsafe.Pointer(buf))), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EC_POINT_oct2point", _err)
 }
 
@@ -322,7 +322,7 @@ var _mkcgo_EC_POINT_point2oct uintptr
 
 func EC_POINT_point2oct(group EC_GROUP_PTR, p EC_POINT_PTR, form Point_conversion_form_t, buf *byte, len int, ctx BN_CTX_PTR) (int, error) {
 	var _err uintptr
-	r0, _ := syscallN(4, _mkcgo_EC_POINT_point2oct, uintptr(group), uintptr(p), uintptr(form), uintptr(unsafe.Pointer(buf)), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(4, _mkcgo_EC_POINT_point2oct, uintptr(group), uintptr(p), uintptr(form), uintptr(escapePtr(unsafe.Pointer(buf))), uintptr(len), uintptr(ctx), uintptr(unsafe.Pointer(&_err)))
 	return int(r0), newMkcgoErr("EC_POINT_point2oct", _err)
 }
 
@@ -389,7 +389,7 @@ var _mkcgo_EVP_CIPHER_fetch uintptr
 
 func EVP_CIPHER_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_CIPHER_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_CIPHER_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_CIPHER_fetch, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_CIPHER_PTR(r0), newMkcgoErr("EVP_CIPHER_fetch", _err)
 }
 
@@ -411,7 +411,7 @@ var _mkcgo_EVP_CipherInit_ex uintptr
 
 func EVP_CipherInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte, enc int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_CipherInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(escapePtr(unsafe.Pointer(iv))), uintptr(enc), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_CipherInit_ex", _err)
 }
 
@@ -435,7 +435,7 @@ var _mkcgo_EVP_DecryptInit_ex uintptr
 
 func EVP_DecryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DecryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DecryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(escapePtr(unsafe.Pointer(iv))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DecryptInit_ex", _err)
 }
 
@@ -499,7 +499,7 @@ var _mkcgo_EVP_DigestSignFinal uintptr
 
 func EVP_DigestSignFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen *int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(unsafe.Pointer(siglen)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignFinal, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(sig))), uintptr(escapePtr(unsafe.Pointer(siglen))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestSignFinal", _err)
 }
 
@@ -507,7 +507,7 @@ var _mkcgo_EVP_DigestSignInit uintptr
 
 func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestSignInit, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(pctx))), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestSignInit", _err)
 }
 
@@ -531,7 +531,7 @@ var _mkcgo_EVP_DigestVerify uintptr
 
 func EVP_DigestVerify(ctx EVP_MD_CTX_PTR, sigret *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerify, uintptr(ctx), uintptr(unsafe.Pointer(sigret)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerify, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(sigret))), uintptr(siglen), uintptr(escapePtr(unsafe.Pointer(tbs))), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestVerify", _err)
 }
 
@@ -539,7 +539,7 @@ var _mkcgo_EVP_DigestVerifyFinal uintptr
 
 func EVP_DigestVerifyFinal(ctx EVP_MD_CTX_PTR, sig *byte, siglen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyFinal, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyFinal, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(sig))), uintptr(siglen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestVerifyFinal", _err)
 }
 
@@ -547,7 +547,7 @@ var _mkcgo_EVP_DigestVerifyInit uintptr
 
 func EVP_DigestVerifyInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_MD_PTR, e ENGINE_PTR, pkey EVP_PKEY_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyInit, uintptr(ctx), uintptr(unsafe.Pointer(pctx)), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_DigestVerifyInit, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(pctx))), uintptr(__type), uintptr(e), uintptr(pkey), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_DigestVerifyInit", _err)
 }
 
@@ -563,7 +563,7 @@ var _mkcgo_EVP_EncryptInit_ex uintptr
 
 func EVP_EncryptInit_ex(ctx EVP_CIPHER_CTX_PTR, __type EVP_CIPHER_PTR, impl ENGINE_PTR, key *byte, iv *byte) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_EncryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(iv)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_EncryptInit_ex, uintptr(ctx), uintptr(__type), uintptr(impl), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(escapePtr(unsafe.Pointer(iv))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_EncryptInit_ex", _err)
 }
 
@@ -609,7 +609,7 @@ var _mkcgo_EVP_KDF_derive uintptr
 
 func EVP_KDF_derive(ctx EVP_KDF_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_KDF_derive, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_KDF_derive, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_KDF_derive", _err)
 }
 
@@ -617,7 +617,7 @@ var _mkcgo_EVP_KDF_fetch uintptr
 
 func EVP_KDF_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KDF_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_KDF_fetch, uintptr(libctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_KDF_fetch, uintptr(libctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_KDF_PTR(r0), newMkcgoErr("EVP_KDF_fetch", _err)
 }
 
@@ -631,7 +631,7 @@ var _mkcgo_EVP_KEYMGMT_fetch uintptr
 
 func EVP_KEYMGMT_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KEYMGMT_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_KEYMGMT_fetch, uintptr(libctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_KEYMGMT_fetch, uintptr(libctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_KEYMGMT_PTR(r0), newMkcgoErr("EVP_KEYMGMT_fetch", _err)
 }
 
@@ -675,7 +675,7 @@ var _mkcgo_EVP_MAC_fetch uintptr
 
 func EVP_MAC_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MAC_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_MAC_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_MAC_fetch, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_MAC_PTR(r0), newMkcgoErr("EVP_MAC_fetch", _err)
 }
 
@@ -683,7 +683,7 @@ var _mkcgo_EVP_MAC_final uintptr
 
 func EVP_MAC_final(ctx EVP_MAC_CTX_PTR, out *byte, outl *int, outsize int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_MAC_final, uintptr(ctx), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(outl)), uintptr(outsize), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_final, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(out))), uintptr(escapePtr(unsafe.Pointer(outl))), uintptr(outsize), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_MAC_final", _err)
 }
 
@@ -691,7 +691,7 @@ var _mkcgo_EVP_MAC_init uintptr
 
 func EVP_MAC_init(ctx EVP_MAC_CTX_PTR, key *byte, keylen int, params OSSL_PARAM_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_MAC_init, uintptr(ctx), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_init, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(keylen), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_MAC_init", _err)
 }
 
@@ -699,7 +699,7 @@ var _mkcgo_EVP_MAC_update uintptr
 
 func EVP_MAC_update(ctx EVP_MAC_CTX_PTR, data *byte, datalen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_MAC_update, uintptr(ctx), uintptr(unsafe.Pointer(data)), uintptr(datalen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_MAC_update, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(data))), uintptr(datalen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_MAC_update", _err)
 }
 
@@ -769,7 +769,7 @@ var _mkcgo_EVP_MD_fetch uintptr
 
 func EVP_MD_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_MD_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_MD_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_MD_fetch, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_MD_PTR(r0), newMkcgoErr("EVP_MD_fetch", _err)
 }
 
@@ -818,7 +818,7 @@ var _mkcgo_EVP_PKEY_CTX_add1_hkdf_info uintptr
 
 func EVP_PKEY_CTX_add1_hkdf_info(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_add1_hkdf_info, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_add1_hkdf_info, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_add1_hkdf_info", _err)
 }
 
@@ -848,7 +848,7 @@ var _mkcgo_EVP_PKEY_CTX_new_from_pkey uintptr
 
 func EVP_PKEY_CTX_new_from_pkey(libctx OSSL_LIB_CTX_PTR, pkey EVP_PKEY_PTR, propquery *byte) (EVP_PKEY_CTX_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_pkey, uintptr(libctx), uintptr(pkey), uintptr(unsafe.Pointer(propquery)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_CTX_new_from_pkey, uintptr(libctx), uintptr(pkey), uintptr(escapePtr(unsafe.Pointer(propquery))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_CTX_PTR(r0), newMkcgoErr("EVP_PKEY_CTX_new_from_pkey", _err)
 }
 
@@ -872,7 +872,7 @@ var _mkcgo_EVP_PKEY_CTX_set1_hkdf_key uintptr
 
 func EVP_PKEY_CTX_set1_hkdf_key(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_key, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_key, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_key", _err)
 }
 
@@ -880,7 +880,7 @@ var _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt uintptr
 
 func EVP_PKEY_CTX_set1_hkdf_salt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set1_hkdf_salt", _err)
 }
 
@@ -908,20 +908,20 @@ func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), 0, 0, 0, 0, 0, uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(&_err)))
 	} else {
-		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(&_err)))
+		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(propq))), uintptr(escapePtr(unsafe.Pointer(__type))), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(unsafe.Pointer(&_err)))
 	}
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_EC", _err)
 }
 
 func EVP_PKEY_Q_keygen_ED25519(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(propq))), uintptr(escapePtr(unsafe.Pointer(__type))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_ED25519", _err)
 }
 
 func EVP_PKEY_Q_keygen_MLKEM(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(propq))), uintptr(escapePtr(unsafe.Pointer(__type))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_MLKEM", _err)
 }
 
@@ -931,14 +931,14 @@ func EVP_PKEY_Q_keygen_RSA(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), 0, 0, 0, 0, 0, uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 	} else {
-		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
+		r0, _ = syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(propq))), uintptr(escapePtr(unsafe.Pointer(__type))), uintptr(arg1), uintptr(unsafe.Pointer(&_err)))
 	}
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_RSA", _err)
 }
 
 func EVP_PKEY_Q_keygen_X25519(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(propq))), uintptr(escapePtr(unsafe.Pointer(__type))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_X25519", _err)
 }
 
@@ -954,7 +954,7 @@ var _mkcgo_EVP_PKEY_decapsulate uintptr
 
 func EVP_PKEY_decapsulate(ctx EVP_PKEY_CTX_PTR, genkey *byte, genkeylen *int, wrappedkey *byte, wrappedkeylen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decapsulate, uintptr(ctx), uintptr(unsafe.Pointer(genkey)), uintptr(unsafe.Pointer(genkeylen)), uintptr(unsafe.Pointer(wrappedkey)), uintptr(wrappedkeylen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decapsulate, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(genkey))), uintptr(escapePtr(unsafe.Pointer(genkeylen))), uintptr(escapePtr(unsafe.Pointer(wrappedkey))), uintptr(wrappedkeylen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_decapsulate", _err)
 }
 
@@ -970,7 +970,7 @@ var _mkcgo_EVP_PKEY_decrypt uintptr
 
 func EVP_PKEY_decrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_decrypt, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(escapePtr(unsafe.Pointer(arg2))), uintptr(escapePtr(unsafe.Pointer(arg3))), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_decrypt", _err)
 }
 
@@ -1010,7 +1010,7 @@ var _mkcgo_EVP_PKEY_encapsulate uintptr
 
 func EVP_PKEY_encapsulate(ctx EVP_PKEY_CTX_PTR, wrappedkey *byte, wrappedkeylen *int, genkey *byte, genkeylen *int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encapsulate, uintptr(ctx), uintptr(unsafe.Pointer(wrappedkey)), uintptr(unsafe.Pointer(wrappedkeylen)), uintptr(unsafe.Pointer(genkey)), uintptr(unsafe.Pointer(genkeylen)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encapsulate, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(wrappedkey))), uintptr(escapePtr(unsafe.Pointer(wrappedkeylen))), uintptr(escapePtr(unsafe.Pointer(genkey))), uintptr(escapePtr(unsafe.Pointer(genkeylen))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_encapsulate", _err)
 }
 
@@ -1026,7 +1026,7 @@ var _mkcgo_EVP_PKEY_encrypt uintptr
 
 func EVP_PKEY_encrypt(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_encrypt, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(escapePtr(unsafe.Pointer(arg2))), uintptr(escapePtr(unsafe.Pointer(arg3))), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_encrypt", _err)
 }
 
@@ -1048,7 +1048,7 @@ var _mkcgo_EVP_PKEY_fromdata uintptr
 
 func EVP_PKEY_fromdata(ctx EVP_PKEY_CTX_PTR, pkey *EVP_PKEY_PTR, selection int32, params OSSL_PARAM_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata, uintptr(ctx), uintptr(unsafe.Pointer(pkey)), uintptr(selection), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_fromdata, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(pkey))), uintptr(selection), uintptr(params), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_fromdata", _err)
 }
 
@@ -1088,7 +1088,7 @@ var _mkcgo_EVP_PKEY_get1_encoded_public_key uintptr
 
 func EVP_PKEY_get1_encoded_public_key(pkey EVP_PKEY_PTR, ppub **byte) (int, error) {
 	var _err uintptr
-	r0, _ := syscallN(4, _mkcgo_EVP_PKEY_get1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(ppub)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(4, _mkcgo_EVP_PKEY_get1_encoded_public_key, uintptr(pkey), uintptr(escapePtr(unsafe.Pointer(ppub))), uintptr(unsafe.Pointer(&_err)))
 	return int(r0), newMkcgoErr("EVP_PKEY_get1_encoded_public_key", _err)
 }
 
@@ -1104,7 +1104,7 @@ var _mkcgo_EVP_PKEY_get_bn_param uintptr
 
 func EVP_PKEY_get_bn_param(pkey EVP_PKEY_PTR, key_name *byte, bn *BIGNUM_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_bn_param, uintptr(pkey), uintptr(unsafe.Pointer(key_name)), uintptr(unsafe.Pointer(bn)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_bn_param, uintptr(pkey), uintptr(escapePtr(unsafe.Pointer(key_name))), uintptr(escapePtr(unsafe.Pointer(bn))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_bn_param", _err)
 }
 
@@ -1112,7 +1112,7 @@ var _mkcgo_EVP_PKEY_get_octet_string_param uintptr
 
 func EVP_PKEY_get_octet_string_param(pkey EVP_PKEY_PTR, key_name *byte, buf *byte, buf_len int, out_len *int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_octet_string_param, uintptr(pkey), uintptr(unsafe.Pointer(key_name)), uintptr(unsafe.Pointer(buf)), uintptr(buf_len), uintptr(unsafe.Pointer(out_len)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_get_octet_string_param, uintptr(pkey), uintptr(escapePtr(unsafe.Pointer(key_name))), uintptr(escapePtr(unsafe.Pointer(buf))), uintptr(buf_len), uintptr(escapePtr(unsafe.Pointer(out_len))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_get_octet_string_param", _err)
 }
 
@@ -1144,7 +1144,7 @@ var _mkcgo_EVP_PKEY_keygen uintptr
 
 func EVP_PKEY_keygen(ctx EVP_PKEY_CTX_PTR, ppkey *EVP_PKEY_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_keygen, uintptr(ctx), uintptr(unsafe.Pointer(ppkey)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_keygen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(ppkey))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_keygen", _err)
 }
 
@@ -1168,7 +1168,7 @@ var _mkcgo_EVP_PKEY_new_raw_private_key uintptr
 
 func EVP_PKEY_new_raw_private_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_private_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_private_key, uintptr(__type), uintptr(e), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_private_key", _err)
 }
 
@@ -1176,7 +1176,7 @@ var _mkcgo_EVP_PKEY_new_raw_public_key uintptr
 
 func EVP_PKEY_new_raw_public_key(__type int32, e ENGINE_PTR, key *byte, keylen int) (EVP_PKEY_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_public_key, uintptr(__type), uintptr(e), uintptr(unsafe.Pointer(key)), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_new_raw_public_key, uintptr(__type), uintptr(e), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(keylen), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_new_raw_public_key", _err)
 }
 
@@ -1184,7 +1184,7 @@ var _mkcgo_EVP_PKEY_paramgen uintptr
 
 func EVP_PKEY_paramgen(ctx EVP_PKEY_CTX_PTR, ppkey *EVP_PKEY_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen, uintptr(ctx), uintptr(unsafe.Pointer(ppkey)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_paramgen, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(ppkey))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_paramgen", _err)
 }
 
@@ -1224,7 +1224,7 @@ var _mkcgo_EVP_PKEY_set1_encoded_public_key uintptr
 
 func EVP_PKEY_set1_encoded_public_key(pkey EVP_PKEY_PTR, pub *byte, publen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_encoded_public_key, uintptr(pkey), uintptr(unsafe.Pointer(pub)), uintptr(publen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_set1_encoded_public_key, uintptr(pkey), uintptr(escapePtr(unsafe.Pointer(pub))), uintptr(publen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_set1_encoded_public_key", _err)
 }
 
@@ -1232,7 +1232,7 @@ var _mkcgo_EVP_PKEY_sign uintptr
 
 func EVP_PKEY_sign(arg0 EVP_PKEY_CTX_PTR, arg1 *byte, arg2 *int, arg3 *byte, arg4 int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(arg3)), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_sign, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(escapePtr(unsafe.Pointer(arg2))), uintptr(escapePtr(unsafe.Pointer(arg3))), uintptr(arg4), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_sign", _err)
 }
 
@@ -1256,7 +1256,7 @@ var _mkcgo_EVP_PKEY_verify uintptr
 
 func EVP_PKEY_verify(ctx EVP_PKEY_CTX_PTR, sig *byte, siglen int, tbs *byte, tbslen int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify, uintptr(ctx), uintptr(unsafe.Pointer(sig)), uintptr(siglen), uintptr(unsafe.Pointer(tbs)), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_verify, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(sig))), uintptr(siglen), uintptr(escapePtr(unsafe.Pointer(tbs))), uintptr(tbslen), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("EVP_PKEY_verify", _err)
 }
 
@@ -1272,7 +1272,7 @@ var _mkcgo_EVP_SIGNATURE_fetch uintptr
 
 func EVP_SIGNATURE_fetch(ctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_SIGNATURE_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_EVP_SIGNATURE_fetch, uintptr(ctx), uintptr(unsafe.Pointer(algorithm)), uintptr(unsafe.Pointer(properties)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_EVP_SIGNATURE_fetch, uintptr(ctx), uintptr(escapePtr(unsafe.Pointer(algorithm))), uintptr(escapePtr(unsafe.Pointer(properties))), uintptr(unsafe.Pointer(&_err)))
 	return EVP_SIGNATURE_PTR(r0), newMkcgoErr("EVP_SIGNATURE_fetch", _err)
 }
 
@@ -1573,7 +1573,7 @@ var _mkcgo_HMAC_Final uintptr
 
 func HMAC_Final(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 *uint32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_HMAC_Final, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(unsafe.Pointer(arg2)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_HMAC_Final, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(escapePtr(unsafe.Pointer(arg2))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("HMAC_Final", _err)
 }
 
@@ -1589,7 +1589,7 @@ var _mkcgo_HMAC_Update uintptr
 
 func HMAC_Update(arg0 HMAC_CTX_PTR, arg1 *byte, arg2 int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_HMAC_Update, uintptr(arg0), uintptr(unsafe.Pointer(arg1)), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_HMAC_Update, uintptr(arg0), uintptr(escapePtr(unsafe.Pointer(arg1))), uintptr(arg2), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("HMAC_Update", _err)
 }
 
@@ -1665,7 +1665,7 @@ var _mkcgo_OSSL_PARAM_BLD_push_BN uintptr
 
 func OSSL_PARAM_BLD_push_BN(bld OSSL_PARAM_BLD_PTR, key *byte, bn BIGNUM_PTR) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_BN, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(bn), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_BN, uintptr(bld), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(bn), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_BN", _err)
 }
 
@@ -1673,7 +1673,7 @@ var _mkcgo_OSSL_PARAM_BLD_push_int32 uintptr
 
 func OSSL_PARAM_BLD_push_int32(bld OSSL_PARAM_BLD_PTR, key *byte, num int32) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_int32, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(num), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_int32, uintptr(bld), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(num), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_int32", _err)
 }
 
@@ -1681,7 +1681,7 @@ var _mkcgo_OSSL_PARAM_BLD_push_octet_string uintptr
 
 func OSSL_PARAM_BLD_push_octet_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf unsafe.Pointer, bsize int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_octet_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(buf), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_octet_string, uintptr(bld), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(buf), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_octet_string", _err)
 }
 
@@ -1689,7 +1689,7 @@ var _mkcgo_OSSL_PARAM_BLD_push_utf8_string uintptr
 
 func OSSL_PARAM_BLD_push_utf8_string(bld OSSL_PARAM_BLD_PTR, key *byte, buf *byte, bsize int) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_utf8_string, uintptr(bld), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(buf)), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_OSSL_PARAM_BLD_push_utf8_string, uintptr(bld), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(escapePtr(unsafe.Pointer(buf))), uintptr(bsize), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("OSSL_PARAM_BLD_push_utf8_string", _err)
 }
 
@@ -1711,14 +1711,14 @@ var _mkcgo_OSSL_PARAM_locate_const uintptr
 
 func OSSL_PARAM_locate_const(p OSSL_PARAM_PTR, key *byte) (OSSL_PARAM_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_locate_const, uintptr(p), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_locate_const, uintptr(p), uintptr(escapePtr(unsafe.Pointer(key))), uintptr(unsafe.Pointer(&_err)))
 	return OSSL_PARAM_PTR(r0), newMkcgoErr("OSSL_PARAM_locate_const", _err)
 }
 
 var _mkcgo_OSSL_PROVIDER_available uintptr
 
 func OSSL_PROVIDER_available(libctx OSSL_LIB_CTX_PTR, name *byte) int32 {
-	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_available, uintptr(libctx), uintptr(unsafe.Pointer(name)))
+	r0, _ := syscallN(0, _mkcgo_OSSL_PROVIDER_available, uintptr(libctx), uintptr(escapePtr(unsafe.Pointer(name))))
 	return int32(r0)
 }
 
@@ -1733,7 +1733,7 @@ var _mkcgo_OSSL_PROVIDER_try_load uintptr
 
 func OSSL_PROVIDER_try_load(libctx OSSL_LIB_CTX_PTR, name *byte, retain_fallbacks int32) (OSSL_PROVIDER_PTR, error) {
 	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_OSSL_PROVIDER_try_load, uintptr(libctx), uintptr(unsafe.Pointer(name)), uintptr(retain_fallbacks), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(1, _mkcgo_OSSL_PROVIDER_try_load, uintptr(libctx), uintptr(escapePtr(unsafe.Pointer(name))), uintptr(retain_fallbacks), uintptr(unsafe.Pointer(&_err)))
 	return OSSL_PROVIDER_PTR(r0), newMkcgoErr("OSSL_PROVIDER_try_load", _err)
 }
 
@@ -1759,7 +1759,7 @@ var _mkcgo_PKCS5_PBKDF2_HMAC uintptr
 
 func PKCS5_PBKDF2_HMAC(pass *byte, passlen int32, salt *byte, saltlen int32, iter int32, digest EVP_MD_PTR, keylen int32, out *byte) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_PKCS5_PBKDF2_HMAC, uintptr(unsafe.Pointer(pass)), uintptr(passlen), uintptr(unsafe.Pointer(salt)), uintptr(saltlen), uintptr(iter), uintptr(digest), uintptr(keylen), uintptr(unsafe.Pointer(out)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_PKCS5_PBKDF2_HMAC, uintptr(escapePtr(unsafe.Pointer(pass))), uintptr(passlen), uintptr(escapePtr(unsafe.Pointer(salt))), uintptr(saltlen), uintptr(iter), uintptr(digest), uintptr(keylen), uintptr(escapePtr(unsafe.Pointer(out))), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("PKCS5_PBKDF2_HMAC", _err)
 }
 
@@ -1780,19 +1780,19 @@ func RSA_free(arg0 RSA_PTR) {
 var _mkcgo_RSA_get0_crt_params uintptr
 
 func RSA_get0_crt_params(r RSA_PTR, dmp1 *BIGNUM_PTR, dmq1 *BIGNUM_PTR, iqmp *BIGNUM_PTR) {
-	syscallN(0, _mkcgo_RSA_get0_crt_params, uintptr(r), uintptr(unsafe.Pointer(dmp1)), uintptr(unsafe.Pointer(dmq1)), uintptr(unsafe.Pointer(iqmp)))
+	syscallN(0, _mkcgo_RSA_get0_crt_params, uintptr(r), uintptr(escapePtr(unsafe.Pointer(dmp1))), uintptr(escapePtr(unsafe.Pointer(dmq1))), uintptr(escapePtr(unsafe.Pointer(iqmp))))
 }
 
 var _mkcgo_RSA_get0_factors uintptr
 
 func RSA_get0_factors(rsa RSA_PTR, p *BIGNUM_PTR, q *BIGNUM_PTR) {
-	syscallN(0, _mkcgo_RSA_get0_factors, uintptr(rsa), uintptr(unsafe.Pointer(p)), uintptr(unsafe.Pointer(q)))
+	syscallN(0, _mkcgo_RSA_get0_factors, uintptr(rsa), uintptr(escapePtr(unsafe.Pointer(p))), uintptr(escapePtr(unsafe.Pointer(q))))
 }
 
 var _mkcgo_RSA_get0_key uintptr
 
 func RSA_get0_key(rsa RSA_PTR, n *BIGNUM_PTR, e *BIGNUM_PTR, d *BIGNUM_PTR) {
-	syscallN(0, _mkcgo_RSA_get0_key, uintptr(rsa), uintptr(unsafe.Pointer(n)), uintptr(unsafe.Pointer(e)), uintptr(unsafe.Pointer(d)))
+	syscallN(0, _mkcgo_RSA_get0_key, uintptr(rsa), uintptr(escapePtr(unsafe.Pointer(n))), uintptr(escapePtr(unsafe.Pointer(e))), uintptr(escapePtr(unsafe.Pointer(d))))
 }
 
 var _mkcgo_RSA_new uintptr


### PR DESCRIPTION
Update mkcgo generator to force escaping the nocgo binding parameters unless the function has `noescape,nocallback` attributes. This will match how cgo escapes variables by default to ensure that variables are always being safely referred to. 

```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: AMD EPYC 7763 64-Core Processor
                         │ /mnt/c/Users/mclayton/workspace/openssl/old.txt │ /mnt/c/Users/mclayton/workspace/openssl/new.txt │
                         │                     sec/op                      │          sec/op            vs base              │
AES_Encrypt-16                                                512.6n ± 11%                503.7n ±  9%  -1.74% (p=0.026 n=7)
AES_Decrypt-16                                                606.2n ±  0%                619.0n ±  1%  +2.11% (p=0.001 n=7)
AESGCM_Open-16                                                1.232µ ±  0%                1.219µ ±  1%  -1.06% (p=0.001 n=7)
AESGCM_Seal-16                                                1.188µ ±  1%                1.173µ ±  1%  -1.26% (p=0.003 n=7)
TDESEncrypt-16                                                1.089µ ±  0%                1.096µ ±  0%  +0.64% (p=0.001 n=7)
TDESDecrypt-16                                                1.189µ ±  0%                1.187µ ±  2%       ~ (p=0.519 n=7)
ECDH-16                                                       112.4µ ±  0%                113.0µ ±  0%  +0.50% (p=0.007 n=7)
Ed25519GenerateKey-16                                         52.02µ ±  1%                51.37µ ±  1%  -1.23% (p=0.007 n=7)
Ed25519NewKeyFromSeed-16                                      51.55µ ±  1%                51.42µ ±  1%       ~ (p=0.128 n=7)
Ed25519Signing-16                                             48.05µ ±  1%                47.94µ ±  0%       ~ (p=0.097 n=7)
Ed25519Verification-16                                        124.7µ ±  2%                124.9µ ±  3%       ~ (p=0.620 n=7)
NewSHA256-16                                                  18.18n ±  0%                18.18n ±  2%       ~ (p=0.952 n=7)
Hash8Bytes/New-16                                             254.9n ±  0%                262.1n ±  0%  +2.82% (p=0.001 n=7)
Hash8Bytes/NewSteps-16                                        294.9n ±  0%                300.3n ±  0%  +1.83% (p=0.001 n=7)
Hash8Bytes/Sum256-16                                          271.8n ±  1%                272.8n ±  0%       ~ (p=0.102 n=7)
Hash1K/New-16                                                 1.059µ ±  0%                1.074µ ±  1%  +1.42% (p=0.001 n=7)
Hash1K/NewSteps-16                                            1.285µ ±  0%                1.304µ ±  1%  +1.48% (p=0.001 n=7)
Hash1K/Sum256-16                                              922.7n ±  0%                924.1n ±  1%  +0.15% (p=0.006 n=7)
Hash8K/New-16                                                 5.652µ ±  0%                5.674µ ±  0%  +0.39% (p=0.001 n=7)
Hash8K/NewSteps-16                                            6.015µ ±  0%                6.042µ ±  0%  +0.45% (p=0.001 n=7)
Hash8K/Sum256-16                                              5.505µ ±  0%                5.513µ ±  0%  +0.15% (p=0.001 n=7)
Hash256K/New-16                                               168.1µ ±  0%                168.2µ ±  0%       ~ (p=0.053 n=7)
Hash256K/NewSteps-16                                          169.3µ ±  0%                168.9µ ±  0%  -0.27% (p=0.026 n=7)
Hash256K/Sum256-16                                            168.0µ ±  1%                168.0µ ±  0%       ~ (p=0.805 n=7)
Hash1M/New-16                                                 698.3µ ±  0%                698.4µ ±  0%       ~ (p=0.902 n=7)
Hash1M/NewSteps-16                                            672.5µ ±  0%                672.5µ ±  0%       ~ (p=0.535 n=7)
Hash1M/Sum256-16                                              698.0µ ±  0%                698.0µ ±  1%       ~ (p=0.902 n=7)
HMACSHA256_32-16                                              1.085µ ±  4%                1.074µ ±  1%  -1.01% (p=0.005 n=7)
HMACNewWriteSum-16                                            4.794µ ±  3%                4.893µ ±  6%       ~ (p=0.209 n=7)
Error-16                                                      4.410µ ±  1%                4.472µ ±  1%  +1.41% (p=0.002 n=7)
EncryptRSA/PKCS1-16                                           30.73µ ±  0%                30.78µ ±  0%       ~ (p=0.456 n=7)
EncryptRSA/OAEP-16                                            33.67µ ±  0%                33.74µ ±  1%       ~ (p=0.259 n=7)
GenerateKeyRSA-16                                             202.3m ± 40%                187.7m ± 41%       ~ (p=0.535 n=7)
geomean                                                       9.892µ                      9.897µ        +0.05%

                       │ /mnt/c/Users/mclayton/workspace/openssl/old.txt │ /mnt/c/Users/mclayton/workspace/openssl/new.txt │
                       │                       B/s                       │            B/s             vs base              │
AES_Encrypt-16                                             29.76Mi ± 10%                30.30Mi ± 8%  +1.79% (p=0.026 n=7)
AES_Decrypt-16                                             25.18Mi ±  0%                24.65Mi ± 1%  -2.08% (p=0.001 n=7)
AESGCM_Open-16                                             49.52Mi ±  0%                50.09Mi ± 1%  +1.14% (p=0.001 n=7)
AESGCM_Seal-16                                             51.36Mi ±  0%                52.03Mi ± 1%  +1.30% (p=0.001 n=7)
TDESEncrypt-16                                             7.010Mi ±  0%                6.962Mi ± 0%  -0.68% (p=0.001 n=7)
TDESDecrypt-16                                             6.418Mi ±  0%                6.428Mi ± 2%       ~ (p=0.764 n=7)
Hash8Bytes/New-16                                          29.93Mi ±  0%                29.11Mi ± 0%  -2.74% (p=0.001 n=7)
Hash8Bytes/NewSteps-16                                     25.87Mi ±  0%                25.41Mi ± 0%  -1.81% (p=0.001 n=7)
Hash8Bytes/Sum256-16                                       28.07Mi ±  0%                27.97Mi ± 0%       ~ (p=0.120 n=7)
Hash1K/New-16                                              921.9Mi ±  0%                909.1Mi ± 1%  -1.39% (p=0.001 n=7)
Hash1K/NewSteps-16                                         759.7Mi ±  0%                749.1Mi ± 1%  -1.39% (p=0.001 n=7)
Hash1K/Sum256-16                                           1.034Gi ±  0%                1.032Gi ± 1%  -0.15% (p=0.008 n=7)
Hash8K/New-16                                              1.350Gi ±  0%                1.345Gi ± 0%  -0.40% (p=0.001 n=7)
Hash8K/NewSteps-16                                         1.268Gi ±  0%                1.263Gi ± 0%  -0.46% (p=0.001 n=7)
Hash8K/Sum256-16                                           1.386Gi ±  0%                1.384Gi ± 0%  -0.14% (p=0.001 n=7)
Hash256K/New-16                                            1.453Gi ±  0%                1.451Gi ± 0%       ~ (p=0.053 n=7)
Hash256K/NewSteps-16                                       1.442Gi ±  0%                1.446Gi ± 0%  +0.27% (p=0.026 n=7)
Hash256K/Sum256-16                                         1.453Gi ±  1%                1.453Gi ± 0%       ~ (p=0.805 n=7)
Hash1M/New-16                                              1.398Gi ±  0%                1.398Gi ± 0%       ~ (p=0.902 n=7)
Hash1M/NewSteps-16                                         1.452Gi ±  0%                1.452Gi ± 0%       ~ (p=0.535 n=7)
Hash1M/Sum256-16                                           1.399Gi ±  0%                1.399Gi ± 1%       ~ (p=0.902 n=7)
HMACSHA256_32-16                                           28.11Mi ±  4%                28.42Mi ± 1%  +1.09% (p=0.005 n=7)
HMACNewWriteSum-16                                         6.371Mi ±  3%                6.237Mi ± 7%       ~ (p=0.209 n=7)
geomean                                                    178.7Mi                      178.1Mi       -0.36%

                         │ /mnt/c/Users/mclayton/workspace/openssl/old.txt │ /mnt/c/Users/mclayton/workspace/openssl/new.txt │
                         │                      B/op                       │         B/op           vs base                  │
AES_Encrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AES_Decrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AESGCM_Open-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AESGCM_Seal-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
TDESEncrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
TDESDecrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
ECDH-16                                                       32.00 ± 0%                32.00 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519GenerateKey-16                                         8.000 ± 0%               16.000 ± 0%  +100.00% (p=0.001 n=7)
Ed25519NewKeyFromSeed-16                                      8.000 ± 0%                8.000 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519Signing-16                                             0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519Verification-16                                        0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
NewSHA256-16                                                  0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/New-16                                             0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/NewSteps-16                                        0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/Sum256-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/New-16                                               0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/NewSteps-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/Sum256-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
HMACSHA256_32-16                                              32.00 ± 0%                32.00 ± 0%         ~ (p=1.000 n=7) ¹
HMACNewWriteSum-16                                            640.0 ± 0%                672.0 ± 0%    +5.00% (p=0.001 n=7)
Error-16                                                      208.0 ± 0%                216.0 ± 0%    +3.85% (p=0.001 n=7)
EncryptRSA/PKCS1-16                                           504.0 ± 0%                504.0 ± 0%         ~ (p=1.000 n=7) ¹
EncryptRSA/OAEP-16                                            504.0 ± 0%                504.0 ± 0%         ~ (p=1.000 n=7) ¹
GenerateKeyRSA-16                                           72.14Ki ± 0%              72.16Ki ± 0%    +0.02% (p=0.001 n=7)
geomean                                                                  ²                            +2.39%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │ /mnt/c/Users/mclayton/workspace/openssl/old.txt │ /mnt/c/Users/mclayton/workspace/openssl/new.txt │
                         │                    allocs/op                    │       allocs/op        vs base                  │
AES_Encrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AES_Decrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AESGCM_Open-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
AESGCM_Seal-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
TDESEncrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
TDESDecrypt-16                                                0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
ECDH-16                                                       1.000 ± 0%                1.000 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519GenerateKey-16                                         1.000 ± 0%                2.000 ± 0%  +100.00% (p=0.001 n=7)
Ed25519NewKeyFromSeed-16                                      1.000 ± 0%                1.000 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519Signing-16                                             0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Ed25519Verification-16                                        0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
NewSHA256-16                                                  0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/New-16                                             0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/NewSteps-16                                        0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/Sum256-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/New-16                                               0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/NewSteps-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/Sum256-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8Bytes/Sum256-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash8K/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/New-16                                               0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/NewSteps-16                                          0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash256K/Sum256-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/New-16                                                 0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/NewSteps-16                                            0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
Hash1M/Sum256-16                                              0.000 ± 0%                0.000 ± 0%         ~ (p=1.000 n=7) ¹
HMACSHA256_32-16                                              1.000 ± 0%                1.000 ± 0%         ~ (p=1.000 n=7) ¹
HMACNewWriteSum-16                                            5.000 ± 0%                6.000 ± 0%   +20.00% (p=0.001 n=7)
Error-16                                                      2.000 ± 0%                3.000 ± 0%   +50.00% (p=0.001 n=7)
EncryptRSA/PKCS1-16                                           8.000 ± 0%                8.000 ± 0%         ~ (p=1.000 n=7) ¹
EncryptRSA/OAEP-16                                            8.000 ± 0%                8.000 ± 0%         ~ (p=1.000 n=7) ¹
GenerateKeyRSA-16                                             8.000 ± 0%               10.000 ± 0%   +25.00% (p=0.001 n=7)
geomean                                                                  ²                            +4.66%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```