### PR TITLE
Reduce newParamBuilder memory footprint

### DIFF
--- a/dsa.go
+++ b/dsa.go
@@ -246,10 +246,7 @@ func newDSA1(params DSAParameters, x, y BigInt) (pkey ossl.EVP_PKEY_PTR, err err
 func newDSA3(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
 	checkMajorVersion(3)
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 
 	bld.addBigInt(_OSSL_PKEY_PARAM_FFC_P, params.P, false)

--- a/ecdh.go
+++ b/ecdh.go
@@ -204,10 +204,7 @@ func newECDHPkey1(nid int32, bytes []byte, isPrivate bool) (pkey ossl.EVP_PKEY_P
 func newECDHPkey3(nid int32, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR, error) {
 	checkMajorVersion(3)
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
 	var selection int32

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -199,10 +199,7 @@ func newECDSAKey3(nid int32, bx, by, bd ossl.BIGNUM_PTR) (ossl.EVP_PKEY_PTR, err
 		return nil, err
 	}
 	// Construct the parameters.
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 	bld.addUTF8String(_OSSL_PKEY_PARAM_GROUP_NAME, ossl.OBJ_nid2sn(nid), 0)
 	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubBytes)

--- a/hkdf.go
+++ b/hkdf.go
@@ -343,10 +343,8 @@ func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey [
 		}
 	}()
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return ctx, err
-	}
+	bld := newParamBuilder()
+	defer bld.finalize()
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY))
 	bld.addOctetString(_OSSL_KDF_PARAM_PREFIX, []byte("tls13 "))
@@ -399,10 +397,8 @@ func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, 
 		}
 	}()
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return ctx, err
-	}
+	bld := newParamBuilder()
+	defer bld.finalize()
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
 	if len(secret) > 0 {

--- a/hmac.go
+++ b/hmac.go
@@ -96,10 +96,7 @@ var fetchHMAC3 = sync.OnceValue(func() ossl.EVP_MAC_PTR {
 })
 
 func buildHMAC3Params(md ossl.EVP_MD_PTR) (ossl.OSSL_PARAM_PTR, error) {
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 	bld.addUTF8String(_OSSL_MAC_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	return bld.build()

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -389,7 +389,7 @@ int EVP_MAC_final(_EVP_MAC_CTX_PTR ctx, unsigned char *out, size_t *outl, size_t
 // OSSL_PARAM API
 void OSSL_PARAM_free(_OSSL_PARAM_PTR p) __attribute__((tag("3")));
 const _OSSL_PARAM_PTR OSSL_PARAM_locate_const(const _OSSL_PARAM_PTR p, const char *key) __attribute__((tag("3")));
-_OSSL_PARAM_BLD_PTR OSSL_PARAM_BLD_new(void) __attribute__((tag("3")));
+_OSSL_PARAM_BLD_PTR OSSL_PARAM_BLD_new(void) __attribute__((tag("3"),noerror));
 void OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR bld) __attribute__((tag("3")));
 _OSSL_PARAM_PTR OSSL_PARAM_BLD_to_param(_OSSL_PARAM_BLD_PTR bld) __attribute__((tag("3")));
 int OSSL_PARAM_BLD_push_utf8_string(_OSSL_PARAM_BLD_PTR bld, const char *key, const char *buf, size_t bsize) __attribute__((tag("3"),slice("buf","bsize")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -1930,10 +1930,8 @@ void _mkcgo_OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR _arg0) {
 	_g_OSSL_PARAM_BLD_free(_arg0);
 }
 
-_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(uintptr_t *_err_state) {
-	_OSSL_PARAM_BLD_PTR _ret = _g_OSSL_PARAM_BLD_new();
-	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
-	return _ret;
+_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(void) {
+	return _g_OSSL_PARAM_BLD_new();
 }
 
 int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR _arg0, const char* _arg1, const _BIGNUM_PTR _arg2, uintptr_t *_err_state) {

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -336,7 +336,7 @@ unsigned int _mkcgo_OPENSSL_version_major(void);
 unsigned int _mkcgo_OPENSSL_version_minor(void);
 unsigned int _mkcgo_OPENSSL_version_patch(void);
 void _mkcgo_OSSL_PARAM_BLD_free(_OSSL_PARAM_BLD_PTR);
-_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(uintptr_t *);
+_OSSL_PARAM_BLD_PTR _mkcgo_OSSL_PARAM_BLD_new(void);
 int _mkcgo_OSSL_PARAM_BLD_push_BN(_OSSL_PARAM_BLD_PTR, const char*, const _BIGNUM_PTR, uintptr_t *);
 int _mkcgo_OSSL_PARAM_BLD_push_int32(_OSSL_PARAM_BLD_PTR, const char*, int32_t, uintptr_t *);
 int _mkcgo_OSSL_PARAM_BLD_push_octet_string(_OSSL_PARAM_BLD_PTR, const char*, const unsigned char*, size_t, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -1363,10 +1363,8 @@ func OSSL_PARAM_BLD_free(bld OSSL_PARAM_BLD_PTR) {
 	C._mkcgo_OSSL_PARAM_BLD_free(bld)
 }
 
-func OSSL_PARAM_BLD_new() (OSSL_PARAM_BLD_PTR, error) {
-	var _err C.uintptr_t
-	_ret := C._mkcgo_OSSL_PARAM_BLD_new(mkcgoNoEscape(&_err))
-	return _ret, newMkcgoErr("OSSL_PARAM_BLD_new", uintptr(_err))
+func OSSL_PARAM_BLD_new() OSSL_PARAM_BLD_PTR {
+	return C._mkcgo_OSSL_PARAM_BLD_new()
 }
 
 func OSSL_PARAM_BLD_push_BN(bld OSSL_PARAM_BLD_PTR, key *byte, bn BIGNUM_PTR) (int32, error) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -1716,10 +1716,9 @@ func OSSL_PARAM_BLD_free(bld OSSL_PARAM_BLD_PTR) {
 
 var _mkcgo_OSSL_PARAM_BLD_new uintptr
 
-func OSSL_PARAM_BLD_new() (OSSL_PARAM_BLD_PTR, error) {
-	var _err uintptr
-	r0, _ := syscallN(1, _mkcgo_OSSL_PARAM_BLD_new, uintptr(unsafe.Pointer(&_err)))
-	return OSSL_PARAM_BLD_PTR(r0), newMkcgoErr("OSSL_PARAM_BLD_new", _err)
+func OSSL_PARAM_BLD_new() OSSL_PARAM_BLD_PTR {
+	r0, _ := syscallN(0, _mkcgo_OSSL_PARAM_BLD_new)
+	return OSSL_PARAM_BLD_PTR(r0)
 }
 
 var _mkcgo_OSSL_PARAM_BLD_push_BN uintptr

--- a/mlkem.go
+++ b/mlkem.go
@@ -308,10 +308,7 @@ func createMLKEMPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 		return nil, errors.New("mlkem: invalid seed size")
 	}
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 
 	bld.addOctetString(_OSSL_PKEY_PARAM_ML_KEM_SEED, seed)
@@ -327,10 +324,7 @@ func createMLKEMPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
 
 // createMLKEMPublicKey creates an ML-KEM public key from encoded bytes.
 func createMLKEMPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 
 	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubKeyBytes)

--- a/params.go
+++ b/params.go
@@ -40,7 +40,7 @@ type paramBuilder struct {
 func newParamBuilder() *paramBuilder {
 	bld := ossl.OSSL_PARAM_BLD_new()
 	if bld == nil {
-		// If this happens it indicated an issue allocating memory.
+		// If this happens it indicates an issue allocating memory.
 		panic("openssl: failed to create OSSL_PARAM_BLD")
 	}
 	return &paramBuilder{bld: bld}

--- a/params.go
+++ b/params.go
@@ -36,17 +36,14 @@ type paramBuilder struct {
 }
 
 // newParamBuilder creates a new paramBuilder.
-func newParamBuilder() (*paramBuilder, error) {
-	bld, err := ossl.OSSL_PARAM_BLD_new()
-	if err != nil {
-		return nil, err
+// [paramBuilder.finalize] must be called to free the builder.
+func newParamBuilder() *paramBuilder {
+	bld := ossl.OSSL_PARAM_BLD_new()
+	if bld == nil {
+		// If this happens it indicated an issue allocating memory.
+		panic("openssl: failed to create OSSL_PARAM_BLD")
 	}
-	pb := &paramBuilder{
-		bld:      bld,
-		bnToFree: make([]bnParam, 0, 8), // the maximum known number of BIGNUMs to free are 8 for RSA
-	}
-	runtime.SetFinalizer(pb, (*paramBuilder).finalize)
-	return pb, nil
+	return &paramBuilder{bld: bld}
 }
 
 // finalize frees the builder.
@@ -156,27 +153,6 @@ func (b *paramBuilder) addBN(name cString, value ossl.BIGNUM_PTR) {
 	}
 }
 
-// addBin adds a byte slice to the builder.
-// The slice is converted to a BIGNUM using BN_bin2bn and freed when the builder is finalized.
-// If private is true, the BIGNUM will be cleared with BN_clear_free,
-// otherwise it will be freed with BN_free.
-func (b *paramBuilder) addBin(name cString, value []byte, private bool) {
-	if !b.check() {
-		return
-	}
-	if len(value) == 0 {
-		// Nothing to do.
-		return
-	}
-	bn, err := ossl.BN_bin2bn(value, nil)
-	if err != nil {
-		b.err = err
-		return
-	}
-	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
-	b.addBN(name, bn)
-}
-
 // addBigInt adds a BigInt to the builder.
 // The BigInt is converted using bigToBN to a BIGNUM that is freed when the builder is finalized.
 // If private is true, the BIGNUM will be cleared with BN_clear_free,
@@ -193,6 +169,11 @@ func (b *paramBuilder) addBigInt(name cString, value BigInt, private bool) {
 	if err != nil {
 		b.err = err
 		return
+	}
+	if b.bnToFree == nil {
+		// Preallocate the slice to avoid growing it later, which would cause allocations and copies.
+		// The maximum known number of BIGNUMs to free are 8 for RSA, so we use that as the capacity.
+		b.bnToFree = make([]bnParam, 0, 8)
 	}
 	b.bnToFree = append(b.bnToFree, bnParam{bn, private})
 	b.addBN(name, bn)

--- a/rsa.go
+++ b/rsa.go
@@ -324,10 +324,7 @@ func HashVerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, msg, sig []byte) er
 }
 
 func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (ossl.EVP_PKEY_PTR, error) {
-	bld, err := newParamBuilder()
-	if err != nil {
-		return nil, err
-	}
+	bld := newParamBuilder()
 	defer bld.finalize()
 
 	bld.addBigInt(_OSSL_PKEY_PARAM_RSA_N, n, false)

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -137,10 +137,8 @@ func tls1PRF3(result, secret, label, seed []byte, md ossl.EVP_MD_PTR) error {
 	}
 	defer ossl.EVP_KDF_CTX_free(ctx)
 
-	bld, err := newParamBuilder()
-	if err != nil {
-		return err
-	}
+	bld := newParamBuilder()
+	defer bld.finalize()
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addOctetString(_OSSL_KDF_PARAM_SECRET, secret)
 	bld.addOctetString(_OSSL_KDF_PARAM_SEED, label)


### PR DESCRIPTION
Using `newParamBuilder` introduces two heap allocations. These are avoidable if the function can be inlined and the big number array is only allocated when necessary.

Example of improvements when calling `openssl.NewHMAC`:

```
qmuntaldiaz@Quims-MacBook-Pro go-openssl % benchstat old.txt new.txt                                                  
goos: darwin
goarch: arm64
pkg: github.com/golang-fips/openssl/v2
cpu: Apple M3 Pro
                   │   old.txt   │              new.txt              │
                   │   sec/op    │   sec/op     vs base              │
HMACNewWriteSum-12   1.850µ ± 9%   1.731µ ± 2%  -6.43% (p=0.001 n=7)

                   │   old.txt    │              new.txt               │
                   │     B/s      │     B/s       vs base              │
HMACNewWriteSum-12   16.49Mi ± 8%   17.63Mi ± 2%  +6.94% (p=0.001 n=7)

                   │  old.txt   │              new.txt              │
                   │    B/op    │    B/op     vs base               │
HMACNewWriteSum-12   640.0 ± 0%   448.0 ± 0%  -30.00% (p=0.001 n=7)

                   │  old.txt   │              new.txt              │
                   │ allocs/op  │ allocs/op   vs base               │
HMACNewWriteSum-12   5.000 ± 0%   3.000 ± 0%  -40.00% (p=0.001 n=7)
```