### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/benchcheck/check.go
+++ b/.github/benchcheck/check.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/perf/benchfmt"
+	"golang.org/x/perf/benchmath"
+)
+
+type benchKey struct {
+	Name string
+	Unit string
+}
+
+type config struct {
+	TimeThreshold float64 // minimum sec/op regression percentage
+	MinTime       float64 // minimum base time in seconds
+	Alpha         float64 // significance level
+}
+
+type regression struct {
+	Name      string
+	Unit      string
+	PctChange float64
+	PValue    float64
+	BaseVal   float64
+}
+
+func cmdCheck(args []string) {
+	fs := flag.NewFlagSet("check", flag.ExitOnError)
+	timeThreshold := fs.Float64("time-threshold", 5, "minimum sec/op regression percentage to flag")
+	minTime := fs.Duration("min-time", time.Microsecond, "minimum base time for sec/op checks")
+	alpha := fs.Float64("alpha", 0.05, "significance level for statistical tests")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: benchcheck check [flags] base.txt head.txt\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+	fs.Parse(args)
+
+	if fs.NArg() != 2 {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	cfg := config{
+		TimeThreshold: *timeThreshold,
+		MinTime:       minTime.Seconds(),
+		Alpha:         *alpha,
+	}
+
+	basePath, headPath := fs.Arg(0), fs.Arg(1)
+
+	// Extract test failures from both files.
+	var failureLines []string
+	if lines, err := extractFailuresFromFile(basePath, "base: "); err == nil {
+		failureLines = append(failureLines, lines...)
+	}
+	if lines, err := extractFailuresFromFile(headPath, "head: "); err == nil {
+		failureLines = append(failureLines, lines...)
+	}
+	hasFailures := len(failureLines) > 0
+
+	// Parse benchmarks and check regressions.
+	baseValues := parseBenchmarksFromFile(basePath)
+	headValues := parseBenchmarksFromFile(headPath)
+	regressions := checkRegressions(baseValues, headValues, cfg)
+	hasRegressions := len(regressions) > 0
+
+	// Sort regressions by percentage descending.
+	sort.Slice(regressions, func(i, j int) bool {
+		return regressions[i].PctChange > regressions[j].PctChange
+	})
+
+	// Write regressions.txt.
+	var regressionLines []string
+	for _, r := range regressions {
+		if isAllocUnit(r.Unit) {
+			regressionLines = append(regressionLines, fmt.Sprintf("alloc regression: %s [%s] +%.2f%% (p=%.3f)", r.Name, r.Unit, r.PctChange, r.PValue))
+		} else {
+			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec)", r.Name, r.PctChange, r.PValue, r.BaseVal))
+		}
+	}
+	writeLines("regressions.txt", regressionLines)
+	writeLines("failures.txt", failureLines)
+
+	// Write status.txt.
+	writeStatus("status.txt", hasRegressions, hasFailures)
+
+	// Print summary with GitHub Actions annotations.
+	if hasRegressions {
+		fmt.Println("::error::Benchmark regression detected — see benchstat output above for details.")
+		fmt.Println()
+		fmt.Println("=== Regressions ===")
+		for _, line := range regressionLines {
+			fmt.Println(line)
+		}
+	}
+	if hasFailures {
+		fmt.Println("::error::Test failure detected — see the 'Run benchmarks' steps for details.")
+		fmt.Println()
+		fmt.Println("=== Test failures ===")
+		for _, line := range failureLines {
+			fmt.Println(line)
+		}
+	}
+	if !hasRegressions && !hasFailures {
+		fmt.Println("No benchmark regressions or test failures detected.")
+	}
+	if hasRegressions || hasFailures {
+		os.Exit(1)
+	}
+}
+
+func extractFailuresFromFile(path, prefix string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return extractFailures(f, prefix), nil
+}
+
+// extractFailures parses go test output and returns lines related to
+// build errors, test failures, and crash traces.
+func extractFailures(r io.Reader, prefix string) []string {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	inCrash := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "# "):
+			lines = append(lines, prefix+line)
+		case strings.HasPrefix(line, "--- FAIL"):
+			lines = append(lines, prefix+line)
+		case strings.HasPrefix(line, "FAIL\t"):
+			lines = append(lines, prefix+line)
+		case !inCrash && isCrashLine(line):
+			inCrash = true
+			lines = append(lines, prefix+line)
+		case inCrash && line == "":
+			inCrash = false
+			lines = append(lines, "")
+		case inCrash:
+			lines = append(lines, prefix+line)
+		}
+	}
+	return lines
+}
+
+// isCrashLine returns true for signal or panic lines (e.g. "SIGSEGV:", "panic:").
+func isCrashLine(line string) bool {
+	if strings.HasPrefix(line, "panic:") {
+		return true
+	}
+	if !strings.HasPrefix(line, "SIG") {
+		return false
+	}
+	// Match SIG followed by uppercase letters then ':'.
+	i := 3
+	for i < len(line) && line[i] >= 'A' && line[i] <= 'Z' {
+		i++
+	}
+	return i > 3 && i < len(line) && line[i] == ':'
+}
+
+func parseBenchmarksFromFile(path string) map[benchKey][]float64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	return parseBenchmarks(f, path)
+}
+
+func parseBenchmarks(r io.Reader, name string) map[benchKey][]float64 {
+	result := make(map[benchKey][]float64)
+	reader := benchfmt.NewReader(r, name)
+	for reader.Scan() {
+		rec := reader.Result()
+		res, ok := rec.(*benchfmt.Result)
+		if !ok {
+			continue
+		}
+		benchName := res.Name.String()
+		for _, v := range res.Values {
+			key := benchKey{Name: benchName, Unit: v.Unit}
+			result[key] = append(result[key], v.Value)
+		}
+	}
+	return result
+}
+
+func checkRegressions(base, head map[benchKey][]float64, cfg config) []regression {
+	thresholds := &benchmath.Thresholds{CompareAlpha: cfg.Alpha}
+	var regressions []regression
+
+	for key, baseVals := range base {
+		headVals, ok := head[key]
+		if !ok {
+			continue
+		}
+
+		baseSample := benchmath.NewSample(baseVals, thresholds)
+		headSample := benchmath.NewSample(headVals, thresholds)
+
+		cmp := benchmath.AssumeNothing.Compare(baseSample, headSample)
+		if cmp.P >= cmp.Alpha {
+			continue // not statistically significant
+		}
+
+		baseSummary := benchmath.AssumeNothing.Summary(baseSample, 0.95)
+		headSummary := benchmath.AssumeNothing.Summary(headSample, 0.95)
+
+		if headSummary.Center <= baseSummary.Center {
+			continue // improvement or same
+		}
+
+		if baseSummary.Center == 0 {
+			// Base is zero; only flag allocation units (sec/op can't be 0 meaningfully).
+			if isAllocUnit(key.Unit) {
+				regressions = append(regressions, regression{
+					Name:      key.Name,
+					Unit:      key.Unit,
+					PctChange: 100, // 0 → non-zero
+					PValue:    cmp.P,
+				})
+			}
+			continue
+		}
+
+		pctChange := (headSummary.Center - baseSummary.Center) / baseSummary.Center * 100
+
+		switch {
+		case isAllocUnit(key.Unit):
+			regressions = append(regressions, regression{
+				Name:      key.Name,
+				Unit:      key.Unit,
+				PctChange: pctChange,
+				PValue:    cmp.P,
+			})
+		case key.Unit == "sec/op":
+			if baseSummary.Center >= cfg.MinTime && pctChange >= cfg.TimeThreshold {
+				regressions = append(regressions, regression{
+					Name:      key.Name,
+					Unit:      key.Unit,
+					PctChange: pctChange,
+					PValue:    cmp.P,
+					BaseVal:   baseSummary.Center,
+				})
+			}
+		}
+	}
+
+	return regressions
+}
+
+func isAllocUnit(unit string) bool {
+	return unit == "B/op" || unit == "allocs/op"
+}
+
+func writeLines(path string, lines []string) {
+	if len(lines) == 0 {
+		// Write an empty file so the artifact upload doesn't skip it.
+		os.WriteFile(path, nil, 0o644)
+		return
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "writing %s: %v\n", path, err)
+		return
+	}
+	defer f.Close()
+	for _, line := range lines {
+		fmt.Fprintln(f, line)
+	}
+}
+
+func writeStatus(path string, regression, failures bool) {
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "writing %s: %v\n", path, err)
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "regression=%v\n", regression)
+	fmt.Fprintf(f, "test_failures=%v\n", failures)
+}

--- a/.github/benchcheck/check.go
+++ b/.github/benchcheck/check.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -38,8 +39,23 @@ func cmdCheck(args []string) {
 	timeThreshold := fs.Float64("time-threshold", 5, "minimum sec/op regression percentage to flag")
 	minTime := fs.Duration("min-time", time.Microsecond, "minimum base time for sec/op checks")
 	alpha := fs.Float64("alpha", 0.05, "significance level for statistical tests")
+	regressionsOut := fs.String("o-regressions", "regressions.txt", "output file for regression details")
+	failuresOut := fs.String("o-failures", "failures.txt", "output file for test failure details")
+	statusOut := fs.String("o-status", "status.json", "output file for machine-readable status (JSON)")
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: benchcheck check [flags] base.txt head.txt\n\nFlags:\n")
+		fmt.Fprintf(os.Stderr, `usage: benchcheck check [flags] base.txt head.txt
+
+Compare base and head benchmark results, detect regressions and test failures.
+
+Writes the following output files (paths configurable via flags):
+  regressions.txt  One-line summary per detected regression.
+  failures.txt     Extracted build errors, test failures, and crash traces.
+  status.json      Machine-readable JSON status for the report subcommand.
+
+Exits 0 if no issues are found, 1 if regressions or failures are detected.
+
+Flags:
+`)
 		fs.PrintDefaults()
 	}
 	fs.Parse(args)
@@ -59,11 +75,12 @@ func cmdCheck(args []string) {
 
 	// Extract test failures from both files.
 	var failureLines []string
-	if lines, err := extractFailuresFromFile(basePath, "base: "); err == nil {
-		failureLines = append(failureLines, lines...)
+	var err error
+	if failureLines, err = appendFailuresFromFile(failureLines, basePath, "base: "); err != nil {
+		fmt.Fprintf(os.Stderr, "reading %s: %v\n", basePath, err)
 	}
-	if lines, err := extractFailuresFromFile(headPath, "head: "); err == nil {
-		failureLines = append(failureLines, lines...)
+	if failureLines, err = appendFailuresFromFile(failureLines, headPath, "head: "); err != nil {
+		fmt.Fprintf(os.Stderr, "reading %s: %v\n", headPath, err)
 	}
 	hasFailures := len(failureLines) > 0
 
@@ -87,11 +104,11 @@ func cmdCheck(args []string) {
 			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec)", r.Name, r.PctChange, r.PValue, r.BaseVal))
 		}
 	}
-	writeLines("regressions.txt", regressionLines)
-	writeLines("failures.txt", failureLines)
+	writeLines(*regressionsOut, regressionLines)
+	writeLines(*failuresOut, failureLines)
 
-	// Write status.txt.
-	writeStatus("status.txt", hasRegressions, hasFailures)
+	// Write status.json.
+	writeStatus(*statusOut, hasRegressions, hasFailures)
 
 	// Print summary with GitHub Actions annotations.
 	if hasRegressions {
@@ -118,18 +135,19 @@ func cmdCheck(args []string) {
 	}
 }
 
-func extractFailuresFromFile(path, prefix string) ([]string, error) {
+func appendFailuresFromFile(lines []string, path, prefix string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return lines, err
 	}
 	defer f.Close()
-	return extractFailures(f, prefix), nil
+	result, err := extractFailures(f, prefix)
+	return append(lines, result...), err
 }
 
 // extractFailures parses go test output and returns lines related to
 // build errors, test failures, and crash traces.
-func extractFailures(r io.Reader, prefix string) []string {
+func extractFailures(r io.Reader, prefix string) ([]string, error) {
 	var lines []string
 	scanner := bufio.NewScanner(r)
 	inCrash := false
@@ -152,7 +170,7 @@ func extractFailures(r io.Reader, prefix string) []string {
 			lines = append(lines, prefix+line)
 		}
 	}
-	return lines
+	return lines, scanner.Err()
 }
 
 // isCrashLine returns true for signal or panic lines (e.g. "SIGSEGV:", "panic:").
@@ -267,29 +285,30 @@ func isAllocUnit(unit string) bool {
 }
 
 func writeLines(path string, lines []string) {
+	data := []byte(strings.Join(lines, "\n") + "\n")
 	if len(lines) == 0 {
-		// Write an empty file so the artifact upload doesn't skip it.
-		os.WriteFile(path, nil, 0o644)
-		return
+		data = nil
 	}
-	f, err := os.Create(path)
-	if err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "writing %s: %v\n", path, err)
-		return
-	}
-	defer f.Close()
-	for _, line := range lines {
-		fmt.Fprintln(f, line)
 	}
 }
 
+// Status is the machine-readable status written by check and read by report.
+type Status struct {
+	Regression     bool `json:"regression"`
+	TestFailures   bool `json:"test_failures"`
+	BenchmarkError bool `json:"benchmark_error"`
+}
+
 func writeStatus(path string, regression, failures bool) {
-	f, err := os.Create(path)
+	s := Status{Regression: regression, TestFailures: failures}
+	data, err := json.Marshal(s)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "writing %s: %v\n", path, err)
+		fmt.Fprintf(os.Stderr, "marshaling status: %v\n", err)
 		return
 	}
-	defer f.Close()
-	fmt.Fprintf(f, "regression=%v\n", regression)
-	fmt.Fprintf(f, "test_failures=%v\n", failures)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "writing %s: %v\n", path, err)
+	}
 }

--- a/.github/benchcheck/go.mod
+++ b/.github/benchcheck/go.mod
@@ -1,0 +1,7 @@
+module github.com/golang-fips/openssl/benchcheck
+
+go 1.25.0
+
+require golang.org/x/perf v0.0.0-20260211190930-8161c38c6cdc
+
+require github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect

--- a/.github/benchcheck/go.sum
+++ b/.github/benchcheck/go.sum
@@ -1,0 +1,4 @@
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
+golang.org/x/perf v0.0.0-20260211190930-8161c38c6cdc h1:sIFroTtzaCeprqS7v3ElN+EmHd/s6c1csQ9AcPq/zWU=
+golang.org/x/perf v0.0.0-20260211190930-8161c38c6cdc/go.mod h1:z/K43VgoJkBLXbImpHAD2mvxECFj2bgN5phU37hHDoA=

--- a/.github/benchcheck/main.go
+++ b/.github/benchcheck/main.go
@@ -1,0 +1,181 @@
+// benchcheck reads two Go benchmark result files and detects regressions.
+//
+// Usage: benchcheck [flags] base.txt head.txt
+//
+// It prints "true" to stdout if any regressions are found, "false" otherwise.
+// Regression details are printed to stderr.
+//
+// Regression rules:
+//   - B/op or allocs/op: any statistically significant increase.
+//   - sec/op: statistically significant increase >= threshold,
+//     but only for benchmarks whose base time >= min-time.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/perf/benchfmt"
+	"golang.org/x/perf/benchmath"
+)
+
+var (
+	timeThreshold = flag.Float64("time-threshold", 5, "minimum sec/op regression percentage to flag")
+	minTime       = flag.Duration("min-time", time.Microsecond, "minimum base time for sec/op checks")
+	alpha         = flag.Float64("alpha", 0.05, "significance level for statistical tests")
+)
+
+type benchKey struct {
+	Name string
+	Unit string
+}
+
+type config struct {
+	TimeThreshold float64 // minimum sec/op regression percentage
+	MinTime       float64 // minimum base time in seconds
+	Alpha         float64 // significance level
+}
+
+type regression struct {
+	Name      string
+	Unit      string
+	PctChange float64
+	PValue    float64
+	BaseVal   float64
+}
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 2 {
+		fmt.Fprintf(os.Stderr, "usage: benchcheck [flags] base.txt head.txt\n")
+		os.Exit(2)
+	}
+
+	cfg := config{
+		TimeThreshold: *timeThreshold,
+		MinTime:       minTime.Seconds(),
+		Alpha:         *alpha,
+	}
+
+	baseFile, err := os.Open(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading base: %v\n", err)
+		os.Exit(1)
+	}
+	defer baseFile.Close()
+	baseValues := parseBenchmarks(baseFile, flag.Arg(0))
+
+	headFile, err := os.Open(flag.Arg(1))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading head: %v\n", err)
+		os.Exit(1)
+	}
+	defer headFile.Close()
+	headValues := parseBenchmarks(headFile, flag.Arg(1))
+
+	regressions := checkRegressions(baseValues, headValues, cfg)
+	for _, r := range regressions {
+		if isAllocUnit(r.Unit) {
+			fmt.Fprintf(os.Stderr, "alloc regression: %s [%s] +%.2f%% (p=%.3f)\n",
+				r.Name, r.Unit, r.PctChange, r.PValue)
+		} else {
+			fmt.Fprintf(os.Stderr, "time regression: %s +%.2f%% (p=%.3f, base=%.2g sec)\n",
+				r.Name, r.PctChange, r.PValue, r.BaseVal)
+		}
+	}
+
+	if len(regressions) > 0 {
+		fmt.Println("true")
+	} else {
+		fmt.Println("false")
+	}
+}
+
+func parseBenchmarks(r io.Reader, name string) map[benchKey][]float64 {
+	result := make(map[benchKey][]float64)
+	reader := benchfmt.NewReader(r, name)
+	for reader.Scan() {
+		rec := reader.Result()
+		res, ok := rec.(*benchfmt.Result)
+		if !ok {
+			continue
+		}
+		benchName := res.Name.String()
+		for _, v := range res.Values {
+			key := benchKey{Name: benchName, Unit: v.Unit}
+			result[key] = append(result[key], v.Value)
+		}
+	}
+	return result
+}
+
+func checkRegressions(base, head map[benchKey][]float64, cfg config) []regression {
+	thresholds := &benchmath.Thresholds{CompareAlpha: cfg.Alpha}
+	var regressions []regression
+
+	for key, baseVals := range base {
+		headVals, ok := head[key]
+		if !ok {
+			continue
+		}
+
+		baseSample := benchmath.NewSample(baseVals, thresholds)
+		headSample := benchmath.NewSample(headVals, thresholds)
+
+		cmp := benchmath.AssumeNothing.Compare(baseSample, headSample)
+		if cmp.P >= cmp.Alpha {
+			continue // not statistically significant
+		}
+
+		baseSummary := benchmath.AssumeNothing.Summary(baseSample, 0.95)
+		headSummary := benchmath.AssumeNothing.Summary(headSample, 0.95)
+
+		if headSummary.Center <= baseSummary.Center {
+			continue // improvement or same
+		}
+
+		if baseSummary.Center == 0 {
+			// Base is zero; only flag allocation units (sec/op can't be 0 meaningfully).
+			if isAllocUnit(key.Unit) {
+				regressions = append(regressions, regression{
+					Name:      key.Name,
+					Unit:      key.Unit,
+					PctChange: 100, // 0 → non-zero
+					PValue:    cmp.P,
+				})
+			}
+			continue
+		}
+
+		pctChange := (headSummary.Center - baseSummary.Center) / baseSummary.Center * 100
+
+		switch {
+		case isAllocUnit(key.Unit):
+			regressions = append(regressions, regression{
+				Name:      key.Name,
+				Unit:      key.Unit,
+				PctChange: pctChange,
+				PValue:    cmp.P,
+			})
+		case key.Unit == "sec/op":
+			if baseSummary.Center >= cfg.MinTime && pctChange >= cfg.TimeThreshold {
+				regressions = append(regressions, regression{
+					Name:      key.Name,
+					Unit:      key.Unit,
+					PctChange: pctChange,
+					PValue:    cmp.P,
+					BaseVal:   baseSummary.Center,
+				})
+			}
+		}
+	}
+
+	return regressions
+}
+
+func isAllocUnit(unit string) bool {
+	return unit == "B/op" || unit == "allocs/op"
+}

--- a/.github/benchcheck/main.go
+++ b/.github/benchcheck/main.go
@@ -1,181 +1,37 @@
-// benchcheck reads two Go benchmark result files and detects regressions.
+// benchcheck is a tool for analyzing Go benchmark results in CI.
 //
-// Usage: benchcheck [flags] base.txt head.txt
+// Commands:
 //
-// It prints "true" to stdout if any regressions are found, "false" otherwise.
-// Regression details are printed to stderr.
-//
-// Regression rules:
-//   - B/op or allocs/op: any statistically significant increase.
-//   - sec/op: statistically significant increase >= threshold,
-//     but only for benchmarks whose base time >= min-time.
+//	benchcheck check [flags] base.txt head.txt
+//	benchcheck report [flags] results-dir
 package main
 
 import (
-	"flag"
 	"fmt"
-	"io"
 	"os"
-	"time"
-
-	"golang.org/x/perf/benchfmt"
-	"golang.org/x/perf/benchmath"
 )
 
-var (
-	timeThreshold = flag.Float64("time-threshold", 5, "minimum sec/op regression percentage to flag")
-	minTime       = flag.Duration("min-time", time.Microsecond, "minimum base time for sec/op checks")
-	alpha         = flag.Float64("alpha", 0.05, "significance level for statistical tests")
-)
-
-type benchKey struct {
-	Name string
-	Unit string
-}
-
-type config struct {
-	TimeThreshold float64 // minimum sec/op regression percentage
-	MinTime       float64 // minimum base time in seconds
-	Alpha         float64 // significance level
-}
-
-type regression struct {
-	Name      string
-	Unit      string
-	PctChange float64
-	PValue    float64
-	BaseVal   float64
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: benchcheck <command> [flags] [args]\n\n")
+	fmt.Fprintf(os.Stderr, "Commands:\n")
+	fmt.Fprintf(os.Stderr, "  check   Compare benchmarks, detect regressions and test failures\n")
+	fmt.Fprintf(os.Stderr, "  report  Build a markdown report from benchmark artifacts\n")
+	os.Exit(2)
 }
 
 func main() {
-	flag.Parse()
-	if flag.NArg() != 2 {
-		fmt.Fprintf(os.Stderr, "usage: benchcheck [flags] base.txt head.txt\n")
-		os.Exit(2)
+	if len(os.Args) < 2 {
+		usage()
 	}
-
-	cfg := config{
-		TimeThreshold: *timeThreshold,
-		MinTime:       minTime.Seconds(),
-		Alpha:         *alpha,
+	switch os.Args[1] {
+	case "check":
+		cmdCheck(os.Args[2:])
+	case "report":
+		cmdReport(os.Args[2:])
+	case "-h", "-help", "--help", "help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1])
+		usage()
 	}
-
-	baseFile, err := os.Open(flag.Arg(0))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "reading base: %v\n", err)
-		os.Exit(1)
-	}
-	defer baseFile.Close()
-	baseValues := parseBenchmarks(baseFile, flag.Arg(0))
-
-	headFile, err := os.Open(flag.Arg(1))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "reading head: %v\n", err)
-		os.Exit(1)
-	}
-	defer headFile.Close()
-	headValues := parseBenchmarks(headFile, flag.Arg(1))
-
-	regressions := checkRegressions(baseValues, headValues, cfg)
-	for _, r := range regressions {
-		if isAllocUnit(r.Unit) {
-			fmt.Fprintf(os.Stderr, "alloc regression: %s [%s] +%.2f%% (p=%.3f)\n",
-				r.Name, r.Unit, r.PctChange, r.PValue)
-		} else {
-			fmt.Fprintf(os.Stderr, "time regression: %s +%.2f%% (p=%.3f, base=%.2g sec)\n",
-				r.Name, r.PctChange, r.PValue, r.BaseVal)
-		}
-	}
-
-	if len(regressions) > 0 {
-		fmt.Println("true")
-	} else {
-		fmt.Println("false")
-	}
-}
-
-func parseBenchmarks(r io.Reader, name string) map[benchKey][]float64 {
-	result := make(map[benchKey][]float64)
-	reader := benchfmt.NewReader(r, name)
-	for reader.Scan() {
-		rec := reader.Result()
-		res, ok := rec.(*benchfmt.Result)
-		if !ok {
-			continue
-		}
-		benchName := res.Name.String()
-		for _, v := range res.Values {
-			key := benchKey{Name: benchName, Unit: v.Unit}
-			result[key] = append(result[key], v.Value)
-		}
-	}
-	return result
-}
-
-func checkRegressions(base, head map[benchKey][]float64, cfg config) []regression {
-	thresholds := &benchmath.Thresholds{CompareAlpha: cfg.Alpha}
-	var regressions []regression
-
-	for key, baseVals := range base {
-		headVals, ok := head[key]
-		if !ok {
-			continue
-		}
-
-		baseSample := benchmath.NewSample(baseVals, thresholds)
-		headSample := benchmath.NewSample(headVals, thresholds)
-
-		cmp := benchmath.AssumeNothing.Compare(baseSample, headSample)
-		if cmp.P >= cmp.Alpha {
-			continue // not statistically significant
-		}
-
-		baseSummary := benchmath.AssumeNothing.Summary(baseSample, 0.95)
-		headSummary := benchmath.AssumeNothing.Summary(headSample, 0.95)
-
-		if headSummary.Center <= baseSummary.Center {
-			continue // improvement or same
-		}
-
-		if baseSummary.Center == 0 {
-			// Base is zero; only flag allocation units (sec/op can't be 0 meaningfully).
-			if isAllocUnit(key.Unit) {
-				regressions = append(regressions, regression{
-					Name:      key.Name,
-					Unit:      key.Unit,
-					PctChange: 100, // 0 → non-zero
-					PValue:    cmp.P,
-				})
-			}
-			continue
-		}
-
-		pctChange := (headSummary.Center - baseSummary.Center) / baseSummary.Center * 100
-
-		switch {
-		case isAllocUnit(key.Unit):
-			regressions = append(regressions, regression{
-				Name:      key.Name,
-				Unit:      key.Unit,
-				PctChange: pctChange,
-				PValue:    cmp.P,
-			})
-		case key.Unit == "sec/op":
-			if baseSummary.Center >= cfg.MinTime && pctChange >= cfg.TimeThreshold {
-				regressions = append(regressions, regression{
-					Name:      key.Name,
-					Unit:      key.Unit,
-					PctChange: pctChange,
-					PValue:    cmp.P,
-					BaseVal:   baseSummary.Center,
-				})
-			}
-		}
-	}
-
-	return regressions
-}
-
-func isAllocUnit(unit string) bool {
-	return unit == "B/op" || unit == "allocs/op"
 }

--- a/.github/benchcheck/main_test.go
+++ b/.github/benchcheck/main_test.go
@@ -174,3 +174,89 @@ func TestParseBenchmarks(t *testing.T) {
 		t.Fatalf("expected 2 B/op values for SHA256, got %d", len(sha256Alloc))
 	}
 }
+
+func TestExtractFailures_BuildErrors(t *testing.T) {
+	input := "# runtime/cgo\ncgo-gcc-prolog:3:20: error: call to undeclared function\nFAIL\tgithub.com/example [build failed]\n"
+	lines := extractFailures(strings.NewReader(input), "")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "# ") {
+		t.Errorf("expected build error line, got: %s", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "FAIL\t") {
+		t.Errorf("expected FAIL line, got: %s", lines[1])
+	}
+}
+
+func TestExtractFailures_TestFailures(t *testing.T) {
+	input := "--- FAIL: TestFoo (0.01s)\n    foo_test.go:42: expected 1, got 2\nFAIL\tgithub.com/example\t0.123s\n"
+	lines := extractFailures(strings.NewReader(input), "pfx: ")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "pfx: --- FAIL: TestFoo (0.01s)" {
+		t.Errorf("unexpected line: %s", lines[0])
+	}
+	if lines[1] != "pfx: FAIL\tgithub.com/example\t0.123s" {
+		t.Errorf("unexpected line: %s", lines[1])
+	}
+}
+
+func TestExtractFailures_CrashTrace(t *testing.T) {
+	input := "SIGSEGV: segmentation violation\nPC=0x1234\ngoroutine 1 [running]:\nmain.foo()\n\tfile.go:10\n\ngoroutine 2 [sleep]:\ntime.Sleep()\n"
+	lines := extractFailures(strings.NewReader(input), "")
+	// Should capture lines up to and including the blank line, not goroutine 2.
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "goroutine 2") {
+			t.Error("should not capture second goroutine")
+		}
+		if strings.Contains(l, "SIGSEGV") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SIGSEGV line")
+	}
+}
+
+func TestExtractFailures_Panic(t *testing.T) {
+	input := "panic: runtime error: index out of range\ngoroutine 1 [running]:\nmain.foo()\n\n"
+	lines := extractFailures(strings.NewReader(input), "")
+	if len(lines) == 0 {
+		t.Fatal("expected panic lines")
+	}
+	if !strings.HasPrefix(lines[0], "panic:") {
+		t.Errorf("expected panic line, got: %s", lines[0])
+	}
+}
+
+func TestExtractFailures_NoFailures(t *testing.T) {
+	input := "BenchmarkFoo-8\t1000\t1234 ns/op\t56 B/op\t3 allocs/op\nok\tgithub.com/example\t1.234s\n"
+	lines := extractFailures(strings.NewReader(input), "")
+	if len(lines) != 0 {
+		t.Errorf("expected no failures, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestIsCrashLine(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"SIGSEGV: segmentation violation", true},
+		{"SIGABRT: abort", true},
+		{"panic: runtime error", true},
+		{"SIGTERM", false},           // no colon
+		{"SIG: bad", false},          // no uppercase letters between SIG and :
+		{"SIGNATURE: foo", true},     // SIG + uppercase + colon
+		{"something else", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isCrashLine(tt.line); got != tt.want {
+			t.Errorf("isCrashLine(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}

--- a/.github/benchcheck/main_test.go
+++ b/.github/benchcheck/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// benchLines generates n identical benchmark result lines.
+func benchLines(name string, n int, nsPerOp float64, bPerOp, allocsPerOp int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%s\t1\t%.1f ns/op\t%d B/op\t%d allocs/op\n",
+			name, nsPerOp, bPerOp, allocsPerOp)
+	}
+	return b.String()
+}
+
+func parse(t *testing.T, text string) map[benchKey][]float64 {
+	t.Helper()
+	return parseBenchmarks(strings.NewReader(text), "test.txt")
+}
+
+func defaultCfg() config {
+	return config{
+		TimeThreshold: 5,
+		MinTime:       1e-6, // 1µs
+		Alpha:         0.05,
+	}
+}
+
+func TestNoRegression(t *testing.T) {
+	data := benchLines("BenchmarkFoo-8", 10, 5000, 64, 2)
+	base := parse(t, data)
+	head := parse(t, data)
+	regressions := checkRegressions(base, head, defaultCfg())
+	if len(regressions) != 0 {
+		t.Errorf("expected no regressions, got %d: %+v", len(regressions), regressions)
+	}
+}
+
+func TestAllocRegression_BPerOp(t *testing.T) {
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 64, 2))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 128, 2))
+	regressions := checkRegressions(base, head, defaultCfg())
+	found := false
+	for _, r := range regressions {
+		if r.Unit == "B/op" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected B/op regression, got none")
+	}
+}
+
+func TestAllocRegression_AllocsPerOp(t *testing.T) {
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 64, 2))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 64, 4))
+	regressions := checkRegressions(base, head, defaultCfg())
+	found := false
+	for _, r := range regressions {
+		if r.Unit == "allocs/op" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected allocs/op regression, got none")
+	}
+}
+
+func TestTimeRegression_AboveThreshold(t *testing.T) {
+	// 5000 ns = 5µs (above 1µs minimum), 10% regression (above 5% threshold)
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 0, 0))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5500, 0, 0))
+	regressions := checkRegressions(base, head, defaultCfg())
+	found := false
+	for _, r := range regressions {
+		if r.Unit == "sec/op" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected sec/op regression, got none")
+	}
+}
+
+func TestTimeRegression_BelowMinTime(t *testing.T) {
+	// 50 ns (below 1µs minimum) — should NOT flag even with large % increase
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 50, 0, 0))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 100, 0, 0))
+	regressions := checkRegressions(base, head, defaultCfg())
+	for _, r := range regressions {
+		if r.Unit == "sec/op" {
+			t.Errorf("unexpected sec/op regression for sub-µs benchmark: %+v", r)
+		}
+	}
+}
+
+func TestTimeRegression_BelowPctThreshold(t *testing.T) {
+	// 5000 ns = 5µs, but only 2% regression (below 5% threshold)
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 0, 0))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5100, 0, 0))
+	regressions := checkRegressions(base, head, defaultCfg())
+	for _, r := range regressions {
+		if r.Unit == "sec/op" {
+			t.Errorf("unexpected sec/op regression for <5%% change: %+v", r)
+		}
+	}
+}
+
+func TestImprovement_NotFlagged(t *testing.T) {
+	// Head is faster — should NOT flag
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 64, 2))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 4000, 32, 1))
+	regressions := checkRegressions(base, head, defaultCfg())
+	if len(regressions) != 0 {
+		t.Errorf("expected no regressions for improvement, got %d: %+v",
+			len(regressions), regressions)
+	}
+}
+
+func TestZeroBaseAlloc(t *testing.T) {
+	// Base has 0 B/op, head has non-zero
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 0, 0))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 64, 2))
+	regressions := checkRegressions(base, head, defaultCfg())
+	allocFound := false
+	for _, r := range regressions {
+		if isAllocUnit(r.Unit) {
+			allocFound = true
+		}
+	}
+	if !allocFound {
+		t.Error("expected allocation regression for 0→non-zero, got none")
+	}
+}
+
+func TestCustomThresholds(t *testing.T) {
+	// 10% time threshold — 8% regression should NOT flag
+	base := parse(t, benchLines("BenchmarkFoo-8", 10, 5000, 0, 0))
+	head := parse(t, benchLines("BenchmarkFoo-8", 10, 5400, 0, 0))
+	cfg := config{
+		TimeThreshold: 10,
+		MinTime:       1e-6,
+		Alpha:         0.05,
+	}
+	regressions := checkRegressions(base, head, cfg)
+	for _, r := range regressions {
+		if r.Unit == "sec/op" {
+			t.Errorf("unexpected sec/op regression with 10%% threshold: %+v", r)
+		}
+	}
+}
+
+func TestParseBenchmarks(t *testing.T) {
+	input := "BenchmarkSHA256-8\t1000\t1234 ns/op\t56 B/op\t3 allocs/op\n" +
+		"BenchmarkSHA256-8\t1000\t1245 ns/op\t56 B/op\t3 allocs/op\n" +
+		"BenchmarkAES-8\t1000\t567 ns/op\t0 B/op\t0 allocs/op\n"
+	values := parse(t, input)
+
+	// benchfmt strips the "Benchmark" prefix from names.
+	sha256Time := values[benchKey{Name: "SHA256-8", Unit: "sec/op"}]
+	if len(sha256Time) != 2 {
+		t.Fatalf("expected 2 sec/op values for SHA256, got %d", len(sha256Time))
+	}
+	// 1234 ns = 1.234e-6 sec
+	if sha256Time[0] < 1e-7 || sha256Time[0] > 1e-5 {
+		t.Errorf("unexpected sec/op value: %g", sha256Time[0])
+	}
+
+	sha256Alloc := values[benchKey{Name: "SHA256-8", Unit: "B/op"}]
+	if len(sha256Alloc) != 2 {
+		t.Fatalf("expected 2 B/op values for SHA256, got %d", len(sha256Alloc))
+	}
+}

--- a/.github/benchcheck/main_test.go
+++ b/.github/benchcheck/main_test.go
@@ -177,7 +177,10 @@ func TestParseBenchmarks(t *testing.T) {
 
 func TestExtractFailures_BuildErrors(t *testing.T) {
 	input := "# runtime/cgo\ncgo-gcc-prolog:3:20: error: call to undeclared function\nFAIL\tgithub.com/example [build failed]\n"
-	lines := extractFailures(strings.NewReader(input), "")
+	lines, err := extractFailures(strings.NewReader(input), "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
 	}
@@ -191,7 +194,10 @@ func TestExtractFailures_BuildErrors(t *testing.T) {
 
 func TestExtractFailures_TestFailures(t *testing.T) {
 	input := "--- FAIL: TestFoo (0.01s)\n    foo_test.go:42: expected 1, got 2\nFAIL\tgithub.com/example\t0.123s\n"
-	lines := extractFailures(strings.NewReader(input), "pfx: ")
+	lines, err := extractFailures(strings.NewReader(input), "pfx: ")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
 	}
@@ -205,7 +211,10 @@ func TestExtractFailures_TestFailures(t *testing.T) {
 
 func TestExtractFailures_CrashTrace(t *testing.T) {
 	input := "SIGSEGV: segmentation violation\nPC=0x1234\ngoroutine 1 [running]:\nmain.foo()\n\tfile.go:10\n\ngoroutine 2 [sleep]:\ntime.Sleep()\n"
-	lines := extractFailures(strings.NewReader(input), "")
+	lines, err := extractFailures(strings.NewReader(input), "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Should capture lines up to and including the blank line, not goroutine 2.
 	found := false
 	for _, l := range lines {
@@ -223,7 +232,10 @@ func TestExtractFailures_CrashTrace(t *testing.T) {
 
 func TestExtractFailures_Panic(t *testing.T) {
 	input := "panic: runtime error: index out of range\ngoroutine 1 [running]:\nmain.foo()\n\n"
-	lines := extractFailures(strings.NewReader(input), "")
+	lines, err := extractFailures(strings.NewReader(input), "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(lines) == 0 {
 		t.Fatal("expected panic lines")
 	}
@@ -234,7 +246,10 @@ func TestExtractFailures_Panic(t *testing.T) {
 
 func TestExtractFailures_NoFailures(t *testing.T) {
 	input := "BenchmarkFoo-8\t1000\t1234 ns/op\t56 B/op\t3 allocs/op\nok\tgithub.com/example\t1.234s\n"
-	lines := extractFailures(strings.NewReader(input), "")
+	lines, err := extractFailures(strings.NewReader(input), "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(lines) != 0 {
 		t.Errorf("expected no failures, got %d: %v", len(lines), lines)
 	}

--- a/.github/benchcheck/report.go
+++ b/.github/benchcheck/report.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -55,7 +57,7 @@ func cmdReport(args []string) {
 		if jobURL == "" {
 			jobURL = *runURL
 		}
-		status := readJobStatus(filepath.Join(dir, "status.txt"))
+		status := readJobStatus(filepath.Join(dir, "status.json"))
 		failures := readFileContent(filepath.Join(dir, "failures.txt"))
 		regressions := readFileContent(filepath.Join(dir, "regressions.txt"))
 
@@ -105,25 +107,34 @@ type jobStatus struct {
 	failed       bool // derived: any of the above
 }
 
+func (s *jobStatus) setFailed(field *bool) {
+	*field = true
+	s.failed = true
+}
+
 func readJobStatus(path string) jobStatus {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		// Missing status file means the job errored before writing it.
-		return jobStatus{failed: true, benchError: true}
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "reading %s: %v\n", path, err)
+		}
+		// Missing or unreadable status file means the job errored before writing it.
+		return jobStatus{benchError: true, failed: true}
+	}
+	var status Status
+	if err := json.Unmarshal(data, &status); err != nil {
+		fmt.Fprintf(os.Stderr, "parsing %s: %v\n", path, err)
+		return jobStatus{benchError: true, failed: true}
 	}
 	var s jobStatus
-	for _, line := range strings.Split(string(data), "\n") {
-		switch {
-		case line == "regression=true":
-			s.regression = true
-			s.failed = true
-		case line == "test_failures=true":
-			s.testFailures = true
-			s.failed = true
-		case line == "benchmark_error=true":
-			s.benchError = true
-			s.failed = true
-		}
+	if status.Regression {
+		s.setFailed(&s.regression)
+	}
+	if status.TestFailures {
+		s.setFailed(&s.testFailures)
+	}
+	if status.BenchmarkError {
+		s.setFailed(&s.benchError)
 	}
 	return s
 }

--- a/.github/benchcheck/report.go
+++ b/.github/benchcheck/report.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func cmdReport(args []string) {
+	fs := flag.NewFlagSet("report", flag.ExitOnError)
+	runURL := fs.String("run-url", "", "URL of the workflow run (fallback for job links)")
+	jobURLsFile := fs.String("job-urls", "", "TSV file mapping artifact labels to job URLs")
+	overallResult := fs.String("overall-result", "success", "overall bench job result (success/failure)")
+	maxLen := fs.Int("max-len", 65536, "maximum output length for GitHub PR comment compatibility")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: benchcheck report [flags] results-dir\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+	fs.Parse(args)
+
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	resultsDir := fs.Arg(0)
+	jobURLs := loadJobURLs(*jobURLsFile)
+
+	var buf strings.Builder
+
+	// Marker for finding/updating existing PR comments.
+	buf.WriteString("<!-- benchmark-results -->\n")
+
+	// Header.
+	buf.WriteString("## Benchmark Results\n\n")
+	if *overallResult == "failure" {
+		buf.WriteString(":warning: **Issues detected** — expand failed jobs below for details\n\n")
+	} else {
+		buf.WriteString(":white_check_mark: **No significant regressions detected**\n\n")
+	}
+
+	// Process each artifact directory.
+	entries, _ := filepath.Glob(filepath.Join(resultsDir, "benchstat-*"))
+	sort.Strings(entries)
+	for _, dir := range entries {
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		label := strings.TrimPrefix(info.Name(), "benchstat-")
+		jobURL := jobURLs[label]
+		if jobURL == "" {
+			jobURL = *runURL
+		}
+		status := readJobStatus(filepath.Join(dir, "status.txt"))
+		failures := readFileContent(filepath.Join(dir, "failures.txt"))
+		regressions := readFileContent(filepath.Join(dir, "regressions.txt"))
+
+		if status.failed {
+			buf.WriteString("<details>\n")
+			fmt.Fprintf(&buf, "<summary>:x: <code>%s</code></summary>\n\n", label)
+			if status.benchError {
+				fmt.Fprintf(&buf, ":boom: **Benchmark run failed** — see [workflow logs](%s) for details.\n\n", jobURL)
+			}
+			if failures != "" {
+				buf.WriteString("**Test failures:**\n```\n")
+				buf.WriteString(failures)
+				buf.WriteString("\n```\n\n")
+			}
+			if regressions != "" {
+				buf.WriteString("**Regressions:**\n```\n")
+				buf.WriteString(regressions)
+				buf.WriteString("\n```\n\n")
+			} else if !status.benchError {
+				buf.WriteString("No benchmark regressions detected.\n\n")
+			}
+			fmt.Fprintf(&buf, ":file_folder: [Full results](%s)\n\n", jobURL)
+			buf.WriteString("</details>\n\n")
+		} else {
+			fmt.Fprintf(&buf, ":white_check_mark: `%s` · [results](%s)\n", label, jobURL)
+		}
+	}
+
+	// Truncate if needed to fit GitHub's PR comment limit.
+	output := buf.String()
+	if len(output) > *maxLen {
+		truncMsg := "\n\n---\n:scissors: **Report truncated** — see workflow artifacts for full results.\n"
+		cut := *maxLen - len(truncMsg)
+		if cut < 0 {
+			cut = 0
+		}
+		output = output[:cut] + truncMsg
+	}
+
+	fmt.Print(output)
+}
+
+type jobStatus struct {
+	regression   bool
+	testFailures bool
+	benchError   bool
+	failed       bool // derived: any of the above
+}
+
+func readJobStatus(path string) jobStatus {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Missing status file means the job errored before writing it.
+		return jobStatus{failed: true, benchError: true}
+	}
+	var s jobStatus
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case line == "regression=true":
+			s.regression = true
+			s.failed = true
+		case line == "test_failures=true":
+			s.testFailures = true
+			s.failed = true
+		case line == "benchmark_error=true":
+			s.benchError = true
+			s.failed = true
+		}
+	}
+	return s
+}
+
+func loadJobURLs(path string) map[string]string {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	urls := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) == 2 {
+			urls[parts[0]] = parts[1]
+		}
+	}
+	return urls
+}
+
+func readFileContent(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,10 +1,7 @@
 name: Benchmark
 
 on:
-  # TODO: Remove pull_request trigger after testing; keep only issue_comment and workflow_dispatch.
   pull_request:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       base-ref:
@@ -16,53 +13,25 @@ permissions:
   actions: read
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   setup:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/bench'))
     runs-on: ubuntu-latest
     outputs:
       head-ref: ${{ steps.resolve.outputs.head-ref }}
       base-ref: ${{ steps.resolve.outputs.base-ref }}
       pr-number: ${{ steps.resolve.outputs.pr-number }}
     steps:
-      - name: React to comment
-        if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes',
-            });
-
       - name: Resolve refs
         id: resolve
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName === 'issue_comment') {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-              });
-              core.setOutput('head-ref', pr.data.head.sha);
-              core.setOutput('base-ref', pr.data.base.ref);
-              core.setOutput('pr-number', String(context.issue.number));
-            } else if (context.eventName === 'pull_request') {
+            if (context.eventName === 'pull_request') {
               core.setOutput('head-ref', context.payload.pull_request.head.sha);
               core.setOutput('base-ref', context.payload.pull_request.base.ref);
               core.setOutput('pr-number', String(context.payload.pull_request.number));

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -177,25 +177,33 @@ jobs:
           failures.txt
           status.txt
 
-    - name: "⚠️ RESULTS: regression or test failure detected"
-      if: steps.benchstat.outputs.regression == 'true' || steps.test-failures.outputs.found == 'true'
+    - name: "📊 RESULTS"
+      if: always()
       run: |
-        echo "::error::Benchmark regression or test failure detected."
-        if [ -s regressions.txt ]; then
-          echo ""
-          echo "=== Regressions ==="
-          cat regressions.txt
+        failed=false
+        if [ "${{ steps.benchstat.outputs.regression }}" = "true" ]; then
+          echo "::error::Benchmark regression detected — see the 'Compare benchmarks' step for benchstat output."
+          if [ -s regressions.txt ]; then
+            echo ""
+            echo "=== Regressions ==="
+            cat regressions.txt
+          fi
+          failed=true
         fi
-        if [ -s failures.txt ]; then
-          echo ""
-          echo "=== Test failures ==="
-          cat failures.txt
+        if [ "${{ steps.test-failures.outputs.found }}" = "true" ]; then
+          echo "::error::Test failure detected — see the 'Run benchmarks (base)' and 'Run benchmarks (head)' steps for details."
+          if [ -s failures.txt ]; then
+            echo ""
+            echo "=== Test failures ==="
+            cat failures.txt
+          fi
+          failed=true
         fi
-        exit 1
-
-    - name: "✅ RESULTS: no regressions"
-      if: steps.benchstat.outputs.regression == 'false' && steps.test-failures.outputs.found == 'false'
-      run: echo "No benchmark regressions or test failures detected."
+        if [ "$failed" = false ]; then
+          echo "✅ No benchmark regressions or test failures detected."
+        else
+          exit 1
+        fi
 
   conclusion:
     needs: [setup, bench]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,8 +56,11 @@ jobs:
           - { go-version: 1.26.x, openssl-version: "", host: ubuntu-latest, platform: azl3 }
     name: bench (${{ matrix.platform }}, ${{ matrix.host }}, ossl${{ matrix.openssl-version || 'system' }}, go${{ matrix.go-version }})
     runs-on: ${{ matrix.host }}
-    container: ${{ matrix.platform == 'azl3' && fromJSON('{"image":"mcr.microsoft.com/azurelinux/base/core:3.0"}') || fromJSON('null') }}
+    container: ${{ matrix.platform == 'azl3' && fromJSON('{"image":"mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0"}') || fromJSON('null') }}
     steps:
+    - name: Initialize status
+      run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
+
     - name: Install build tools (Ubuntu)
       if: matrix.platform == 'ubuntu'
       run: sudo apt-get update && sudo apt-get install -y build-essential
@@ -65,10 +68,8 @@ jobs:
     - name: Install build tools (AZL3)
       if: matrix.platform == 'azl3'
       run: |
-        # The AZL3 base container ships without GPG keys for the package repos.
-        # Disable repo metadata signature verification to allow package installation.
-        sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/*.repo
-        tdnf install -y --nogpgcheck gcc binutils kernel-headers glibc-devel openssl-devel git tar ca-certificates
+        export GNUPGHOME=/root/.gnupg
+        tdnf install -y openssl-devel
 
     - name: Checkout HEAD
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -123,7 +124,7 @@ jobs:
           benchstat.txt
           regressions.txt
           failures.txt
-          status.txt
+          status.json
 
   conclusion:
     needs: [setup, bench]
@@ -168,9 +169,9 @@ jobs:
         run: |
           go build -C head/.github/benchcheck -o "$PWD/benchcheck" .
           ./benchcheck report \
-            --run-url="$RUN_URL" \
-            --job-urls=job_urls.tsv \
-            --overall-result="${{ needs.bench.result }}" \
+            -run-url="$RUN_URL" \
+            -job-urls=job_urls.tsv \
+            -overall-result="${{ needs.bench.result }}" \
             results/ > report.md
 
       - name: Post PR comment

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          go build -C head/.github/benchcheck -o benchcheck .
+          go build -C head/.github/benchcheck -o "$PWD/benchcheck" .
           ./benchcheck report \
             --run-url="$RUN_URL" \
             --job-urls=job_urls.tsv \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ on:
         default: 'v2'
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
   issues: write
@@ -157,7 +158,8 @@ jobs:
       id: benchstat
       run: |
         benchstat base.txt head.txt | tee benchstat.txt
-        regression=$(go run -C head/.github/benchcheck . "$PWD/base.txt" "$PWD/head.txt")
+        go build -C head/.github/benchcheck -o "$PWD/benchcheck" .
+        regression=$(./benchcheck "$PWD/base.txt" "$PWD/head.txt" 2> regressions.txt)
         echo "regression=$regression" >> "$GITHUB_OUTPUT"
 
     - name: Save status
@@ -165,6 +167,7 @@ jobs:
       run: |
         echo 'regression=${{ steps.benchstat.outputs.regression }}' > status.txt
         echo 'test_failures=${{ steps.test-failures.outputs.found }}' >> status.txt
+        echo 'benchmark_error=${{ steps.benchstat.outcome == 'failure' && steps.benchstat.outputs.regression == '' }}' >> status.txt
 
     - name: Upload benchstat results
       if: always()
@@ -173,6 +176,7 @@ jobs:
         name: benchstat-${{ matrix.platform }}-${{ matrix.host }}-ossl${{ matrix.openssl-version || 'system' }}-go${{ matrix.go-version }}
         path: |
           benchstat.txt
+          regressions.txt
           failures.txt
           status.txt
 
@@ -193,7 +197,26 @@ jobs:
           path: results
           pattern: benchstat-*
 
+      - name: Fetch job URLs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --paginate --jq '
+              .jobs[] | select(.name | startswith("bench (")) |
+              (.name | ltrimstr("bench (") | rtrimstr(")") | split(", ")) as $p |
+              (if ($p | length) == 4 then
+                {go: $p[0], ossl: (if $p[1] == "" then "system" else $p[1] end), host: $p[2], platform: $p[3]}
+              elif ($p | length) == 3 then
+                {go: $p[0], ossl: "system", host: $p[1], platform: $p[2]}
+              else empty end) as $m |
+              "\($m.platform)-\($m.host)-ossl\($m.ossl)-go\($m.go)\t\(.html_url)"' \
+            > job_urls.tsv
+          cat job_urls.tsv
+
       - name: Build report
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
             echo "## Benchmark Results"
@@ -207,30 +230,50 @@ jobs:
             for dir in results/benchstat-*; do
               [ -d "$dir" ] || continue
               label="${dir#results/benchstat-}"
-              icon=":white_check_mark:"
+              job_url=$(awk -F'\t' -v label="$label" '$1 == label {print $2; exit}' job_urls.tsv)
+              job_url="${job_url:-$RUN_URL}"
+              failed=false
+              bench_error=false
               if [ -f "$dir/status.txt" ]; then
-                grep -q 'regression=true' "$dir/status.txt" && icon=":x:"
-                grep -q 'test_failures=true' "$dir/status.txt" && icon=":x:"
+                grep -q 'regression=true' "$dir/status.txt" && failed=true
+                grep -q 'test_failures=true' "$dir/status.txt" && failed=true
+                grep -q 'benchmark_error=true' "$dir/status.txt" && { failed=true; bench_error=true; }
+              else
+                failed=true
+                bench_error=true
               fi
-              echo "<details>"
-              echo "<summary>${icon} <code>$label</code></summary>"
-              echo ""
-              if [ -f "$dir/failures.txt" ] && [ -s "$dir/failures.txt" ]; then
-                echo "**Test failures:**"
-                echo '```'
-                cat "$dir/failures.txt"
-                echo '```'
+              if [ "$failed" = true ]; then
+                echo "<details>"
+                echo "<summary>:x: <code>$label</code></summary>"
                 echo ""
+                if [ "$bench_error" = true ]; then
+                  echo ":boom: **Benchmark run failed** — see [workflow logs]($job_url) for details."
+                  echo ""
+                fi
+                if [ -f "$dir/failures.txt" ] && [ -s "$dir/failures.txt" ]; then
+                  echo "**Test failures:**"
+                  echo '```'
+                  cat "$dir/failures.txt"
+                  echo '```'
+                  echo ""
+                fi
+                if [ -f "$dir/regressions.txt" ] && [ -s "$dir/regressions.txt" ]; then
+                  echo "**Regressions:**"
+                  echo '```'
+                  sort -t'+' -k2 -rn "$dir/regressions.txt"
+                  echo '```'
+                  echo ""
+                elif [ "$bench_error" != true ]; then
+                  echo "No benchmark regressions detected."
+                  echo ""
+                fi
+                echo ":file_folder: [Full results]($job_url)"
+                echo ""
+                echo "</details>"
+                echo ""
+              else
+                echo ":white_check_mark: \`$label\` · [results]($job_url)"
               fi
-              if [ -f "$dir/benchstat.txt" ]; then
-                echo "**Benchstat:**"
-                echo '```'
-                cat "$dir/benchstat.txt"
-                echo '```'
-              fi
-              echo ""
-              echo "</details>"
-              echo ""
             done
           } > report.md
 
@@ -242,9 +285,13 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('report.md', 'utf8');
+            let body = fs.readFileSync('report.md', 'utf8');
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const marker = '<!-- benchmark-results -->';
+            const maxLen = 65536 - marker.length - 1;
+            if (body.length > maxLen) {
+              body = body.substring(0, maxLen - 200) + '\n\n---\n:scissors: **Report truncated** — see workflow artifacts for full results.\n';
+            }
             const fullBody = marker + '\n' + body;
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,9 +144,36 @@ jobs:
     - name: Check for test failures
       id: test-failures
       run: |
+        extract_failures() {
+          local file=$1 prefix=$2
+          # Extract a compact crash/failure summary including the first goroutine's
+          # stack trace (the one that crashed). Stops at the first blank line after
+          # the crash to avoid dumping all goroutines.
+          awk '
+            # Build errors
+            /^# / { print; next }
+            # Test failures
+            /^--- FAIL/ { print; next }
+            # Package FAIL lines
+            /^FAIL\t/ { print; next }
+            # Start of a crash: capture signal, panic, and first goroutine stack
+            /^SIG[A-Z]+:/ || /^panic:/ {
+              crash = 1
+              print
+              next
+            }
+            crash && /^$/ {
+              # Blank line after first goroutine = stop
+              crash = 0
+              print ""
+              next
+            }
+            crash { print }
+          ' "$file" | sed "s/^/${prefix}/" || true
+        }
         {
-          grep -E '^(FAIL|---\s*FAIL)' base.txt | sed 's/^/base: /' || true
-          grep -E '^(FAIL|---\s*FAIL)' head.txt | sed 's/^/head: /' || true
+          extract_failures base.txt "base: "
+          extract_failures head.txt "head: "
         } > failures.txt
         if [ -s failures.txt ]; then
           echo "found=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,155 @@
+name: Benchmark
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.25.x, 1.26.x]
+        openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0]
+        host: [ubuntu-22.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.host }}
+    steps:
+    - name: Install build tools
+      run: sudo apt-get update && sudo apt-get install -y build-essential
+
+    - name: Checkout HEAD (your branch)
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        path: head
+
+    - name: Checkout BASE (target branch)
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.base_ref }}
+        path: base
+
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache-dependency-path: head/go.mod
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Install OpenSSL
+      run: sudo sh ./head/scripts/openssl.sh ${{ matrix.openssl-version }}
+
+    - name: Run benchmarks (base)
+      working-directory: base
+      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        CGO_ENABLED: 1
+
+    - name: Run benchmarks (head)
+      working-directory: head
+      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+        CGO_ENABLED: 1
+
+    - name: Compare benchmarks
+      run: |
+        benchstat base.txt head.txt | tee benchstat.txt
+        # For sec/op, B/op, allocs/op: a "+" means regression (slower / more allocs).
+        # For B/s: a "+" means improvement (more throughput), so we exclude it.
+        # Only flag regressions >= 5% to ignore CI noise on shared runners.
+        if awk '
+          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
+          /^$/ { header=0 }
+          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
+          END { exit !found }
+        ' benchstat.txt; then
+          echo ""
+          echo "Statistically significant benchmark regression(s) >= 5% detected."
+          exit 1
+        fi
+        echo ""
+        echo "No significant benchmark regressions detected."
+
+  osslbench:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.25.x, 1.26.x]
+        host:
+          - {os: macos-15-intel, openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib}
+          - {os: macos-15, openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib}
+          - {os: windows-2022, openssl-version: libcrypto-3-x64.dll}
+    runs-on: ${{ matrix.host.os }}
+    steps:
+    - name: Checkout HEAD (your branch)
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        path: head
+
+    - name: Checkout BASE (target branch)
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ github.base_ref }}
+        path: base
+
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache-dependency-path: head/go.mod
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Run benchmarks (base)
+      shell: bash
+      working-directory: base
+      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
+        CGO_ENABLED: 1
+
+    - name: Run benchmarks (head)
+      shell: bash
+      working-directory: head
+      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
+        CGO_ENABLED: 1
+
+    - name: Compare benchmarks
+      shell: bash
+      run: |
+        benchstat base.txt head.txt | tee benchstat.txt
+        # For sec/op, B/op, allocs/op: a "+" means regression (slower / more allocs).
+        # For B/s: a "+" means improvement (more throughput), so we exclude it.
+        # Only flag regressions >= 5% to ignore CI noise on shared runners.
+        if awk '
+          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
+          /^$/ { header=0 }
+          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
+          END { exit !found }
+        ' benchstat.txt; then
+          echo ""
+          echo "Statistically significant benchmark regression(s) >= 5% detected."
+          exit 1
+        fi
+        echo ""
+        echo "No significant benchmark regressions detected."
+
+  conclusion:
+    needs: [bench, osslbench]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Result
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more benchmark jobs detected regressions or were cancelled."
+            exit 1
+          fi
+          echo "All benchmark jobs passed."

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,22 +71,35 @@ jobs:
               core.setOutput('pr-number', '');
             }
 
-  bench-ubuntu:
+  bench:
     needs: setup
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1, 3.4.0, 3.5.0]
+        openssl-version: ["3.0.13", "3.1.5", "3.2.1", "3.3.1", "3.4.0", "3.5.0"]
         host: [ubuntu-22.04, ubuntu-24.04-arm]
+        platform: [ubuntu]
+        include:
+          # AZL3 with system OpenSSL
+          - { go-version: 1.25.x, openssl-version: "", host: ubuntu-latest, platform: azl3 }
+          - { go-version: 1.26.x, openssl-version: "", host: ubuntu-latest, platform: azl3 }
     runs-on: ${{ matrix.host }}
+    container: ${{ matrix.platform == 'azl3' && fromJSON('{"image":"mcr.microsoft.com/azurelinux/base/core:3.0"}') || fromJSON('null') }}
     steps:
-    - name: Install build tools
+    - name: Install build tools (Ubuntu)
+      if: matrix.platform == 'ubuntu'
       run: sudo apt-get update && sudo apt-get install -y build-essential
 
-    - name: Install OpenSSL
+    - name: Install build tools (AZL3)
+      if: matrix.platform == 'azl3'
       run: |
-        # Checkout just the install script first
+        sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/*.repo
+        tdnf install -y --nogpgcheck gcc binutils kernel-headers glibc-devel openssl-devel git tar ca-certificates
+
+    - name: Install OpenSSL
+      if: matrix.openssl-version != ''
+      run: |
         git clone --depth 1 --filter=blob:none --sparse ${{ github.server_url }}/${{ github.repository }} _openssl_setup
         cd _openssl_setup && git sparse-checkout set scripts
         cd ..
@@ -157,94 +170,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: benchstat-ubuntu-${{ matrix.host }}-ossl${{ matrix.openssl-version }}-go${{ matrix.go-version }}
-        path: |
-          benchstat.txt
-          failures.txt
-          status.txt
-
-    - name: Fail on regression or test failure
-      if: steps.benchstat.outputs.regression == 'true' || steps.test-failures.outputs.found == 'true'
-      run: |
-        echo "Benchmark regression or test failure detected."
-        exit 1
-
-  bench-azl3:
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.25.x, 1.26.x]
-    runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/azurelinux/base/core:3.0
-    steps:
-    - name: Install build tools
-      run: tdnf install -y --nogpgcheck gcc glibc-devel openssl-devel git tar
-
-    - name: Checkout HEAD
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ needs.setup.outputs.head-ref }}
-        path: head
-
-    - name: Checkout BASE
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ needs.setup.outputs.base-ref }}
-        path: base
-
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version: ${{ matrix.go-version }}
-        cache-dependency-path: head/go.mod
-
-    - name: Install benchstat
-      run: go install golang.org/x/perf/cmd/benchstat@latest
-
-    - name: Run benchmarks (base)
-      working-directory: base
-      run: |
-        export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
-
-    - name: Run benchmarks (head)
-      working-directory: head
-      run: |
-        export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
-
-    - name: Check for test failures
-      id: test-failures
-      run: |
-        {
-          grep -E '^(FAIL|---\s*FAIL)' base.txt | sed 's/^/base: /' || true
-          grep -E '^(FAIL|---\s*FAIL)' head.txt | sed 's/^/head: /' || true
-        } > failures.txt
-        if [ -s failures.txt ]; then
-          echo "found=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "found=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Compare benchmarks
-      id: benchstat
-      run: |
-        benchstat base.txt head.txt | tee benchstat.txt
-        regression=$(go run -C head/.github/benchcheck . "$PWD/base.txt" "$PWD/head.txt")
-        echo "regression=$regression" >> "$GITHUB_OUTPUT"
-
-    - name: Save status
-      if: always()
-      run: |
-        echo 'regression=${{ steps.benchstat.outputs.regression }}' > status.txt
-        echo 'test_failures=${{ steps.test-failures.outputs.found }}' >> status.txt
-
-    - name: Upload benchstat results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: benchstat-azl3-go${{ matrix.go-version }}
+        name: benchstat-${{ matrix.platform }}-${{ matrix.host }}-ossl${{ matrix.openssl-version || 'system' }}-go${{ matrix.go-version }}
         path: |
           benchstat.txt
           failures.txt
@@ -257,7 +183,7 @@ jobs:
         exit 1
 
   conclusion:
-    needs: [setup, bench-ubuntu, bench-azl3]
+    needs: [setup, bench]
     runs-on: ubuntu-latest
     if: always() && needs.setup.result == 'success'
     steps:
@@ -272,7 +198,7 @@ jobs:
           {
             echo "## Benchmark Results"
             echo ""
-            if [[ "${{ needs.bench-ubuntu.result }}" == "failure" || "${{ needs.bench-azl3.result }}" == "failure" ]]; then
+            if [[ "${{ needs.bench.result }}" == "failure" ]]; then
               echo ":warning: **Regressions detected** (>= 5%, statistically significant)"
             else
               echo ":white_check_mark: **No significant regressions detected**"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,21 +144,8 @@ jobs:
       id: benchstat
       run: |
         benchstat base.txt head.txt | tee benchstat.txt
-        # Allocation regressions (B/op, allocs/op): any increase fails.
-        # CPU time regressions (sec/op): >= 5% fails, but only for benchmarks >= 1µs
-        # (benchstat units: n=nano, µ=micro, m=milli; /[0-9].*[µm]/ skips ns-level noise).
-        if awk '
-          /^[[:space:]]*│.*(B\/op|allocs\/op)/ { header="alloc"; next }
-          /^[[:space:]]*│.*sec\/op/ { header="time"; next }
-          /^$/ { header="" }
-          header == "alloc" && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 > 0) found=1 }
-          header == "time" && /[0-9].*[µm]/ && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
-          END { exit !found }
-        ' benchstat.txt; then
-          echo "regression=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "regression=false" >> "$GITHUB_OUTPUT"
-        fi
+        regression=$(go run -C head/.github/benchcheck . "$PWD/base.txt" "$PWD/head.txt")
+        echo "regression=$regression" >> "$GITHUB_OUTPUT"
 
     - name: Save status
       if: always()
@@ -244,21 +231,8 @@ jobs:
       id: benchstat
       run: |
         benchstat base.txt head.txt | tee benchstat.txt
-        # Allocation regressions (B/op, allocs/op): any increase fails.
-        # CPU time regressions (sec/op): >= 5% fails, but only for benchmarks >= 1µs
-        # (benchstat units: n=nano, µ=micro, m=milli; /[0-9].*[µm]/ skips ns-level noise).
-        if awk '
-          /^[[:space:]]*│.*(B\/op|allocs\/op)/ { header="alloc"; next }
-          /^[[:space:]]*│.*sec\/op/ { header="time"; next }
-          /^$/ { header="" }
-          header == "alloc" && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 > 0) found=1 }
-          header == "time" && /[0-9].*[µm]/ && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
-          END { exit !found }
-        ' benchstat.txt; then
-          echo "regression=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "regression=false" >> "$GITHUB_OUTPUT"
-        fi
+        regression=$(go run -C head/.github/benchcheck . "$PWD/base.txt" "$PWD/head.txt")
+        echo "regression=$regression" >> "$GITHUB_OUTPUT"
 
     - name: Save status
       if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,10 +1,10 @@
 name: Benchmark
 
 on:
-  # TODO: Remove push trigger after testing; keep only workflow_dispatch.
-  push:
-    branches:
-      - dev/mclayton/benchmark-workflow
+  # TODO: Remove pull_request trigger after testing; keep only issue_comment and workflow_dispatch.
+  pull_request:
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       base-ref:
@@ -12,17 +12,72 @@ on:
         required: true
         default: 'v2'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  bench:
+  setup:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/bench'))
+    runs-on: ubuntu-latest
+    outputs:
+      head-ref: ${{ steps.resolve.outputs.head-ref }}
+      base-ref: ${{ steps.resolve.outputs.base-ref }}
+      pr-number: ${{ steps.resolve.outputs.pr-number }}
+    steps:
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve refs
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              core.setOutput('head-ref', pr.data.head.sha);
+              core.setOutput('base-ref', pr.data.base.ref);
+              core.setOutput('pr-number', String(context.issue.number));
+            } else if (context.eventName === 'pull_request') {
+              core.setOutput('head-ref', context.payload.pull_request.head.sha);
+              core.setOutput('base-ref', context.payload.pull_request.base.ref);
+              core.setOutput('pr-number', String(context.payload.pull_request.number));
+            } else {
+              core.setOutput('head-ref', context.sha);
+              core.setOutput('base-ref', '${{ inputs.base-ref }}');
+              core.setOutput('pr-number', '');
+            }
+
+  bench-ubuntu:
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0]
+        openssl-version: [3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0]
         host: [ubuntu-22.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.host }}
     steps:
@@ -38,39 +93,234 @@ jobs:
         sudo sh ./_openssl_setup/scripts/openssl.sh ${{ matrix.openssl-version }}
         rm -rf _openssl_setup
 
-    - uses: microsoft/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
+    - name: Checkout HEAD
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        base-ref: ${{ inputs.base-ref || 'v2' }}
-        go-version: ${{ matrix.go-version }}
-        env-vars: |
-          GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
-          CGO_ENABLED=1
+        ref: ${{ needs.setup.outputs.head-ref }}
+        path: head
 
-  osslbench:
+    - name: Checkout BASE
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ needs.setup.outputs.base-ref }}
+        path: base
+
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache-dependency-path: head/go.mod
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Run benchmarks (base)
+      working-directory: base
+      run: |
+        export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
+        export CGO_ENABLED=1
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt || true
+
+    - name: Run benchmarks (head)
+      working-directory: head
+      run: |
+        export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
+        export CGO_ENABLED=1
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt || true
+
+    - name: Compare benchmarks
+      id: benchstat
+      run: |
+        benchstat base.txt head.txt | tee benchstat.txt
+        THRESHOLD="5"
+        if awk -v threshold="$THRESHOLD" '
+          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
+          /^$/ { header=0 }
+          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= threshold) found=1 }
+          END { exit !found }
+        ' benchstat.txt; then
+          echo "regression=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "regression=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save status
+      if: always() && steps.benchstat.outcome == 'success'
+      run: echo '${{ steps.benchstat.outputs.regression }}' > status.txt
+
+    - name: Upload benchstat results
+      if: always() && steps.benchstat.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchstat-ubuntu-${{ matrix.host }}-ossl${{ matrix.openssl-version }}-go${{ matrix.go-version }}
+        path: |
+          benchstat.txt
+          status.txt
+
+    - name: Fail on regression
+      if: steps.benchstat.outputs.regression == 'true'
+      run: |
+        echo "Statistically significant benchmark regression(s) >= 5% detected."
+        exit 1
+
+  bench-azl3:
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        host:
-          - {os: macos-15-intel, openssl-version: /usr/local/opt/openssl@3/lib/libcrypto.3.dylib}
-          - {os: macos-15, openssl-version: /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib}
-          - {os: windows-2022, openssl-version: libcrypto-3-x64.dll}
-    runs-on: ${{ matrix.host.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
-    - uses: microsoft/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
+    - name: Install build tools
+      run: tdnf install -y gcc glibc-devel openssl-devel git tar
+
+    - name: Checkout HEAD
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        base-ref: ${{ inputs.base-ref || 'v2' }}
+        ref: ${{ needs.setup.outputs.head-ref }}
+        path: head
+
+    - name: Checkout BASE
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ needs.setup.outputs.base-ref }}
+        path: base
+
+    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      with:
         go-version: ${{ matrix.go-version }}
-        env-vars: |
-          GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.host.openssl-version }}
-          CGO_ENABLED=1
+        cache-dependency-path: head/go.mod
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Run benchmarks (base)
+      working-directory: base
+      run: |
+        export CGO_ENABLED=1
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt || true
+
+    - name: Run benchmarks (head)
+      working-directory: head
+      run: |
+        export CGO_ENABLED=1
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt || true
+
+    - name: Compare benchmarks
+      id: benchstat
+      run: |
+        benchstat base.txt head.txt | tee benchstat.txt
+        THRESHOLD="5"
+        if awk -v threshold="$THRESHOLD" '
+          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
+          /^$/ { header=0 }
+          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= threshold) found=1 }
+          END { exit !found }
+        ' benchstat.txt; then
+          echo "regression=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "regression=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Save status
+      if: always() && steps.benchstat.outcome == 'success'
+      run: echo '${{ steps.benchstat.outputs.regression }}' > status.txt
+
+    - name: Upload benchstat results
+      if: always() && steps.benchstat.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchstat-azl3-go${{ matrix.go-version }}
+        path: |
+          benchstat.txt
+          status.txt
+
+    - name: Fail on regression
+      if: steps.benchstat.outputs.regression == 'true'
+      run: |
+        echo "Statistically significant benchmark regression(s) >= 5% detected."
+        exit 1
 
   conclusion:
-    needs: [bench, osslbench]
+    needs: [setup, bench-ubuntu, bench-azl3]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: always() && needs.setup.result == 'success'
     steps:
-      - name: Result
+      - name: Download all benchstat artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+          pattern: benchstat-*
+
+      - name: Build report
+        run: |
+          {
+            echo "## Benchmark Results"
+            echo ""
+            if [[ "${{ needs.bench-ubuntu.result }}" == "failure" || "${{ needs.bench-azl3.result }}" == "failure" ]]; then
+              echo ":warning: **Regressions detected** (>= 5%, statistically significant)"
+            else
+              echo ":white_check_mark: **No significant regressions detected**"
+            fi
+            echo ""
+            for dir in results/benchstat-*; do
+              [ -d "$dir" ] || continue
+              label="${dir#results/benchstat-}"
+              if [ -f "$dir/status.txt" ] && grep -q 'true' "$dir/status.txt"; then
+                icon=":x:"
+              else
+                icon=":white_check_mark:"
+              fi
+              echo "<details>"
+              echo "<summary>${icon} <code>$label</code></summary>"
+              echo ""
+              echo '```'
+              cat "$dir/benchstat.txt"
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+            done
+          } > report.md
+
+      - name: Post PR comment
+        if: needs.setup.outputs.pr-number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.setup.outputs.pr-number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('report.md', 'utf8');
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const marker = '<!-- benchmark-results -->';
+            const fullBody = marker + '\n' + body;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: fullBody,
+              });
+            }
+
+      - name: Check result
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "One or more benchmark jobs detected regressions or were cancelled."

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,17 +65,10 @@ jobs:
     - name: Install build tools (AZL3)
       if: matrix.platform == 'azl3'
       run: |
+        # The AZL3 base container ships without GPG keys for the package repos.
+        # Disable repo metadata signature verification to allow package installation.
         sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/*.repo
         tdnf install -y --nogpgcheck gcc binutils kernel-headers glibc-devel openssl-devel git tar ca-certificates
-
-    - name: Install OpenSSL
-      if: matrix.openssl-version != ''
-      run: |
-        git clone --depth 1 --filter=blob:none --sparse ${{ github.server_url }}/${{ github.repository }} _openssl_setup
-        cd _openssl_setup && git sparse-checkout set scripts
-        cd ..
-        sudo sh ./_openssl_setup/scripts/openssl.sh ${{ matrix.openssl-version }}
-        rm -rf _openssl_setup
 
     - name: Checkout HEAD
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -88,6 +81,10 @@ jobs:
       with:
         ref: ${{ needs.setup.outputs.base-ref }}
         path: base
+
+    - name: Install OpenSSL
+      if: matrix.openssl-version != ''
+      run: sudo sh head/scripts/openssl.sh ${{ matrix.openssl-version }}
 
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
@@ -111,62 +108,13 @@ jobs:
         export CGO_ENABLED=1
         go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
-    - name: Check for test failures
-      id: test-failures
+    - name: "📊 Compare and check"
       run: |
-        extract_failures() {
-          local file=$1 prefix=$2
-          # Extract a compact crash/failure summary including the first goroutine's
-          # stack trace (the one that crashed). Stops at the first blank line after
-          # the crash to avoid dumping all goroutines.
-          awk '
-            # Build errors
-            /^# / { print; next }
-            # Test failures
-            /^--- FAIL/ { print; next }
-            # Package FAIL lines
-            /^FAIL\t/ { print; next }
-            # Start of a crash: capture signal, panic, and first goroutine stack
-            /^SIG[A-Z]+:/ || /^panic:/ {
-              crash = 1
-              print
-              next
-            }
-            crash && /^$/ {
-              # Blank line after first goroutine = stop
-              crash = 0
-              print ""
-              next
-            }
-            crash { print }
-          ' "$file" | sed "s/^/${prefix}/" || true
-        }
-        {
-          extract_failures base.txt "base: "
-          extract_failures head.txt "head: "
-        } > failures.txt
-        if [ -s failures.txt ]; then
-          echo "found=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "found=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Compare benchmarks
-      id: benchstat
-      run: |
-        benchstat base.txt head.txt | tee benchstat.txt
+        benchstat base.txt head.txt | tee benchstat.txt || true
         go build -C head/.github/benchcheck -o "$PWD/benchcheck" .
-        regression=$(./benchcheck "$PWD/base.txt" "$PWD/head.txt" 2> regressions.txt)
-        echo "regression=$regression" >> "$GITHUB_OUTPUT"
+        ./benchcheck check base.txt head.txt
 
-    - name: Save status
-      if: always()
-      run: |
-        echo 'regression=${{ steps.benchstat.outputs.regression }}' > status.txt
-        echo 'test_failures=${{ steps.test-failures.outputs.found }}' >> status.txt
-        echo 'benchmark_error=${{ steps.benchstat.outcome == 'failure' && steps.benchstat.outputs.regression == '' }}' >> status.txt
-
-    - name: Upload benchstat results
+    - name: Upload results
       if: always()
       uses: actions/upload-artifact@v4
       with:
@@ -176,34 +124,6 @@ jobs:
           regressions.txt
           failures.txt
           status.txt
-
-    - name: "📊 RESULTS"
-      if: always()
-      run: |
-        failed=false
-        if [ "${{ steps.benchstat.outputs.regression }}" = "true" ]; then
-          echo "::error::Benchmark regression detected — see the 'Compare benchmarks' step for benchstat output."
-          if [ -s regressions.txt ]; then
-            echo ""
-            echo "=== Regressions ==="
-            cat regressions.txt
-          fi
-          failed=true
-        fi
-        if [ "${{ steps.test-failures.outputs.found }}" = "true" ]; then
-          echo "::error::Test failure detected — see the 'Run benchmarks (base)' and 'Run benchmarks (head)' steps for details."
-          if [ -s failures.txt ]; then
-            echo ""
-            echo "=== Test failures ==="
-            cat failures.txt
-          fi
-          failed=true
-        fi
-        if [ "$failed" = false ]; then
-          echo "✅ No benchmark regressions or test failures detected."
-        else
-          exit 1
-        fi
 
   conclusion:
     needs: [setup, bench]
@@ -216,17 +136,28 @@ jobs:
           path: results
           pattern: benchstat-*
 
+      - name: Checkout HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.head-ref }}
+          path: head
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: 1.25.x
+          cache-dependency-path: head/.github/benchcheck/go.mod
+
       - name: Fetch job URLs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Fetch job URLs and find the step number for the RESULTS step to deep-link.
+          # Fetch job URLs and find the step number for the Compare step to deep-link.
           gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
             --paginate --jq '
               .jobs[] | select(.name | startswith("bench (")) |
               (.name | ltrimstr("bench (") | rtrimstr(")") | split(", ")) as $p |
-              # Find the RESULTS step that actually ran (not skipped)
-              (first(.steps[] | select((.name | test("RESULTS")) and .conclusion != "skipped") | .number) // null) as $step |
+              # Find the Compare and check step that actually ran (not skipped)
+              (first(.steps[] | select((.name | test("Compare and check")) and .conclusion != "skipped") | .number) // null) as $step |
               "\($p | join("-"))\t\(.html_url)\(if $step then "#step:\($step):1" else "" end)"' \
             > job_urls.tsv || true
           cat job_urls.tsv
@@ -235,64 +166,12 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          {
-            echo "## Benchmark Results"
-            echo ""
-            if [[ "${{ needs.bench.result }}" == "failure" ]]; then
-              echo ":warning: **Regressions detected** (>= 5%, statistically significant)"
-            else
-              echo ":white_check_mark: **No significant regressions detected**"
-            fi
-            echo ""
-            for dir in results/benchstat-*; do
-              [ -d "$dir" ] || continue
-              label="${dir#results/benchstat-}"
-              job_url=$(awk -F'\t' -v label="$label" '$1 == label {print $2; exit}' job_urls.tsv)
-              job_url="${job_url:-$RUN_URL}"
-              failed=false
-              bench_error=false
-              if [ -f "$dir/status.txt" ]; then
-                grep -q 'regression=true' "$dir/status.txt" && failed=true
-                grep -q 'test_failures=true' "$dir/status.txt" && failed=true
-                grep -q 'benchmark_error=true' "$dir/status.txt" && { failed=true; bench_error=true; }
-              else
-                failed=true
-                bench_error=true
-              fi
-              if [ "$failed" = true ]; then
-                echo "<details>"
-                echo "<summary>:x: <code>$label</code></summary>"
-                echo ""
-                if [ "$bench_error" = true ]; then
-                  echo ":boom: **Benchmark run failed** — see [workflow logs]($job_url) for details."
-                  echo ""
-                fi
-                if [ -f "$dir/failures.txt" ] && [ -s "$dir/failures.txt" ]; then
-                  echo "**Test failures:**"
-                  echo '```'
-                  cat "$dir/failures.txt"
-                  echo '```'
-                  echo ""
-                fi
-                if [ -f "$dir/regressions.txt" ] && [ -s "$dir/regressions.txt" ]; then
-                  echo "**Regressions:**"
-                  echo '```'
-                  sort -t'+' -k2 -rn "$dir/regressions.txt"
-                  echo '```'
-                  echo ""
-                elif [ "$bench_error" != true ]; then
-                  echo "No benchmark regressions detected."
-                  echo ""
-                fi
-                echo ":file_folder: [Full results]($job_url)"
-                echo ""
-                echo "</details>"
-                echo ""
-              else
-                echo ":white_check_mark: \`$label\` · [results]($job_url)"
-              fi
-            done
-          } > report.md
+          go build -C head/.github/benchcheck -o benchcheck .
+          ./benchcheck report \
+            --run-url="$RUN_URL" \
+            --job-urls=job_urls.tsv \
+            --overall-result="${{ needs.bench.result }}" \
+            results/ > report.md
 
       - name: Post PR comment
         if: needs.setup.outputs.pr-number != ''
@@ -302,14 +181,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let body = fs.readFileSync('report.md', 'utf8');
+            const body = fs.readFileSync('report.md', 'utf8');
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const marker = '<!-- benchmark-results -->';
-            const maxLen = 65536 - marker.length - 1;
-            if (body.length > maxLen) {
-              body = body.substring(0, maxLen - 200) + '\n\n---\n:scissors: **Report truncated** — see workflow artifacts for full results.\n';
-            }
-            const fullBody = marker + '\n' + body;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -323,14 +197,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
-                body: fullBody,
+                body,
               });
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body: fullBody,
+                body,
               });
             }
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -118,14 +118,27 @@ jobs:
       run: |
         export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt || true
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../base.txt || true
 
     - name: Run benchmarks (head)
       working-directory: head
       run: |
         export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt || true
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../head.txt || true
+
+    - name: Check for test failures
+      id: test-failures
+      run: |
+        {
+          grep -E '^(FAIL|---\s*FAIL)' base.txt | sed 's/^/base: /' || true
+          grep -E '^(FAIL|---\s*FAIL)' head.txt | sed 's/^/head: /' || true
+        } > failures.txt
+        if [ -s failures.txt ]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Compare benchmarks
       id: benchstat
@@ -144,22 +157,25 @@ jobs:
         fi
 
     - name: Save status
-      if: always() && steps.benchstat.outcome == 'success'
-      run: echo '${{ steps.benchstat.outputs.regression }}' > status.txt
+      if: always()
+      run: |
+        echo 'regression=${{ steps.benchstat.outputs.regression }}' > status.txt
+        echo 'test_failures=${{ steps.test-failures.outputs.found }}' >> status.txt
 
     - name: Upload benchstat results
-      if: always() && steps.benchstat.outcome == 'success'
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchstat-ubuntu-${{ matrix.host }}-ossl${{ matrix.openssl-version }}-go${{ matrix.go-version }}
         path: |
           benchstat.txt
+          failures.txt
           status.txt
 
-    - name: Fail on regression
-      if: steps.benchstat.outputs.regression == 'true'
+    - name: Fail on regression or test failure
+      if: steps.benchstat.outputs.regression == 'true' || steps.test-failures.outputs.found == 'true'
       run: |
-        echo "Statistically significant benchmark regression(s) >= 5% detected."
+        echo "Benchmark regression or test failure detected."
         exit 1
 
   bench-azl3:
@@ -173,7 +189,9 @@ jobs:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
     - name: Install build tools
-      run: tdnf install -y gcc glibc-devel openssl-devel git tar
+      run: |
+        tdnf install -y --nogpgcheck azurelinux-repos
+        tdnf install -y gcc glibc-devel openssl-devel git tar
 
     - name: Checkout HEAD
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -199,13 +217,26 @@ jobs:
       working-directory: base
       run: |
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt || true
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../base.txt || true
 
     - name: Run benchmarks (head)
       working-directory: head
       run: |
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt || true
+        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../head.txt || true
+
+    - name: Check for test failures
+      id: test-failures
+      run: |
+        {
+          grep -E '^(FAIL|---\s*FAIL)' base.txt | sed 's/^/base: /' || true
+          grep -E '^(FAIL|---\s*FAIL)' head.txt | sed 's/^/head: /' || true
+        } > failures.txt
+        if [ -s failures.txt ]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Compare benchmarks
       id: benchstat
@@ -224,22 +255,25 @@ jobs:
         fi
 
     - name: Save status
-      if: always() && steps.benchstat.outcome == 'success'
-      run: echo '${{ steps.benchstat.outputs.regression }}' > status.txt
+      if: always()
+      run: |
+        echo 'regression=${{ steps.benchstat.outputs.regression }}' > status.txt
+        echo 'test_failures=${{ steps.test-failures.outputs.found }}' >> status.txt
 
     - name: Upload benchstat results
-      if: always() && steps.benchstat.outcome == 'success'
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchstat-azl3-go${{ matrix.go-version }}
         path: |
           benchstat.txt
+          failures.txt
           status.txt
 
-    - name: Fail on regression
-      if: steps.benchstat.outputs.regression == 'true'
+    - name: Fail on regression or test failure
+      if: steps.benchstat.outputs.regression == 'true' || steps.test-failures.outputs.found == 'true'
       run: |
-        echo "Statistically significant benchmark regression(s) >= 5% detected."
+        echo "Benchmark regression or test failure detected."
         exit 1
 
   conclusion:
@@ -267,17 +301,27 @@ jobs:
             for dir in results/benchstat-*; do
               [ -d "$dir" ] || continue
               label="${dir#results/benchstat-}"
-              if [ -f "$dir/status.txt" ] && grep -q 'true' "$dir/status.txt"; then
-                icon=":x:"
-              else
-                icon=":white_check_mark:"
+              icon=":white_check_mark:"
+              if [ -f "$dir/status.txt" ]; then
+                grep -q 'regression=true' "$dir/status.txt" && icon=":x:"
+                grep -q 'test_failures=true' "$dir/status.txt" && icon=":x:"
               fi
               echo "<details>"
               echo "<summary>${icon} <code>$label</code></summary>"
               echo ""
-              echo '```'
-              cat "$dir/benchstat.txt"
-              echo '```'
+              if [ -f "$dir/failures.txt" ] && [ -s "$dir/failures.txt" ]; then
+                echo "**Test failures:**"
+                echo '```'
+                cat "$dir/failures.txt"
+                echo '```'
+                echo ""
+              fi
+              if [ -f "$dir/benchstat.txt" ]; then
+                echo "**Benchstat:**"
+                echo '```'
+                cat "$dir/benchstat.txt"
+                echo '```'
+              fi
               echo ""
               echo "</details>"
               echo ""

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        openssl-version: [3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0]
+        openssl-version: [3.0.13, 3.1.5, 3.2.1, 3.3.1, 3.4.0, 3.5.0]
         host: [ubuntu-22.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.host }}
     steps:
@@ -118,14 +118,14 @@ jobs:
       run: |
         export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../base.txt || true
+        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
 
     - name: Run benchmarks (head)
       working-directory: head
       run: |
         export GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../head.txt || true
+        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
     - name: Check for test failures
       id: test-failures
@@ -144,11 +144,15 @@ jobs:
       id: benchstat
       run: |
         benchstat base.txt head.txt | tee benchstat.txt
-        THRESHOLD="5"
-        if awk -v threshold="$THRESHOLD" '
-          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
-          /^$/ { header=0 }
-          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= threshold) found=1 }
+        # Allocation regressions (B/op, allocs/op): any increase fails.
+        # CPU time regressions (sec/op): >= 5% fails, but only for benchmarks >= 1µs
+        # (benchstat units: n=nano, µ=micro, m=milli; /[0-9].*[µm]/ skips ns-level noise).
+        if awk '
+          /^[[:space:]]*│.*(B\/op|allocs\/op)/ { header="alloc"; next }
+          /^[[:space:]]*│.*sec\/op/ { header="time"; next }
+          /^$/ { header="" }
+          header == "alloc" && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 > 0) found=1 }
+          header == "time" && /[0-9].*[µm]/ && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
           END { exit !found }
         ' benchstat.txt; then
           echo "regression=true" >> "$GITHUB_OUTPUT"
@@ -189,9 +193,7 @@ jobs:
       image: mcr.microsoft.com/azurelinux/base/core:3.0
     steps:
     - name: Install build tools
-      run: |
-        tdnf install -y --nogpgcheck azurelinux-repos
-        tdnf install -y gcc glibc-devel openssl-devel git tar
+      run: tdnf install -y --nogpgcheck gcc glibc-devel openssl-devel git tar
 
     - name: Checkout HEAD
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -217,13 +219,13 @@ jobs:
       working-directory: base
       run: |
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../base.txt || true
+        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../base.txt || true
 
     - name: Run benchmarks (head)
       working-directory: head
       run: |
         export CGO_ENABLED=1
-        go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>&1 | tee ../head.txt || true
+        go test -run='^$' -bench=. -count=10 -benchmem -timeout 60m ./... 2>&1 | tee ../head.txt || true
 
     - name: Check for test failures
       id: test-failures
@@ -242,11 +244,15 @@ jobs:
       id: benchstat
       run: |
         benchstat base.txt head.txt | tee benchstat.txt
-        THRESHOLD="5"
-        if awk -v threshold="$THRESHOLD" '
-          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
-          /^$/ { header=0 }
-          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= threshold) found=1 }
+        # Allocation regressions (B/op, allocs/op): any increase fails.
+        # CPU time regressions (sec/op): >= 5% fails, but only for benchmarks >= 1µs
+        # (benchstat units: n=nano, µ=micro, m=milli; /[0-9].*[µm]/ skips ns-level noise).
+        if awk '
+          /^[[:space:]]*│.*(B\/op|allocs\/op)/ { header="alloc"; next }
+          /^[[:space:]]*│.*sec\/op/ { header="time"; next }
+          /^$/ { header="" }
+          header == "alloc" && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 > 0) found=1 }
+          header == "time" && /[0-9].*[µm]/ && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
           END { exit !found }
         ' benchstat.txt; then
           echo "regression=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,12 @@
 name: Benchmark
 
 on:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'Base ref to compare against (branch, tag, or SHA)'
+        required: true
+        default: 'v2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +33,7 @@ jobs:
     - name: Checkout BASE (target branch)
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.base_ref }}
+        ref: ${{ inputs.base-ref }}
         path: base
 
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -94,7 +99,7 @@ jobs:
     - name: Checkout BASE (target branch)
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: ${{ github.base_ref }}
+        ref: ${{ inputs.base-ref }}
         path: base
 
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,10 @@
 name: Benchmark
 
 on:
+  # TODO: Remove push trigger after testing; keep only workflow_dispatch.
+  push:
+    branches:
+      - dev/mclayton/benchmark-workflow
   workflow_dispatch:
     inputs:
       base-ref:
@@ -34,9 +38,9 @@ jobs:
         sudo sh ./_openssl_setup/scripts/openssl.sh ${{ matrix.openssl-version }}
         rm -rf _openssl_setup
 
-    - uses: golang-fips/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
+    - uses: microsoft/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
       with:
-        base-ref: ${{ inputs.base-ref }}
+        base-ref: ${{ inputs.base-ref || 'v2' }}
         go-version: ${{ matrix.go-version }}
         env-vars: |
           GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
@@ -53,9 +57,9 @@ jobs:
           - {os: windows-2022, openssl-version: libcrypto-3-x64.dll}
     runs-on: ${{ matrix.host.os }}
     steps:
-    - uses: golang-fips/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
+    - uses: microsoft/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
       with:
-        base-ref: ${{ inputs.base-ref }}
+        base-ref: ${{ inputs.base-ref || 'v2' }}
         go-version: ${{ matrix.go-version }}
         env-vars: |
           GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.host.openssl-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,6 +54,7 @@ jobs:
           # AZL3 with system OpenSSL
           - { go-version: 1.25.x, openssl-version: "", host: ubuntu-latest, platform: azl3 }
           - { go-version: 1.26.x, openssl-version: "", host: ubuntu-latest, platform: azl3 }
+    name: bench (${{ matrix.platform }}, ${{ matrix.host }}, ossl${{ matrix.openssl-version || 'system' }}, go${{ matrix.go-version }})
     runs-on: ${{ matrix.host }}
     container: ${{ matrix.platform == 'azl3' && fromJSON('{"image":"mcr.microsoft.com/azurelinux/base/core:3.0"}') || fromJSON('null') }}
     steps:
@@ -176,11 +177,25 @@ jobs:
           failures.txt
           status.txt
 
-    - name: Fail on regression or test failure
+    - name: "⚠️ RESULTS: regression or test failure detected"
       if: steps.benchstat.outputs.regression == 'true' || steps.test-failures.outputs.found == 'true'
       run: |
-        echo "Benchmark regression or test failure detected."
+        echo "::error::Benchmark regression or test failure detected."
+        if [ -s regressions.txt ]; then
+          echo ""
+          echo "=== Regressions ==="
+          cat regressions.txt
+        fi
+        if [ -s failures.txt ]; then
+          echo ""
+          echo "=== Test failures ==="
+          cat failures.txt
+        fi
         exit 1
+
+    - name: "✅ RESULTS: no regressions"
+      if: steps.benchstat.outputs.regression == 'false' && steps.test-failures.outputs.found == 'false'
+      run: echo "No benchmark regressions or test failures detected."
 
   conclusion:
     needs: [setup, bench]
@@ -197,17 +212,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Fetch job URLs and find the step number for the RESULTS step to deep-link.
           gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
             --paginate --jq '
               .jobs[] | select(.name | startswith("bench (")) |
               (.name | ltrimstr("bench (") | rtrimstr(")") | split(", ")) as $p |
-              (if ($p | length) == 4 then
-                {go: $p[0], ossl: (if $p[1] == "" then "system" else $p[1] end), host: $p[2], platform: $p[3]}
-              elif ($p | length) == 3 then
-                {go: $p[0], ossl: "system", host: $p[1], platform: $p[2]}
-              else empty end) as $m |
-              "\($m.platform)-\($m.host)-ossl\($m.ossl)-go\($m.go)\t\(.html_url)"' \
-            > job_urls.tsv
+              # Find the RESULTS step that actually ran (not skipped)
+              (first(.steps[] | select((.name | test("RESULTS")) and .conclusion != "skipped") | .number) // null) as $step |
+              "\($p | join("-"))\t\(.html_url)\(if $step then "#step:\($step):1" else "" end)"' \
+            > job_urls.tsv || true
           cat job_urls.tsv
 
       - name: Build report

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,60 +25,22 @@ jobs:
     - name: Install build tools
       run: sudo apt-get update && sudo apt-get install -y build-essential
 
-    - name: Checkout HEAD (your branch)
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        path: head
-
-    - name: Checkout BASE (target branch)
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.base-ref }}
-        path: base
-
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version: ${{ matrix.go-version }}
-        cache-dependency-path: head/go.mod
-
-    - name: Install benchstat
-      run: go install golang.org/x/perf/cmd/benchstat@latest
-
     - name: Install OpenSSL
-      run: sudo sh ./head/scripts/openssl.sh ${{ matrix.openssl-version }}
-
-    - name: Run benchmarks (base)
-      working-directory: base
-      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt
-      env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
-        CGO_ENABLED: 1
-
-    - name: Run benchmarks (head)
-      working-directory: head
-      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt
-      env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
-        CGO_ENABLED: 1
-
-    - name: Compare benchmarks
       run: |
-        benchstat base.txt head.txt | tee benchstat.txt
-        # For sec/op, B/op, allocs/op: a "+" means regression (slower / more allocs).
-        # For B/s: a "+" means improvement (more throughput), so we exclude it.
-        # Only flag regressions >= 5% to ignore CI noise on shared runners.
-        if awk '
-          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
-          /^$/ { header=0 }
-          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
-          END { exit !found }
-        ' benchstat.txt; then
-          echo ""
-          echo "Statistically significant benchmark regression(s) >= 5% detected."
-          exit 1
-        fi
-        echo ""
-        echo "No significant benchmark regressions detected."
+        # Checkout just the install script first
+        git clone --depth 1 --filter=blob:none --sparse ${{ github.server_url }}/${{ github.repository }} _openssl_setup
+        cd _openssl_setup && git sparse-checkout set scripts
+        cd ..
+        sudo sh ./_openssl_setup/scripts/openssl.sh ${{ matrix.openssl-version }}
+        rm -rf _openssl_setup
+
+    - uses: golang-fips/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
+      with:
+        base-ref: ${{ inputs.base-ref }}
+        go-version: ${{ matrix.go-version }}
+        env-vars: |
+          GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.openssl-version }}
+          CGO_ENABLED=1
 
   osslbench:
     strategy:
@@ -91,60 +53,13 @@ jobs:
           - {os: windows-2022, openssl-version: libcrypto-3-x64.dll}
     runs-on: ${{ matrix.host.os }}
     steps:
-    - name: Checkout HEAD (your branch)
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: golang-fips/go-infra/.github/actions/benchmark@dev/mclayton/benchmark-workflow
       with:
-        path: head
-
-    - name: Checkout BASE (target branch)
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.base-ref }}
-        path: base
-
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
+        base-ref: ${{ inputs.base-ref }}
         go-version: ${{ matrix.go-version }}
-        cache-dependency-path: head/go.mod
-
-    - name: Install benchstat
-      run: go install golang.org/x/perf/cmd/benchstat@latest
-
-    - name: Run benchmarks (base)
-      shell: bash
-      working-directory: base
-      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../base.txt
-      env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
-        CGO_ENABLED: 1
-
-    - name: Run benchmarks (head)
-      shell: bash
-      working-directory: head
-      run: go test -run='^$' -bench=. -count=7 -benchmem -timeout 30m ./... 2>/dev/null | tee ../head.txt
-      env:
-        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.host.openssl-version }}
-        CGO_ENABLED: 1
-
-    - name: Compare benchmarks
-      shell: bash
-      run: |
-        benchstat base.txt head.txt | tee benchstat.txt
-        # For sec/op, B/op, allocs/op: a "+" means regression (slower / more allocs).
-        # For B/s: a "+" means improvement (more throughput), so we exclude it.
-        # Only flag regressions >= 5% to ignore CI noise on shared runners.
-        if awk '
-          /^[[:space:]]*│.*(sec\/op|B\/op|allocs\/op)/ { header=1; next }
-          /^$/ { header=0 }
-          header && match($0, /\+([0-9]+\.[0-9]+)% \(p=/, m) { if (m[1]+0 >= 5) found=1 }
-          END { exit !found }
-        ' benchstat.txt; then
-          echo ""
-          echo "Statistically significant benchmark regression(s) >= 5% detected."
-          exit 1
-        fi
-        echo ""
-        echo "No significant benchmark regressions detected."
+        env-vars: |
+          GO_OPENSSL_VERSION_OVERRIDE=${{ matrix.host.openssl-version }}
+          CGO_ENABLED=1
 
   conclusion:
     needs: [bench, osslbench]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 .vscode/
+.github/benchcheck/benchcheck

--- a/cshake_test.go
+++ b/cshake_test.go
@@ -243,6 +243,9 @@ func benchmarkHash(b *testing.B, h hash.Hash, size, num int) {
 // benchmarkCSHAKE is specialized to the Shake instances, which don't
 // require a copy on reading output.
 func benchmarkCSHAKE(b *testing.B, h *openssl.SHAKE, size, num int) {
+	if !openssl.SupportsSHAKE(128) {
+		b.Skip("SHAKE not supported")
+	}
 	b.StopTimer()
 	h.Reset()
 	data := sequentialBytes(size)

--- a/cshake_test.go
+++ b/cshake_test.go
@@ -247,9 +247,6 @@ func benchmarkHash(b *testing.B, hType crypto.Hash, hfun func() *openssl.Hash, s
 // benchmarkCSHAKE is specialized to the Shake instances, which don't
 // require a copy on reading output.
 func benchmarkCSHAKE(b *testing.B, h *openssl.SHAKE, size, num int) {
-	if !openssl.SupportsSHAKE(128) {
-		b.Skip("SHAKE not supported")
-	}
 	b.StopTimer()
 	h.Reset()
 	data := sequentialBytes(size)

--- a/cshake_test.go
+++ b/cshake_test.go
@@ -246,7 +246,11 @@ func benchmarkHash(b *testing.B, hType crypto.Hash, hfun func() *openssl.Hash, s
 
 // benchmarkCSHAKE is specialized to the Shake instances, which don't
 // require a copy on reading output.
-func benchmarkCSHAKE(b *testing.B, h *openssl.SHAKE, size, num int) {
+func benchmarkCSHAKE(b *testing.B, bits int, newShake func() *openssl.SHAKE, size, num int) {
+	if !openssl.SupportsSHAKE(bits) {
+		b.Skip("SHAKE not supported")
+	}
+	h := newShake()
 	b.StopTimer()
 	h.Reset()
 	data := sequentialBytes(size)


### PR DESCRIPTION
Implement a workflow that runs benchmarks on different versions of go and openssl. This will run for every PR. Verified that it will catch an alloc increase: 
- https://github.com/golang-fips/openssl/pull/416

Posts results in the comments with links pointing to the specific job. Since comments have a character limit, the results will just show top regressions and shoudl show test failures.

- https://github.com/golang-fips/openssl/issues/408