### PR TITLE
Fix chacha20 bench

### DIFF
--- a/chacha20poly1305_test.go
+++ b/chacha20poly1305_test.go
@@ -163,12 +163,12 @@ func TestChaCha20Poly1305Random(t *testing.T) {
 	t.Run("Standard", func(t *testing.T) { f(t, 12) })
 }
 
-func benchmarkChaCha20Poly1305Seal(b *testing.B, buf []byte, nonceSize int) {
+func benchmarkChaCha20Poly1305Seal(b *testing.B, buf []byte, nLen int) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(buf)))
 
 	var key [32]byte
-	var nonce = make([]byte, nonceSize)
+	var nonce = make([]byte, nLen)
 	var ad [13]byte
 	var out []byte
 
@@ -186,12 +186,12 @@ func benchmarkChaCha20Poly1305Seal(b *testing.B, buf []byte, nonceSize int) {
 	}
 }
 
-func benchmarkChaCha20Poly1305Open(b *testing.B, buf []byte, nonceSize int) {
+func benchmarkChaCha20Poly1305Open(b *testing.B, buf []byte, nLen int) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(buf)))
 
 	var key [32]byte
-	var nonce = make([]byte, nonceSize)
+	var nonce = make([]byte, nLen)
 	var ad [13]byte
 	var ct []byte
 	var out []byte


### PR DESCRIPTION
Previously. was failing with: 

```
BenchmarkChacha20Poly1305/Open-64-X-4       	panic: chacha20poly1305: bad nonce length passed to Seal

goroutine 96 [running]:
github.com/golang-fips/openssl/v2.(*chacha20poly1305).Seal(0xc000047e88?, {0x0?, 0x7f69f7f57490?, 0x7f69f7f4ea78?}, {0xc000022270?, 0xc000180008?, 0xc00001a500?}, {0xc00001a500, 0x40, 0x40}, ...)
	/home/runner/work/openssl/openssl/head/chacha20poly1305.go:53 +0x50b
github.com/golang-fips/openssl/v2_test.benchmarkChaCha20Poly1305Open(0xc000136848, {0xc00001a500, 0x40, 0x40}, 0x18)
	/home/runner/work/openssl/openssl/head/chacha20poly1305_test.go:206 +0x12f
github.com/golang-fips/openssl/v2_test.BenchmarkChacha20Poly1305.func3(0xc000136848)
	/home/runner/work/openssl/openssl/head/chacha20poly1305_test.go:227 +0x45
testing.(*B).runN(0xc000136848, 0x1)
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/benchmark.go:219 +0x190
testing.(*B).run1.func1()
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/benchmark.go:245 +0x48
created by testing.(*B).run1 in goroutine 56
	/opt/hostedtoolcache/go/1.25.8/x64/src/testing/benchmark.go:238 +0x90
exit status 2
FAIL	github.com/golang-fips/openssl/v2	60.681s
?   	github.com/golang-fips/openssl/v2/bbig	[no test files]
?   	github.com/golang-fips/openssl/v2/cmd/checkheader	[no test files]
?   	github.com/golang-fips/openssl/v2/cmd/genaesmodes	[no test files]
?   	github.com/golang-fips/openssl/v2/cmd/gentestvectors	[no test files]
?   	github.com/golang-fips/openssl/v2/cmd/mkcgo	[no test files]
?   	github.com/golang-fips/openssl/v2/internal/cryptotest	[no test files]
?   	github.com/golang-fips/openssl/v2/internal/fakecgo	[no test files]
PASS
ok  	github.com/golang-fips/openssl/v2/internal/mkcgo	0.002s
?   	github.com/golang-fips/openssl/v2/internal/ossl	[no test files]
?   	github.com/golang-fips/openssl/v2/osslsetup	[no test files]
FAIL
```

Results after the fix:
```
$ GO_OPENSSL_VERSION_OVERRIDE=/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib go test -run='^$' -bench='BenchmarkChacha20Poly1305' -count=1 -benchmem ./...
Using /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib
OpenSSL version: OpenSSL 3.6.1 27 Jan 2026
FIPS enabled: false
FIPS capable: false
goos: darwin
goarch: arm64
pkg: github.com/golang-fips/openssl/v2
cpu: Apple M4 Max
BenchmarkChacha20Poly1305/Open-64-14             2020446               597.0 ns/op       107.20 MB/s           0 B/op          0 allocs/op
BenchmarkChacha20Poly1305/Seal-64-14             2083592               573.5 ns/op       111.59 MB/s           0 B/op          0 allocs/op
BenchmarkChacha20Poly1305/Open-1350-14           1000000              1164 ns/op        1159.77 MB/s           0 B/op          0 allocs/op
BenchmarkChacha20Poly1305/Seal-1350-14           1000000              1164 ns/op        1159.34 MB/s           0 B/op          0 allocs/op
BenchmarkChacha20Poly1305/Open-8192-14            302056              3938 ns/op        2080.43 MB/s           0 B/op          0 allocs/op
BenchmarkChacha20Poly1305/Seal-8192-14            303046              3949 ns/op        2074.32 MB/s           0 B/op          0 allocs/op
PASS
ok      github.com/golang-fips/openssl/v2       8.752s
```