### PR TITLE
cshake_test: skip CSHAKE benchmarks on OpenSSL < 3.3

### DIFF
--- a/cshake_test.go
+++ b/cshake_test.go
@@ -243,6 +243,9 @@ func benchmarkHash(b *testing.B, h hash.Hash, size, num int) {
 // benchmarkCSHAKE is specialized to the Shake instances, which don't
 // require a copy on reading output.
 func benchmarkCSHAKE(b *testing.B, h *openssl.SHAKE, size, num int) {
+	if !openssl.SupportsSHAKE(128) {
+		b.Skip("SHAKE not supported")
+	}
 	b.StopTimer()
 	h.Reset()
 	data := sequentialBytes(size)


### PR DESCRIPTION
EVP_DigestSqueeze was added in OpenSSL 3.3. On earlier versions, NewSHAKE128/256 succeeds (the EVP_MD loads) but Read() calls through a null function pointer,  resulting in a SIGSEGV at runtime. Add a SupportsSHAKE guard to skip the benchmarks on unsupported versions.