### PR TITLE
Stop passing nil pointer to OSSL_PARAM_BLD_push_octet_string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0]
+        openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0, 3.5.6]
         host: [ubuntu-22.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.host }}
     steps:

--- a/params.go
+++ b/params.go
@@ -108,6 +108,10 @@ func (b *paramBuilder) addUTF8String(name cString, value *byte, size int) {
 	}
 }
 
+// emptyOctetStringBuf serves as a non-nil sentinel pointer for
+// zero-length octet strings passed to OpenSSL.
+var emptyOctetStringBuf byte
+
 // addOctetString adds an octet string to the builder.
 // The value is pinned and will be unpinned when the builder is freed.
 func (b *paramBuilder) addOctetString(name cString, value []byte) {
@@ -116,6 +120,10 @@ func (b *paramBuilder) addOctetString(name cString, value []byte) {
 	}
 	if len(value) != 0 {
 		b.pinner.Pin(&value[0])
+	} else {
+		// OpenSSL >= 3.5.6 rejects a NULL buf in OSSL_PARAM_BLD_push_octet_string
+		// even when bsize is 0 (see crypto/param_build.c).
+		value = unsafe.Slice(&emptyOctetStringBuf, 0)
 	}
 	if _, err := ossl.OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), value); err != nil {
 		b.err = addParamError{name.str(), err}

--- a/params.go
+++ b/params.go
@@ -108,10 +108,6 @@ func (b *paramBuilder) addUTF8String(name cString, value *byte, size int) {
 	}
 }
 
-// emptyOctetStringBuf serves as a non-nil sentinel pointer for
-// zero-length octet strings passed to OpenSSL.
-var emptyOctetStringBuf byte
-
 // addOctetString adds an octet string to the builder.
 // The value is pinned and will be unpinned when the builder is freed.
 func (b *paramBuilder) addOctetString(name cString, value []byte) {
@@ -123,7 +119,7 @@ func (b *paramBuilder) addOctetString(name cString, value []byte) {
 	} else {
 		// OpenSSL >= 3.5.6 rejects a NULL buf in OSSL_PARAM_BLD_push_octet_string
 		// even when bsize is 0 (see crypto/param_build.c).
-		value = unsafe.Slice(&emptyOctetStringBuf, 0)
+		value = []byte{}
 	}
 	if _, err := ossl.OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), value); err != nil {
 		b.err = addParamError{name.str(), err}

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -86,6 +86,13 @@ case "$version" in
         make="build_libs"
         install="install_fips"
         ;;
+    "3.5.6")
+        tag="openssl-3.5.6";
+        sha256="a572efd967f99e2dc8228c46ba45410948d5b9a343f1e0271b9960298982866b"
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
+        ;;
     *)
         echo >&2 "error: unsupported OpenSSL version '$version'"
         exit 1 ;;


### PR DESCRIPTION
This should highlight a breaking API change in OpenSSL: https://github.com/openssl/openssl/commit/e4610b43539b