### PR TITLE
Short-circuit nil octet string params

### DIFF
--- a/hkdf.go
+++ b/hkdf.go
@@ -350,9 +350,7 @@ func newTLS13KDFExpandCtx3(md ossl.EVP_MD_PTR, label, context, pseudorandomKey [
 	bld.addOctetString(_OSSL_KDF_PARAM_PREFIX, []byte("tls13 "))
 	bld.addOctetString(_OSSL_KDF_PARAM_LABEL, label)
 	bld.addOctetString(_OSSL_KDF_PARAM_DATA, context)
-	if len(pseudorandomKey) > 0 {
-		bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
-	}
+	bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
 
 	params, err := bld.build()
 	if err != nil {
@@ -401,18 +399,10 @@ func newHKDFCtx3(md ossl.EVP_MD_PTR, mode int32, secret, salt, pseudorandomKey, 
 	defer bld.finalize()
 	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
 	bld.addInt32(_OSSL_KDF_PARAM_MODE, int32(mode))
-	if len(secret) > 0 {
-		bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)
-	}
-	if len(salt) > 0 {
-		bld.addOctetString(_OSSL_KDF_PARAM_SALT, salt)
-	}
-	if len(pseudorandomKey) > 0 {
-		bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
-	}
-	if len(info) > 0 {
-		bld.addOctetString(_OSSL_KDF_PARAM_INFO, info)
-	}
+	bld.addOctetString(_OSSL_KDF_PARAM_KEY, secret)
+	bld.addOctetString(_OSSL_KDF_PARAM_SALT, salt)
+	bld.addOctetString(_OSSL_KDF_PARAM_KEY, pseudorandomKey)
+	bld.addOctetString(_OSSL_KDF_PARAM_INFO, info)
 	params, err := bld.build()
 	if err != nil {
 		return ctx, err

--- a/params.go
+++ b/params.go
@@ -115,6 +115,11 @@ func (b *paramBuilder) addOctetString(name cString, value []byte) {
 		return
 	}
 	if value == nil {
+		// Short-circuit a nil slice: don't pass anything at all to OpenSSL.
+		// OpenSSL 3.5.6 raises an error when passed null, and expects users
+		// to not call this function at all in this case.
+		// See https://github.com/openssl/openssl/issues/30728
+		//
 		// Don't short-circuit empty slices, as they might have a meaning.
 		// For example, in KDFs an empty salt is different from a nil salt.
 		return

--- a/params.go
+++ b/params.go
@@ -114,12 +114,13 @@ func (b *paramBuilder) addOctetString(name cString, value []byte) {
 	if !b.check() {
 		return
 	}
+	if value == nil {
+		// Don't short-circuit empty slices, as they might have a meaning.
+		// For example, in KDFs an empty salt is different from a nil salt.
+		return
+	}
 	if len(value) != 0 {
 		b.pinner.Pin(&value[0])
-	} else {
-		// OpenSSL >= 3.5.6 rejects a NULL buf in OSSL_PARAM_BLD_push_octet_string
-		// even when bsize is 0 (see crypto/param_build.c).
-		value = []byte{}
 	}
 	if _, err := ossl.OSSL_PARAM_BLD_push_octet_string(b.bld, name.ptr(), value); err != nil {
 		b.err = addParamError{name.str(), err}


### PR DESCRIPTION
This is another approach to fix #417 in which we keep the original caller intent: empty slices are passed to OpenSSL, nil slices are just skipped.