### PR TITLE
Remove OpenSSL 1.1.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.26.x]
-        openssl-version: [1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0, 3.5.6]
+        openssl-version: [1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1, 3.4.0, 3.5.0, 3.5.6]
         host: [ubuntu-22.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.host }}
     steps:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On the other hand, Google maintains a branch that uses cgo and BoringSSL to impl
 
 ### Multiple OpenSSL versions supported
 
-The `openssl` package has support for multiple OpenSSL versions, namely 1.1.0, 1.1.1 and 3.x.
+The `openssl` package has support for multiple OpenSSL versions, namely 1.1.1 and 3.x.
 
 All supported OpenSSL versions pass a small set of automatic tests that ensure they can be built and that there are no major regressions.
 These tests do not validate the cryptographic correctness of the `openssl` package.

--- a/ec.go
+++ b/ec.go
@@ -22,11 +22,6 @@ func SupportsCurve(curve string) bool {
 }
 
 var supportsX25519 = sync.OnceValue(func() bool {
-	if !versionAtOrAbove(1, 1, 1) {
-		// X25519 support was added in OpenSSL 1.1.0, but the APIs we use
-		// to implement it were only added in 1.1.1.
-		return false
-	}
 	ctx, _ := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_X25519, nil)
 	if ctx != nil {
 		ossl.EVP_PKEY_CTX_free(ctx)

--- a/ed25519.go
+++ b/ed25519.go
@@ -28,12 +28,10 @@ const (
 var supportsEd25519 = sync.OnceValue(func() bool {
 	switch major() {
 	case 1:
-		if versionAtOrAbove(1, 1, 1) {
-			ctx, _ := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_ED25519, nil)
-			if ctx != nil {
-				ossl.EVP_PKEY_CTX_free(ctx)
-				return true
-			}
+		ctx, _ := ossl.EVP_PKEY_CTX_new_id(ossl.EVP_PKEY_ED25519, nil)
+		if ctx != nil {
+			ossl.EVP_PKEY_CTX_free(ctx)
+			return true
 		}
 	case 3:
 		sig, _ := ossl.EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)

--- a/evp.go
+++ b/evp.go
@@ -135,33 +135,21 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 		hash.magic = magic512
 		hash.marshalledSize = marshaledSize512
 	case crypto.SHA512_224:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha512_224()
-			hash.magic = magic512_224
-			hash.marshalledSize = marshaledSize512
-		}
+		hash.md = ossl.EVP_sha512_224()
+		hash.magic = magic512_224
+		hash.marshalledSize = marshaledSize512
 	case crypto.SHA512_256:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha512_256()
-			hash.magic = magic512_256
-			hash.marshalledSize = marshaledSize512
-		}
+		hash.md = ossl.EVP_sha512_256()
+		hash.magic = magic512_256
+		hash.marshalledSize = marshaledSize512
 	case crypto.SHA3_224:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha3_224()
-		}
+		hash.md = ossl.EVP_sha3_224()
 	case crypto.SHA3_256:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha3_256()
-		}
+		hash.md = ossl.EVP_sha3_256()
 	case crypto.SHA3_384:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha3_384()
-		}
+		hash.md = ossl.EVP_sha3_384()
 	case crypto.SHA3_512:
-		if versionAtOrAbove(1, 1, 1) {
-			hash.md = ossl.EVP_sha3_512()
-		}
+		hash.md = ossl.EVP_sha3_512()
 	}
 	if hash.md == nil {
 		cacheMD.Store(ch, (*hashAlgorithm)(nil))

--- a/hkdf.go
+++ b/hkdf.go
@@ -17,7 +17,7 @@ import (
 func SupportsHKDF() bool {
 	switch major() {
 	case 1:
-		return versionAtOrAbove(1, 1, 1)
+		return true
 	case 3:
 		_, err := fetchHKDF3()
 		return err == nil

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -137,10 +137,10 @@ typedef void* _BIO_PTR;
 typedef int point_conversion_form_t;
 
 // Tags used by mkcgo to determine which OpenSSL version each function is available in:
-// - no tag: OpenSSL 1.0 or later
+// - no tag: available in all supported versions (OpenSSL 1.1.1+)
 // - legacy_1: Only OpenSSL 1
 // - 3: OpenSSL 3.0 or later
-// - 111: OpenSSL 1.1.1 or later
+// - 33: OpenSSL 3.3 or later
 
 // The noescape/nocallback attributes are performance optimizations.
 // Only add functions that have been observed to benefit from these
@@ -203,16 +203,16 @@ const _EVP_MD_PTR EVP_sha224(void) __attribute__((noerror));
 const _EVP_MD_PTR EVP_sha256(void) __attribute__((noerror));
 const _EVP_MD_PTR EVP_sha384(void) __attribute__((noerror));
 const _EVP_MD_PTR EVP_sha512(void) __attribute__((noerror));
-const _EVP_MD_PTR EVP_sha512_224(void) __attribute__((tag("111"),noerror));
-const _EVP_MD_PTR EVP_sha512_256(void) __attribute__((tag("111"),noerror));
-const _EVP_MD_PTR EVP_sha3_224(void) __attribute__((tag("111"),noerror));
-const _EVP_MD_PTR EVP_sha3_256(void) __attribute__((tag("111"),noerror));
-const _EVP_MD_PTR EVP_sha3_384(void) __attribute__((tag("111"),noerror));
-const _EVP_MD_PTR EVP_sha3_512(void) __attribute__((tag("111"),noerror));
+const _EVP_MD_PTR EVP_sha512_224(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha512_256(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha3_224(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha3_256(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha3_384(void) __attribute__((noerror));
+const _EVP_MD_PTR EVP_sha3_512(void) __attribute__((noerror));
 
 _EVP_MD_CTX_PTR EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(_EVP_MD_CTX_PTR ctx);
-int EVP_MD_CTX_ctrl(_EVP_MD_CTX_PTR ctx, int cmd, int p1, void *p2) __attribute__((tag("111")));
+int EVP_MD_CTX_ctrl(_EVP_MD_CTX_PTR ctx, int cmd, int p1, void *p2);
 int EVP_MD_CTX_copy_ex(_EVP_MD_CTX_PTR out, const _EVP_MD_CTX_PTR in);
 const _OSSL_PARAM_PTR EVP_MD_CTX_gettable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
 const _OSSL_PARAM_PTR EVP_MD_CTX_settable_params(_EVP_MD_CTX_PTR ctx) __attribute__((tag("3")));
@@ -225,12 +225,12 @@ int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute
 int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback,slice("md","s")));
 int EVP_DigestFinalXOF(_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t mdlen) __attribute__((tag("33"),noescape,nocallback,slice("md","mdlen")));
 int EVP_DigestSqueeze(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t outlen) __attribute__((tag("33"),noescape,nocallback,slice("out","outlen")));
-int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),noescape,nocallback,slice("sigret","siglen"),slice("tbs","tbslen")));
+int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((noescape,nocallback,slice("sigret","siglen"),slice("tbs","tbslen")));
 int EVP_DigestSignInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
 int EVP_DigestSignFinal(_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen) __attribute__((slice("sig","siglen")));
 int EVP_DigestVerifyInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
 int EVP_DigestVerifyFinal(_EVP_MD_CTX_PTR ctx, const unsigned char *sig, size_t siglen) __attribute__((slice("sig","siglen")));
-int EVP_DigestVerify(_EVP_MD_CTX_PTR ctx, const unsigned char *sigret, size_t siglen, const unsigned char *tbs, size_t tbslen) __attribute__((tag("111"),slice("sigret","siglen"),slice("tbs","tbslen")));
+int EVP_DigestVerify(_EVP_MD_CTX_PTR ctx, const unsigned char *sigret, size_t siglen, const unsigned char *tbs, size_t tbslen) __attribute__((slice("sigret","siglen"),slice("tbs","tbslen")));
 
 // HMAC API
 int HMAC_Init_ex(_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const _EVP_MD_PTR arg3, _ENGINE_PTR arg4) __attribute__((tag("legacy_1"),noescape,nocallback,slice("arg1","arg2")));
@@ -280,8 +280,8 @@ int EVP_DecryptFinal_ex(_EVP_CIPHER_CTX_PTR ctx, unsigned char *outm, int *outl)
 
 // EVP_PKEY API
 _EVP_PKEY_PTR EVP_PKEY_new(void);
-_EVP_PKEY_PTR EVP_PKEY_new_raw_private_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111"),slice("key","keylen")));
-_EVP_PKEY_PTR EVP_PKEY_new_raw_public_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((tag("111"),slice("key","keylen")));
+_EVP_PKEY_PTR EVP_PKEY_new_raw_private_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((slice("key","keylen")));
+_EVP_PKEY_PTR EVP_PKEY_new_raw_public_key(int type, _ENGINE_PTR e, const unsigned char *key, size_t keylen) __attribute__((slice("key","keylen")));
 int EVP_PKEY_get_size(const _EVP_PKEY_PTR pkey) __attribute__((tag("3"),tag("legacy_1","EVP_PKEY_size")));
 int EVP_PKEY_get_bits(const _EVP_PKEY_PTR pkey) __attribute__((tag("3"),tag("legacy_1","EVP_PKEY_bits"))); 
 void EVP_PKEY_free(_EVP_PKEY_PTR arg0);
@@ -296,8 +296,8 @@ int EVP_PKEY_get_octet_string_param(const _EVP_PKEY_PTR pkey, const char *key_na
 int EVP_PKEY_up_ref(_EVP_PKEY_PTR key);
 int EVP_PKEY_set1_EC_KEY(_EVP_PKEY_PTR pkey, _EC_KEY_PTR key) __attribute__((tag("legacy_1")));
 int EVP_PKEY_CTX_set0_rsa_oaep_label(_EVP_PKEY_CTX_PTR ctx, void *label, int labellen) __attribute__((tag("3"),slice("label","labellen")));
-int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *publen) __attribute__((tag("111"),noescape,nocallback,slice("pub","publen")));
-int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *privlen) __attribute__((tag("111"),noescape,nocallback,slice("priv","privlen")));
+int EVP_PKEY_get_raw_public_key(const _EVP_PKEY_PTR pkey, unsigned char *pub, size_t *publen) __attribute__((noescape,nocallback,slice("pub","publen")));
+int EVP_PKEY_get_raw_private_key(const _EVP_PKEY_PTR pkey, unsigned char *priv, size_t *privlen) __attribute__((noescape,nocallback,slice("priv","privlen")));
 int EVP_PKEY_fromdata_init(_EVP_PKEY_CTX_PTR ctx) __attribute__((tag("3")));
 int EVP_PKEY_fromdata(_EVP_PKEY_CTX_PTR ctx, _EVP_PKEY_PTR *pkey, int selection, _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_PKEY_paramgen_init(_EVP_PKEY_CTX_PTR ctx);

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -295,15 +295,18 @@ void __mkcgo_load_(void* handle) {
 	__mkcgo__dlsym(EVP_DigestFinal_ex)
 	__mkcgo__dlsym(EVP_DigestInit)
 	__mkcgo__dlsym(EVP_DigestInit_ex)
+	__mkcgo__dlsym(EVP_DigestSign)
 	__mkcgo__dlsym(EVP_DigestSignFinal)
 	__mkcgo__dlsym(EVP_DigestSignInit)
 	__mkcgo__dlsym(EVP_DigestUpdate)
+	__mkcgo__dlsym(EVP_DigestVerify)
 	__mkcgo__dlsym(EVP_DigestVerifyFinal)
 	__mkcgo__dlsym(EVP_DigestVerifyInit)
 	__mkcgo__dlsym(EVP_EncryptFinal_ex)
 	__mkcgo__dlsym(EVP_EncryptInit_ex)
 	__mkcgo__dlsym(EVP_EncryptUpdate)
 	__mkcgo__dlsym(EVP_MD_CTX_copy_ex)
+	__mkcgo__dlsym(EVP_MD_CTX_ctrl)
 	__mkcgo__dlsym(EVP_MD_CTX_free)
 	__mkcgo__dlsym(EVP_MD_CTX_new)
 	__mkcgo__dlsym(EVP_PKEY_CTX_ctrl)
@@ -318,9 +321,13 @@ void __mkcgo_load_(void* handle) {
 	__mkcgo__dlsym(EVP_PKEY_encrypt)
 	__mkcgo__dlsym(EVP_PKEY_encrypt_init)
 	__mkcgo__dlsym(EVP_PKEY_free)
+	__mkcgo__dlsym(EVP_PKEY_get_raw_private_key)
+	__mkcgo__dlsym(EVP_PKEY_get_raw_public_key)
 	__mkcgo__dlsym(EVP_PKEY_keygen)
 	__mkcgo__dlsym(EVP_PKEY_keygen_init)
 	__mkcgo__dlsym(EVP_PKEY_new)
+	__mkcgo__dlsym(EVP_PKEY_new_raw_private_key)
+	__mkcgo__dlsym(EVP_PKEY_new_raw_public_key)
 	__mkcgo__dlsym(EVP_PKEY_paramgen)
 	__mkcgo__dlsym(EVP_PKEY_paramgen_init)
 	__mkcgo__dlsym(EVP_PKEY_sign)
@@ -354,7 +361,13 @@ void __mkcgo_load_(void* handle) {
 	__mkcgo__dlsym(EVP_sha224)
 	__mkcgo__dlsym(EVP_sha256)
 	__mkcgo__dlsym(EVP_sha384)
+	__mkcgo__dlsym(EVP_sha3_224)
+	__mkcgo__dlsym(EVP_sha3_256)
+	__mkcgo__dlsym(EVP_sha3_384)
+	__mkcgo__dlsym(EVP_sha3_512)
 	__mkcgo__dlsym(EVP_sha512)
+	__mkcgo__dlsym(EVP_sha512_224)
+	__mkcgo__dlsym(EVP_sha512_256)
 	__mkcgo__dlsym(OBJ_nid2sn)
 	__mkcgo__dlsym(OPENSSL_init)
 	__mkcgo__dlsym(OPENSSL_init_crypto)
@@ -402,15 +415,18 @@ void __mkcgo_unload_() {
 	_g_EVP_DigestFinal_ex = NULL;
 	_g_EVP_DigestInit = NULL;
 	_g_EVP_DigestInit_ex = NULL;
+	_g_EVP_DigestSign = NULL;
 	_g_EVP_DigestSignFinal = NULL;
 	_g_EVP_DigestSignInit = NULL;
 	_g_EVP_DigestUpdate = NULL;
+	_g_EVP_DigestVerify = NULL;
 	_g_EVP_DigestVerifyFinal = NULL;
 	_g_EVP_DigestVerifyInit = NULL;
 	_g_EVP_EncryptFinal_ex = NULL;
 	_g_EVP_EncryptInit_ex = NULL;
 	_g_EVP_EncryptUpdate = NULL;
 	_g_EVP_MD_CTX_copy_ex = NULL;
+	_g_EVP_MD_CTX_ctrl = NULL;
 	_g_EVP_MD_CTX_free = NULL;
 	_g_EVP_MD_CTX_new = NULL;
 	_g_EVP_PKEY_CTX_ctrl = NULL;
@@ -425,9 +441,13 @@ void __mkcgo_unload_() {
 	_g_EVP_PKEY_encrypt = NULL;
 	_g_EVP_PKEY_encrypt_init = NULL;
 	_g_EVP_PKEY_free = NULL;
+	_g_EVP_PKEY_get_raw_private_key = NULL;
+	_g_EVP_PKEY_get_raw_public_key = NULL;
 	_g_EVP_PKEY_keygen = NULL;
 	_g_EVP_PKEY_keygen_init = NULL;
 	_g_EVP_PKEY_new = NULL;
+	_g_EVP_PKEY_new_raw_private_key = NULL;
+	_g_EVP_PKEY_new_raw_public_key = NULL;
 	_g_EVP_PKEY_paramgen = NULL;
 	_g_EVP_PKEY_paramgen_init = NULL;
 	_g_EVP_PKEY_sign = NULL;
@@ -461,45 +481,19 @@ void __mkcgo_unload_() {
 	_g_EVP_sha224 = NULL;
 	_g_EVP_sha256 = NULL;
 	_g_EVP_sha384 = NULL;
+	_g_EVP_sha3_224 = NULL;
+	_g_EVP_sha3_256 = NULL;
+	_g_EVP_sha3_384 = NULL;
+	_g_EVP_sha3_512 = NULL;
 	_g_EVP_sha512 = NULL;
+	_g_EVP_sha512_224 = NULL;
+	_g_EVP_sha512_256 = NULL;
 	_g_OBJ_nid2sn = NULL;
 	_g_OPENSSL_init = NULL;
 	_g_OPENSSL_init_crypto = NULL;
 	_g_OpenSSL_version = NULL;
 	_g_PKCS5_PBKDF2_HMAC = NULL;
 	_g_RAND_bytes = NULL;
-}
-
-void __mkcgo_load_111(void* handle) {
-	__mkcgo__dlsym(EVP_DigestSign)
-	__mkcgo__dlsym(EVP_DigestVerify)
-	__mkcgo__dlsym(EVP_MD_CTX_ctrl)
-	__mkcgo__dlsym(EVP_PKEY_get_raw_private_key)
-	__mkcgo__dlsym(EVP_PKEY_get_raw_public_key)
-	__mkcgo__dlsym(EVP_PKEY_new_raw_private_key)
-	__mkcgo__dlsym(EVP_PKEY_new_raw_public_key)
-	__mkcgo__dlsym(EVP_sha3_224)
-	__mkcgo__dlsym(EVP_sha3_256)
-	__mkcgo__dlsym(EVP_sha3_384)
-	__mkcgo__dlsym(EVP_sha3_512)
-	__mkcgo__dlsym(EVP_sha512_224)
-	__mkcgo__dlsym(EVP_sha512_256)
-}
-
-void __mkcgo_unload_111() {
-	_g_EVP_DigestSign = NULL;
-	_g_EVP_DigestVerify = NULL;
-	_g_EVP_MD_CTX_ctrl = NULL;
-	_g_EVP_PKEY_get_raw_private_key = NULL;
-	_g_EVP_PKEY_get_raw_public_key = NULL;
-	_g_EVP_PKEY_new_raw_private_key = NULL;
-	_g_EVP_PKEY_new_raw_public_key = NULL;
-	_g_EVP_sha3_224 = NULL;
-	_g_EVP_sha3_256 = NULL;
-	_g_EVP_sha3_384 = NULL;
-	_g_EVP_sha3_512 = NULL;
-	_g_EVP_sha512_224 = NULL;
-	_g_EVP_sha512_256 = NULL;
 }
 
 void __mkcgo_load_3(void* handle) {

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -103,8 +103,6 @@ enum {
 uintptr_t mkcgo_err_retrieve();
 void __mkcgo_load_(void* handle);
 void __mkcgo_unload_();
-void __mkcgo_load_111(void* handle);
-void __mkcgo_unload_111();
 void __mkcgo_load_3(void* handle);
 void __mkcgo_unload_3();
 void __mkcgo_load_33(void* handle);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -121,14 +121,6 @@ func MkcgoUnload_() {
 	C.__mkcgo_unload_()
 }
 
-func MkcgoLoad_111(handle unsafe.Pointer) {
-	C.__mkcgo_load_111(handle)
-}
-
-func MkcgoUnload_111() {
-	C.__mkcgo_unload_111()
-}
-
 func MkcgoLoad_3(handle unsafe.Pointer) {
 	C.__mkcgo_load_3(handle)
 }

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -1946,15 +1946,18 @@ func MkcgoLoad_(handle unsafe.Pointer) {
 	_mkcgo_EVP_DigestFinal_ex = dlsym(handle, "EVP_DigestFinal_ex\x00", false)
 	_mkcgo_EVP_DigestInit = dlsym(handle, "EVP_DigestInit\x00", false)
 	_mkcgo_EVP_DigestInit_ex = dlsym(handle, "EVP_DigestInit_ex\x00", false)
+	_mkcgo_EVP_DigestSign = dlsym(handle, "EVP_DigestSign\x00", false)
 	_mkcgo_EVP_DigestSignFinal = dlsym(handle, "EVP_DigestSignFinal\x00", false)
 	_mkcgo_EVP_DigestSignInit = dlsym(handle, "EVP_DigestSignInit\x00", false)
 	_mkcgo_EVP_DigestUpdate = dlsym(handle, "EVP_DigestUpdate\x00", false)
+	_mkcgo_EVP_DigestVerify = dlsym(handle, "EVP_DigestVerify\x00", false)
 	_mkcgo_EVP_DigestVerifyFinal = dlsym(handle, "EVP_DigestVerifyFinal\x00", false)
 	_mkcgo_EVP_DigestVerifyInit = dlsym(handle, "EVP_DigestVerifyInit\x00", false)
 	_mkcgo_EVP_EncryptFinal_ex = dlsym(handle, "EVP_EncryptFinal_ex\x00", false)
 	_mkcgo_EVP_EncryptInit_ex = dlsym(handle, "EVP_EncryptInit_ex\x00", false)
 	_mkcgo_EVP_EncryptUpdate = dlsym(handle, "EVP_EncryptUpdate\x00", false)
 	_mkcgo_EVP_MD_CTX_copy_ex = dlsym(handle, "EVP_MD_CTX_copy_ex\x00", false)
+	_mkcgo_EVP_MD_CTX_ctrl = dlsym(handle, "EVP_MD_CTX_ctrl\x00", false)
 	_mkcgo_EVP_MD_CTX_free = dlsym(handle, "EVP_MD_CTX_free\x00", false)
 	_mkcgo_EVP_MD_CTX_new = dlsym(handle, "EVP_MD_CTX_new\x00", false)
 	_mkcgo_EVP_PKEY_CTX_ctrl = dlsym(handle, "EVP_PKEY_CTX_ctrl\x00", false)
@@ -1969,9 +1972,13 @@ func MkcgoLoad_(handle unsafe.Pointer) {
 	_mkcgo_EVP_PKEY_encrypt = dlsym(handle, "EVP_PKEY_encrypt\x00", false)
 	_mkcgo_EVP_PKEY_encrypt_init = dlsym(handle, "EVP_PKEY_encrypt_init\x00", false)
 	_mkcgo_EVP_PKEY_free = dlsym(handle, "EVP_PKEY_free\x00", false)
+	_mkcgo_EVP_PKEY_get_raw_private_key = dlsym(handle, "EVP_PKEY_get_raw_private_key\x00", false)
+	_mkcgo_EVP_PKEY_get_raw_public_key = dlsym(handle, "EVP_PKEY_get_raw_public_key\x00", false)
 	_mkcgo_EVP_PKEY_keygen = dlsym(handle, "EVP_PKEY_keygen\x00", false)
 	_mkcgo_EVP_PKEY_keygen_init = dlsym(handle, "EVP_PKEY_keygen_init\x00", false)
 	_mkcgo_EVP_PKEY_new = dlsym(handle, "EVP_PKEY_new\x00", false)
+	_mkcgo_EVP_PKEY_new_raw_private_key = dlsym(handle, "EVP_PKEY_new_raw_private_key\x00", false)
+	_mkcgo_EVP_PKEY_new_raw_public_key = dlsym(handle, "EVP_PKEY_new_raw_public_key\x00", false)
 	_mkcgo_EVP_PKEY_paramgen = dlsym(handle, "EVP_PKEY_paramgen\x00", false)
 	_mkcgo_EVP_PKEY_paramgen_init = dlsym(handle, "EVP_PKEY_paramgen_init\x00", false)
 	_mkcgo_EVP_PKEY_sign = dlsym(handle, "EVP_PKEY_sign\x00", false)
@@ -2005,7 +2012,13 @@ func MkcgoLoad_(handle unsafe.Pointer) {
 	_mkcgo_EVP_sha224 = dlsym(handle, "EVP_sha224\x00", false)
 	_mkcgo_EVP_sha256 = dlsym(handle, "EVP_sha256\x00", false)
 	_mkcgo_EVP_sha384 = dlsym(handle, "EVP_sha384\x00", false)
+	_mkcgo_EVP_sha3_224 = dlsym(handle, "EVP_sha3_224\x00", false)
+	_mkcgo_EVP_sha3_256 = dlsym(handle, "EVP_sha3_256\x00", false)
+	_mkcgo_EVP_sha3_384 = dlsym(handle, "EVP_sha3_384\x00", false)
+	_mkcgo_EVP_sha3_512 = dlsym(handle, "EVP_sha3_512\x00", false)
 	_mkcgo_EVP_sha512 = dlsym(handle, "EVP_sha512\x00", false)
+	_mkcgo_EVP_sha512_224 = dlsym(handle, "EVP_sha512_224\x00", false)
+	_mkcgo_EVP_sha512_256 = dlsym(handle, "EVP_sha512_256\x00", false)
 	_mkcgo_OBJ_nid2sn = dlsym(handle, "OBJ_nid2sn\x00", false)
 	_mkcgo_OPENSSL_init = dlsym(handle, "OPENSSL_init\x00", false)
 	_mkcgo_OPENSSL_init_crypto = dlsym(handle, "OPENSSL_init_crypto\x00", false)
@@ -2053,15 +2066,18 @@ func MkcgoUnload_() {
 	_mkcgo_EVP_DigestFinal_ex = 0
 	_mkcgo_EVP_DigestInit = 0
 	_mkcgo_EVP_DigestInit_ex = 0
+	_mkcgo_EVP_DigestSign = 0
 	_mkcgo_EVP_DigestSignFinal = 0
 	_mkcgo_EVP_DigestSignInit = 0
 	_mkcgo_EVP_DigestUpdate = 0
+	_mkcgo_EVP_DigestVerify = 0
 	_mkcgo_EVP_DigestVerifyFinal = 0
 	_mkcgo_EVP_DigestVerifyInit = 0
 	_mkcgo_EVP_EncryptFinal_ex = 0
 	_mkcgo_EVP_EncryptInit_ex = 0
 	_mkcgo_EVP_EncryptUpdate = 0
 	_mkcgo_EVP_MD_CTX_copy_ex = 0
+	_mkcgo_EVP_MD_CTX_ctrl = 0
 	_mkcgo_EVP_MD_CTX_free = 0
 	_mkcgo_EVP_MD_CTX_new = 0
 	_mkcgo_EVP_PKEY_CTX_ctrl = 0
@@ -2076,9 +2092,13 @@ func MkcgoUnload_() {
 	_mkcgo_EVP_PKEY_encrypt = 0
 	_mkcgo_EVP_PKEY_encrypt_init = 0
 	_mkcgo_EVP_PKEY_free = 0
+	_mkcgo_EVP_PKEY_get_raw_private_key = 0
+	_mkcgo_EVP_PKEY_get_raw_public_key = 0
 	_mkcgo_EVP_PKEY_keygen = 0
 	_mkcgo_EVP_PKEY_keygen_init = 0
 	_mkcgo_EVP_PKEY_new = 0
+	_mkcgo_EVP_PKEY_new_raw_private_key = 0
+	_mkcgo_EVP_PKEY_new_raw_public_key = 0
 	_mkcgo_EVP_PKEY_paramgen = 0
 	_mkcgo_EVP_PKEY_paramgen_init = 0
 	_mkcgo_EVP_PKEY_sign = 0
@@ -2112,45 +2132,19 @@ func MkcgoUnload_() {
 	_mkcgo_EVP_sha224 = 0
 	_mkcgo_EVP_sha256 = 0
 	_mkcgo_EVP_sha384 = 0
+	_mkcgo_EVP_sha3_224 = 0
+	_mkcgo_EVP_sha3_256 = 0
+	_mkcgo_EVP_sha3_384 = 0
+	_mkcgo_EVP_sha3_512 = 0
 	_mkcgo_EVP_sha512 = 0
+	_mkcgo_EVP_sha512_224 = 0
+	_mkcgo_EVP_sha512_256 = 0
 	_mkcgo_OBJ_nid2sn = 0
 	_mkcgo_OPENSSL_init = 0
 	_mkcgo_OPENSSL_init_crypto = 0
 	_mkcgo_OpenSSL_version = 0
 	_mkcgo_PKCS5_PBKDF2_HMAC = 0
 	_mkcgo_RAND_bytes = 0
-}
-
-func MkcgoLoad_111(handle unsafe.Pointer) {
-	_mkcgo_EVP_DigestSign = dlsym(handle, "EVP_DigestSign\x00", false)
-	_mkcgo_EVP_DigestVerify = dlsym(handle, "EVP_DigestVerify\x00", false)
-	_mkcgo_EVP_MD_CTX_ctrl = dlsym(handle, "EVP_MD_CTX_ctrl\x00", false)
-	_mkcgo_EVP_PKEY_get_raw_private_key = dlsym(handle, "EVP_PKEY_get_raw_private_key\x00", false)
-	_mkcgo_EVP_PKEY_get_raw_public_key = dlsym(handle, "EVP_PKEY_get_raw_public_key\x00", false)
-	_mkcgo_EVP_PKEY_new_raw_private_key = dlsym(handle, "EVP_PKEY_new_raw_private_key\x00", false)
-	_mkcgo_EVP_PKEY_new_raw_public_key = dlsym(handle, "EVP_PKEY_new_raw_public_key\x00", false)
-	_mkcgo_EVP_sha3_224 = dlsym(handle, "EVP_sha3_224\x00", false)
-	_mkcgo_EVP_sha3_256 = dlsym(handle, "EVP_sha3_256\x00", false)
-	_mkcgo_EVP_sha3_384 = dlsym(handle, "EVP_sha3_384\x00", false)
-	_mkcgo_EVP_sha3_512 = dlsym(handle, "EVP_sha3_512\x00", false)
-	_mkcgo_EVP_sha512_224 = dlsym(handle, "EVP_sha512_224\x00", false)
-	_mkcgo_EVP_sha512_256 = dlsym(handle, "EVP_sha512_256\x00", false)
-}
-
-func MkcgoUnload_111() {
-	_mkcgo_EVP_DigestSign = 0
-	_mkcgo_EVP_DigestVerify = 0
-	_mkcgo_EVP_MD_CTX_ctrl = 0
-	_mkcgo_EVP_PKEY_get_raw_private_key = 0
-	_mkcgo_EVP_PKEY_get_raw_public_key = 0
-	_mkcgo_EVP_PKEY_new_raw_private_key = 0
-	_mkcgo_EVP_PKEY_new_raw_public_key = 0
-	_mkcgo_EVP_sha3_224 = 0
-	_mkcgo_EVP_sha3_256 = 0
-	_mkcgo_EVP_sha3_384 = 0
-	_mkcgo_EVP_sha3_512 = 0
-	_mkcgo_EVP_sha512_224 = 0
-	_mkcgo_EVP_sha512_256 = 0
 }
 
 func MkcgoLoad_3(handle unsafe.Pointer) {

--- a/openssl.go
+++ b/openssl.go
@@ -69,7 +69,7 @@ func utoa(n int) string {
 }
 
 func errUnsupportedVersion() error {
-	return errors.New("openssl: OpenSSL version: " + utoa(major()) + "." + utoa(minor()) + "." + utoa(patch()))
+	return errors.New("openssl: unsupported OpenSSL version: " + utoa(major()) + "." + utoa(minor()) + "." + utoa(patch()) + " (minimum supported version is 1.1.1)")
 }
 
 // checkMajorVersion panics if the current major version is not expected.

--- a/osslsetup/init.go
+++ b/osslsetup/init.go
@@ -25,11 +25,7 @@ func opensslInit(file string) error {
 	ossl.MkcgoLoad_(handle)
 	if vMajor == 1 {
 		ossl.MkcgoLoad_legacy_1(handle)
-		if vPatch == 1 {
-			ossl.MkcgoLoad_111(handle)
-		}
 	} else {
-		ossl.MkcgoLoad_111(handle)
 		ossl.MkcgoLoad_3(handle)
 		if vMajor >= 3 && vMinor >= 3 {
 			ossl.MkcgoLoad_33(handle)
@@ -148,7 +144,7 @@ func openLibrary(file string) (handle unsafe.Pointer, close func(), err error) {
 	var supported bool
 	switch vMajor {
 	case 1:
-		supported = vMinor == 1
+		supported = vMinor == 1 && vPatch >= 1
 	case 3:
 		// OpenSSL guarantees API and ABI compatibility within the same major version since OpenSSL 3.
 		supported = true

--- a/osslsetup/osslsetup.go
+++ b/osslsetup/osslsetup.go
@@ -31,7 +31,7 @@ func utoa(n int) string {
 }
 
 func errUnsupportedVersion() error {
-	return errors.New("openssl: OpenSSL version: " + utoa(vMajor) + "." + utoa(vMinor) + "." + utoa(vPatch))
+	return errors.New("openssl: unsupported OpenSSL version: " + utoa(vMajor) + "." + utoa(vMinor) + "." + utoa(vPatch) + " (minimum supported version is 1.1.1)")
 }
 
 var (

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -9,13 +9,6 @@ set -eux
 version=$1
 
 case "$version" in
-    "1.1.0")
-        tag="OpenSSL_1_1_0l"
-        sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d"
-        config="shared"
-        make="build_libs"
-        install=""
-        ;;
     "1.1.1")
         tag="OpenSSL_1_1_1m"
         sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"


### PR DESCRIPTION
Remove support for 1.1.0 support 

- https://github.com/golang-fips/openssl/issues/401