### PR TITLE
Skip benchmarks on .github-only changes; raise time threshold to 50%

### DIFF
--- a/.github/benchcheck/check.go
+++ b/.github/benchcheck/check.go
@@ -36,7 +36,7 @@ type regression struct {
 
 func cmdCheck(args []string) {
 	fs := flag.NewFlagSet("check", flag.ExitOnError)
-	timeThreshold := fs.Float64("time-threshold", 5, "minimum sec/op regression percentage to flag")
+	timeThreshold := fs.Float64("time-threshold", 50, "minimum sec/op regression percentage to flag")
 	minTime := fs.Duration("min-time", time.Microsecond, "minimum base time for sec/op checks")
 	alpha := fs.Float64("alpha", 0.05, "significance level for statistical tests")
 	regressionsOut := fs.String("o-regressions", "regressions.txt", "output file for regression details")

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,8 @@ name: Benchmark
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
     inputs:
       base-ref:


### PR DESCRIPTION
Improve benchmarks to only run on relevant changes and raise threshold to avoid flaky failures 

- https://github.com/microsoft/go-lab/issues/342