### PR TITLE
Emit available() helpers for 3.x.x+

### DIFF
--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -224,7 +224,7 @@ int EVP_DigestInit(_EVP_MD_CTX_PTR ctx, const _EVP_MD_PTR type);
 int EVP_DigestUpdate(_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt) __attribute__((noescape,nocallback,slice("d","cnt")));
 int EVP_DigestFinal_ex(_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s) __attribute__((noescape,nocallback,slice("md","s")));
 int EVP_DigestFinalXOF(_EVP_MD_CTX_PTR ctx, unsigned char *md, size_t mdlen) __attribute__((tag("33"),noescape,nocallback,slice("md","mdlen")));
-int EVP_DigestSqueeze(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t outlen) __attribute__((tag("33"),noescape,nocallback,slice("out","outlen")));
+int EVP_DigestSqueeze(_EVP_MD_CTX_PTR ctx, unsigned char *out, size_t outlen) __attribute__((tag("33"),optional,noescape,nocallback,slice("out","outlen")));
 int EVP_DigestSign(_EVP_MD_CTX_PTR ctx, unsigned char *sigret, size_t *siglen, const unsigned char *tbs, size_t tbslen) __attribute__((noescape,nocallback,slice("sigret","siglen"),slice("tbs","tbslen")));
 int EVP_DigestSignInit(_EVP_MD_CTX_PTR ctx, _EVP_PKEY_CTX_PTR *pctx, const _EVP_MD_PTR type, _ENGINE_PTR e, _EVP_PKEY_PTR pkey);
 int EVP_DigestSignFinal(_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen) __attribute__((slice("sig","siglen")));
@@ -424,7 +424,7 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, 
 const char *OBJ_nid2sn(int n) __attribute__((noerror));
 
 // EVP KEM API for ML-KEM (OpenSSL 3.x)
-_EVP_KEYMGMT_PTR EVP_KEYMGMT_fetch(_OSSL_LIB_CTX_PTR libctx, const char *algorithm, const char *properties) __attribute__((tag("3")));
+_EVP_KEYMGMT_PTR EVP_KEYMGMT_fetch(_OSSL_LIB_CTX_PTR libctx, const char *algorithm, const char *properties) __attribute__((tag("3"),optional));
 void EVP_KEYMGMT_free(_EVP_KEYMGMT_PTR keymgmt) __attribute__((tag("3")));
 int EVP_PKEY_encapsulate_init(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3")));
 int EVP_PKEY_encapsulate(_EVP_PKEY_CTX_PTR ctx, unsigned char *wrappedkey, size_t *wrappedkeylen, unsigned char *genkey, size_t *genkeylen) __attribute__((tag("3")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -508,7 +508,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_KDF_derive)
 	__mkcgo__dlsym(EVP_KDF_fetch)
 	__mkcgo__dlsym(EVP_KDF_free)
-	__mkcgo__dlsym(EVP_KEYMGMT_fetch)
+	__mkcgo__dlsym_nocheck(EVP_KEYMGMT_fetch, EVP_KEYMGMT_fetch)
 	__mkcgo__dlsym(EVP_KEYMGMT_free)
 	__mkcgo__dlsym(EVP_MAC_CTX_dup)
 	__mkcgo__dlsym(EVP_MAC_CTX_free)
@@ -644,7 +644,7 @@ void __mkcgo_unload_3() {
 
 void __mkcgo_load_33(void* handle) {
 	__mkcgo__dlsym(EVP_DigestFinalXOF)
-	__mkcgo__dlsym(EVP_DigestSqueeze)
+	__mkcgo__dlsym_nocheck(EVP_DigestSqueeze, EVP_DigestSqueeze)
 }
 
 void __mkcgo_unload_33() {
@@ -1126,6 +1126,10 @@ int _mkcgo_EVP_DigestSignInit(_EVP_MD_CTX_PTR _arg0, _EVP_PKEY_CTX_PTR* _arg1, c
 	return _ret;
 }
 
+int _mkcgo_available_EVP_DigestSqueeze() {
+	return _g_EVP_DigestSqueeze != NULL;
+}
+
 int _mkcgo_EVP_DigestSqueeze(_EVP_MD_CTX_PTR _arg0, unsigned char* _arg1, size_t _arg2, uintptr_t *_err_state) {
 	int _ret = _g_EVP_DigestSqueeze(_arg0, _arg1, _arg2);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
@@ -1210,6 +1214,10 @@ _EVP_KDF_PTR _mkcgo_EVP_KDF_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, co
 
 void _mkcgo_EVP_KDF_free(_EVP_KDF_PTR _arg0) {
 	_g_EVP_KDF_free(_arg0);
+}
+
+int _mkcgo_available_EVP_KEYMGMT_fetch() {
+	return _g_EVP_KEYMGMT_fetch != NULL;
 }
 
 _EVP_KEYMGMT_PTR _mkcgo_EVP_KEYMGMT_fetch(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, uintptr_t *_err_state) {

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -116,6 +116,8 @@ void __mkcgo_unload_legacy_1();
 void __mkcgo_load_version(void* handle);
 void __mkcgo_unload_version();
 
+int _mkcgo_available_EVP_DigestSqueeze();
+int _mkcgo_available_EVP_KEYMGMT_fetch();
 int _mkcgo_available_EVP_chacha20_poly1305();
 int _mkcgo_available_OPENSSL_version_major();
 int _mkcgo_available_OPENSSL_version_minor();

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -530,6 +530,10 @@ func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_M
 	return int32(_ret), newMkcgoErr("EVP_DigestSignInit", uintptr(_err))
 }
 
+func EVP_DigestSqueeze_Available() bool {
+	return C._mkcgo_available_EVP_DigestSqueeze() != 0
+}
+
 func EVP_DigestSqueeze(ctx EVP_MD_CTX_PTR, out []byte) (int32, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_DigestSqueeze(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(out))), C.size_t(len(out)), mkcgoNoEscape(&_err))
@@ -620,6 +624,10 @@ func EVP_KDF_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (
 
 func EVP_KDF_free(kdf EVP_KDF_PTR) {
 	C._mkcgo_EVP_KDF_free(kdf)
+}
+
+func EVP_KEYMGMT_fetch_Available() bool {
+	return C._mkcgo_available_EVP_KEYMGMT_fetch() != 0
 }
 
 func EVP_KEYMGMT_fetch(libctx OSSL_LIB_CTX_PTR, algorithm *byte, properties *byte) (EVP_KEYMGMT_PTR, error) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -545,6 +545,10 @@ func EVP_DigestSignInit(ctx EVP_MD_CTX_PTR, pctx *EVP_PKEY_CTX_PTR, __type EVP_M
 	return int32(r0), newMkcgoErr("EVP_DigestSignInit", _err)
 }
 
+func EVP_DigestSqueeze_Available() bool {
+	return _mkcgo_EVP_DigestSqueeze != 0
+}
+
 var _mkcgo_EVP_DigestSqueeze uintptr
 
 func EVP_DigestSqueeze(ctx EVP_MD_CTX_PTR, out []byte) (int32, error) {
@@ -665,6 +669,10 @@ var _mkcgo_EVP_KDF_free uintptr
 
 func EVP_KDF_free(kdf EVP_KDF_PTR) {
 	syscallN(0, _mkcgo_EVP_KDF_free, uintptr(kdf))
+}
+
+func EVP_KEYMGMT_fetch_Available() bool {
+	return _mkcgo_EVP_KEYMGMT_fetch != 0
 }
 
 var _mkcgo_EVP_KEYMGMT_fetch uintptr
@@ -2159,7 +2167,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_KDF_derive = dlsym(handle, "EVP_KDF_derive\x00", false)
 	_mkcgo_EVP_KDF_fetch = dlsym(handle, "EVP_KDF_fetch\x00", false)
 	_mkcgo_EVP_KDF_free = dlsym(handle, "EVP_KDF_free\x00", false)
-	_mkcgo_EVP_KEYMGMT_fetch = dlsym(handle, "EVP_KEYMGMT_fetch\x00", false)
+	_mkcgo_EVP_KEYMGMT_fetch = dlsym(handle, "EVP_KEYMGMT_fetch\x00", true)
 	_mkcgo_EVP_KEYMGMT_free = dlsym(handle, "EVP_KEYMGMT_free\x00", false)
 	_mkcgo_EVP_MAC_CTX_dup = dlsym(handle, "EVP_MAC_CTX_dup\x00", false)
 	_mkcgo_EVP_MAC_CTX_free = dlsym(handle, "EVP_MAC_CTX_free\x00", false)
@@ -2295,7 +2303,7 @@ func MkcgoUnload_3() {
 
 func MkcgoLoad_33(handle unsafe.Pointer) {
 	_mkcgo_EVP_DigestFinalXOF = dlsym(handle, "EVP_DigestFinalXOF\x00", false)
-	_mkcgo_EVP_DigestSqueeze = dlsym(handle, "EVP_DigestSqueeze\x00", false)
+	_mkcgo_EVP_DigestSqueeze = dlsym(handle, "EVP_DigestSqueeze\x00", true)
 }
 
 func MkcgoUnload_33() {


### PR DESCRIPTION
This pull request refactors how the codebase determines whether to emit and use `<Name>_Available()` helper functions for OpenSSL dynamic loading, making the logic more robust and less reliant on a manually-set `Optional` field. It introduces a new helper, `fnHasAvailable`, and updates all relevant code paths to use it. Additionally, it expands the set of available-checking C helper declarations and updates feature detection in the SHAKE implementation.

**Refactoring and logic improvements:**

* Introduced the `fnHasAvailable` helper function in `generate.go` to centralize and clarify the logic for emitting `<Name>_Available()` helpers, replacing checks against the `Optional` field throughout code generation (`cmd/mkcgo/generate.go`).
* Updated all code generation paths (`generateGoCgo`, `generateCHeader`, `generateC`, `generateNocgoFn`) to use `fnHasAvailable` instead of directly checking `fn.Optional`, ensuring consistent logic for when availability helpers are emitted (`cmd/mkcgo/generate.go`). [[1]](diffhunk://#diff-6d1e1a20c0b164eef948b12e08408f7696fa886baa64b7032d0c6959d3b81873L123-R123) [[2]](diffhunk://#diff-6d1e1a20c0b164eef948b12e08408f7696fa886baa64b7032d0c6959d3b81873L264-R264) [[3]](diffhunk://#diff-6d1e1a20c0b164eef948b12e08408f7696fa886baa64b7032d0c6959d3b81873L347-R347) [[4]](diffhunk://#diff-6d1e1a20c0b164eef948b12e08408f7696fa886baa64b7032d0c6959d3b81873L1078-R1086)

**C helper function declarations:**

* Added a large number of new `<Name>_Available` C function declarations to `internal/ossl/zossl.h`, increasing the coverage of runtime-checked OpenSSL symbols.

**Feature detection improvements:**

* Updated the SHAKE support check in `cshake.go` to use `ossl.EVP_DigestSqueeze_Available()` instead of a version check, making feature detection more robust to OpenSSL variants and builds.

- https://github.com/microsoft/go/issues/2254