### PR TITLE
Migrate SHAKE, ML-KEM, DES, and RC4 off versionAtOrAbove

### DIFF
--- a/cshake.go
+++ b/cshake.go
@@ -53,13 +53,15 @@ func SumSHAKE256(data []byte, length int) []byte {
 
 var shakeSupported sync.Map
 
+var hasDigestSqueeze = sync.OnceValue(ossl.EVP_DigestSqueeze_Available)
+
 // SupportsSHAKE returns true if the SHAKE extendable output functions
 // with the given securityBits are supported.
 func SupportsSHAKE(securityBits int) bool {
-	if !versionAtOrAbove(3, 3, 0) {
-		// SHAKE MD's are supported since OpenSSL 1.1.1,
-		// but EVP_DigestSqueeze is only supported since 3.3,
-		// and we need it to implement [sha3.SHAKE].
+	if !hasDigestSqueeze() {
+		// SHAKE MD's are supported since OpenSSL 1.1.1, but
+		// EVP_DigestSqueeze (added in OpenSSL 3.3) is required to
+		// implement [sha3.SHAKE]'s streaming Read API.
 		return false
 	}
 	if v, ok := shakeSupported.Load(securityBits); ok {

--- a/des.go
+++ b/des.go
@@ -12,9 +12,15 @@ import (
 // If CBC is also supported, then the returned cipher.Block
 // will also implement NewCBCEncrypter and NewCBCDecrypter.
 func SupportsDESCipher() bool {
-	// True for stock OpenSSL 1 w/o FIPS.
-	// False for stock OpenSSL 3 unless the legacy provider is available.
-	return (versionAtOrAbove(3, 0, 0) || !FIPS()) && loadCipher(cipherDES, cipherModeECB) != nil
+	switch major() {
+	case 1:
+		// DES is not part of the OpenSSL 1.x FIPS module.
+		return !FIPS() && loadCipher(cipherDES, cipherModeECB) != nil
+	default:
+		// On OpenSSL 3+ availability is decided by the algorithm probe:
+		// EVP_CIPHER_fetch returns nil unless the legacy provider is loaded.
+		return loadCipher(cipherDES, cipherModeECB) != nil
+	}
 }
 
 // SupportsTripleDESCipher returns true if NewTripleDESCipher is supported,

--- a/mlkem.go
+++ b/mlkem.go
@@ -32,36 +32,39 @@ const (
 
 // SupportsMLKEM768 returns true if ML-KEM-768 is supported on this platform.
 func SupportsMLKEM768() bool {
-	if versionAtOrAbove(3, 5, 0) {
-		return supportsMLKEM768()
-	}
-	return false
+	return supportsMLKEM768()
 }
 
 // SupportsMLKEM1024 returns true if ML-KEM-1024 is supported on this platform.
 func SupportsMLKEM1024() bool {
-	if versionAtOrAbove(3, 5, 0) {
-		return supportsMLKEM1024()
-	}
-	return false
+	return supportsMLKEM1024()
 }
 
 var supportsMLKEM768 = sync.OnceValue(func() bool {
-	sig, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLKEM768.ptr(), nil)
-	if sig != nil {
-		ossl.EVP_KEYMGMT_free(sig)
-		return true
+	// EVP_KEYMGMT_fetch was added in OpenSSL 3.0; if it is not available we
+	// are on 1.x and ML-KEM is not supported. On 3.0–3.4 the fetch returns
+	// nil for the ML-KEM algorithm name, which the probe reports as false.
+	if !ossl.EVP_KEYMGMT_fetch_Available() {
+		return false
 	}
-	return false
+	sig, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLKEM768.ptr(), nil)
+	if sig == nil {
+		return false
+	}
+	ossl.EVP_KEYMGMT_free(sig)
+	return true
 })
 
 var supportsMLKEM1024 = sync.OnceValue(func() bool {
-	sig, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLKEM1024.ptr(), nil)
-	if sig != nil {
-		ossl.EVP_KEYMGMT_free(sig)
-		return true
+	if !ossl.EVP_KEYMGMT_fetch_Available() {
+		return false
 	}
-	return false
+	sig, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLKEM1024.ptr(), nil)
+	if sig == nil {
+		return false
+	}
+	ossl.EVP_KEYMGMT_free(sig)
+	return true
 })
 
 // DecapsulationKeyMLKEM768 is the secret key used to decapsulate a shared key

--- a/rc4.go
+++ b/rc4.go
@@ -10,9 +10,15 @@ import (
 
 // SupportsRC4 returns true if NewRC4Cipher is supported.
 func SupportsRC4() bool {
-	// True for stock OpenSSL 1 w/o FIPS.
-	// False for stock OpenSSL 3 unless the legacy provider is available.
-	return (versionAtOrAbove(3, 0, 0) || !FIPS()) && loadCipher(cipherRC4, cipherModeNone) != nil
+	switch major() {
+	case 1:
+		// RC4 is not part of the OpenSSL 1.x FIPS module.
+		return !FIPS() && loadCipher(cipherRC4, cipherModeNone) != nil
+	default:
+		// On OpenSSL 3+ availability is decided by the algorithm probe:
+		// EVP_CIPHER_fetch returns nil unless the legacy provider is loaded.
+		return loadCipher(cipherRC4, cipherModeNone) != nil
+	}
 }
 
 // A RC4Cipher is an instance of RC4 using a particular key.


### PR DESCRIPTION
This pull request refines how support for various cryptographic algorithms is detected, making the checks more accurate and robust across different OpenSSL versions. The main improvements involve updating the feature detection logic for SHAKE, DES, RC4, and ML-KEM algorithms to better reflect their actual availability, especially considering OpenSSL version differences and provider requirements.

**Algorithm support detection improvements:**

* Updated SHAKE support detection (`cshake.go`) to check for the actual presence of `EVP_DigestSqueeze` rather than just relying on the OpenSSL version, ensuring correct feature gating for the streaming API.
* Refactored DES and RC4 support checks (`des.go`, `rc4.go`) to use a `major()` version switch, providing clearer logic that correctly handles FIPS mode and the legacy provider on OpenSSL 3+. [[1]](diffhunk://#diff-22074bec2df4c032031002d073690a2953f7d23c1a0307e12f7bb0f5e7becc19L15-R23) [[2]](diffhunk://#diff-5af6cfee0276c85358eba3cf1feaf8ce486c5e839b8461b96719ef001b88cfd8L13-R21)

**Post-quantum (ML-KEM) support detection:**

* Improved ML-KEM-768 and ML-KEM-1024 support checks (`mlkem.go`) to probe for the availability of `EVP_KEYMGMT_fetch` and the actual algorithm, rather than just checking the OpenSSL version, resulting in more accurate and future-proof detection.
- https://github.com/microsoft/go/issues/2255