### PR TITLE
Tighten remaining version checks

### DIFF
--- a/evp.go
+++ b/evp.go
@@ -577,10 +577,8 @@ func newEvpFromParams(id int32, selection int32, params ossl.OSSL_PARAM_PTR) (os
 	}
 	var pkey ossl.EVP_PKEY_PTR
 	if _, err := ossl.EVP_PKEY_fromdata(ctx, &pkey, selection, params); err != nil {
-		if major() == 3 && minor() <= 2 {
-			// OpenSSL 3.0.1 and 3.0.2 have a bug where EVP_PKEY_fromdata
-			// does not free the internally allocated EVP_PKEY on error.
-			// See https://github.com/openssl/openssl/issues/17407.
+		//versionguardcheck:ignore OpenSSL 3.0.0–3.0.2 leak EVP_PKEY on error: https://github.com/openssl/openssl/issues/17407.
+		if major() == 3 && minor() == 0 && patch() <= 2 {
 			ossl.EVP_PKEY_free(pkey)
 		}
 		return nil, err

--- a/hmac.go
+++ b/hmac.go
@@ -149,12 +149,12 @@ func newHMAC3(key []byte, md ossl.EVP_MD_PTR) hmacCtx3 {
 		panic(err)
 	}
 	var hkey []byte
-	if minor() == 0 && patch() <= 2 {
+	//versionguardcheck:ignore OpenSSL 3.0.0–3.0.2 EVP_MAC_init does not reset without a key: https://github.com/openssl/openssl/issues/17811.
+	if major() == 3 && minor() == 0 && patch() <= 2 {
 		// EVP_MAC_init only resets the ctx internal state if a key is passed
 		// when using OpenSSL 3.0.0, 3.0.1, and 3.0.2. Save a copy of the key
 		// in the context so Reset can use it later. New OpenSSL versions
 		// do not have this issue so it isn't necessary to save the key.
-		// See https://github.com/openssl/openssl/issues/17811.
 		hkey = make([]byte, len(key))
 		copy(hkey, key)
 	}

--- a/openssl.go
+++ b/openssl.go
@@ -233,13 +233,6 @@ func bnToBinPad(bn ossl.BIGNUM_PTR, to []byte) error {
 	return err
 }
 
-// versionAtOrAbove returns true when
-// (major(), minor(), patch()) >= (vmajor, vminor, vpatch),
-// compared lexicographically.
-func versionAtOrAbove(vmajor, vminor, vpatch int) bool {
-	return major() > vmajor || (major() == vmajor && minor() > vminor) || (major() == vmajor && minor() == vminor && patch() >= vpatch)
-}
-
 func bigEndianUint64(b []byte) uint64 {
 	_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
 	return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |


### PR DESCRIPTION
This pull request makes targeted improvements to OpenSSL version-specific handling and code clarity, particularly for OpenSSL 3.0.0–3.0.2 bug workarounds. The main changes involve refining version checks, adding clear annotations for version guard checks, and removing an unused helper function.

**OpenSSL version-specific bug workarounds:**

* Updated the version check in `evp.go` for the EVP_PKEY memory leak workaround to precisely match only OpenSSL 3.0.0–3.0.2, and added an explicit annotation (`//versionguardcheck:ignore`) referencing the relevant OpenSSL issue for clarity.
* Added a `//versionguardcheck:ignore` annotation in `hmac.go` to document the workaround for the EVP_MAC_init reset bug in OpenSSL 3.0.0–3.0.2, improving maintainability and clarity.

**Code cleanup:**

* Removed the unused `versionAtOrAbove` helper function from `openssl.go` to simplify the codebase.

- https://github.com/microsoft/go/issues/2256