### PR TITLE
Add OpenSSL MLDSA support

### DIFF
--- a/const.go
+++ b/const.go
@@ -37,6 +37,9 @@ const ( //checkheader:ignore
 	_KeyTypeX25519           cString = "X25519\x00"
 	_KeyTypeMLKEM768         cString = "ML-KEM-768\x00"
 	_KeyTypeMLKEM1024        cString = "ML-KEM-1024\x00"
+	_KeyTypeMLDSA44          cString = "ML-DSA-44\x00"
+	_KeyTypeMLDSA65          cString = "ML-DSA-65\x00"
+	_KeyTypeMLDSA87          cString = "ML-DSA-87\x00"
 	_KeyTypeChacha20Poly1305 cString = "CHACHA20-POLY1305\x00"
 
 	// Digest names
@@ -85,6 +88,11 @@ const ( //checkheader:ignore
 	_OSSL_PKEY_PARAM_RSA_EXPONENT2      cString = "rsa-exponent2\x00"
 	_OSSL_PKEY_PARAM_RSA_COEFFICIENT1   cString = "rsa-coefficient1\x00"
 	_OSSL_PKEY_PARAM_ML_KEM_SEED        cString = "seed\x00"
+	_OSSL_PKEY_PARAM_ML_DSA_SEED        cString = "seed\x00"
+
+	// Signature parameters
+	_OSSL_SIGNATURE_PARAM_CONTEXT_STRING cString = "context-string\x00"
+	_OSSL_SIGNATURE_PARAM_MU             cString = "mu\x00"
 
 	// MAC parameters
 	_OSSL_MAC_PARAM_DIGEST cString = "digest\x00"

--- a/evp.go
+++ b/evp.go
@@ -247,6 +247,12 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 			pkey, err = ossl.EVP_PKEY_Q_keygen_MLKEM(nil, nil, _KeyTypeMLKEM768.ptr())
 		case ossl.EVP_PKEY_MLKEM_1024:
 			pkey, err = ossl.EVP_PKEY_Q_keygen_MLKEM(nil, nil, _KeyTypeMLKEM1024.ptr())
+		case ossl.EVP_PKEY_ML_DSA_44:
+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA44.ptr())
+		case ossl.EVP_PKEY_ML_DSA_65:
+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA65.ptr())
+		case ossl.EVP_PKEY_ML_DSA_87:
+			pkey, err = ossl.EVP_PKEY_Q_keygen_MLDSA(nil, nil, _KeyTypeMLDSA87.ptr())
 		default:
 			panic("unsupported key type '" + strconv.Itoa(int(id)) + "'")
 		}

--- a/export_test.go
+++ b/export_test.go
@@ -12,4 +12,15 @@ var (
 	EncapsulationKeySizeMLKEM1024 = encapsulationKeySizeMLKEM1024
 )
 
+// MLDSA constants for testing against the stdlib
+var (
+	PrivateKeySizeMLDSA  = privateKeySizeMLDSA
+	PublicKeySizeMLDSA44 = publicKeySizeMLDSA44
+	PublicKeySizeMLDSA65 = publicKeySizeMLDSA65
+	PublicKeySizeMLDSA87 = publicKeySizeMLDSA87
+	SignatureSizeMLDSA44 = signatureSizeMLDSA44
+	SignatureSizeMLDSA65 = signatureSizeMLDSA65
+	SignatureSizeMLDSA87 = signatureSizeMLDSA87
+)
+
 var HashBufSize = hashBufSize

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -53,6 +53,9 @@ enum {
 	_EVP_PKEY_DSA         = 116,
     _EVP_PKEY_MLKEM_768  = 1455,
     _EVP_PKEY_MLKEM_1024 = 1456,
+    _EVP_PKEY_ML_DSA_44  = 1457,
+    _EVP_PKEY_ML_DSA_65  = 1458,
+    _EVP_PKEY_ML_DSA_87  = 1459,
 	_EVP_PKEY_OP_DERIVE = (1 << 10), // this value differs between OpenSSL 1 and 3, but we only use it in 1
 	_EVP_MAX_MD_SIZE    = 64,
 
@@ -82,6 +85,9 @@ enum {
 
 	_NID_ML_KEM_768 = 1455,
 	_NID_ML_KEM_1024 = 1456,
+	_NID_ML_DSA_44 = 1457,
+	_NID_ML_DSA_65 = 1458,
+	_NID_ML_DSA_87 = 1459,
 
 	_RSA_PKCS1_PADDING                 = 1,
 	_RSA_NO_PADDING                    = 3,
@@ -323,12 +329,14 @@ _EVP_PKEY_PTR EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR ctx, const char *propq, con
 _EVP_PKEY_PTR EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
 _EVP_PKEY_PTR EVP_PKEY_Q_keygen_X25519(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
 _EVP_PKEY_PTR EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
+_EVP_PKEY_PTR EVP_PKEY_Q_keygen_MLDSA(_OSSL_LIB_CTX_PTR ctx, const char *propq, const char *type) __attribute__((tag("3"),variadic("EVP_PKEY_Q_keygen"),noescape,nocallback));
 
 _EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new(_EVP_PKEY_PTR arg0, _ENGINE_PTR arg1);
 _EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_id(int id, _ENGINE_PTR e);
 _EVP_PKEY_CTX_PTR EVP_PKEY_CTX_new_from_pkey(_OSSL_LIB_CTX_PTR libctx, _EVP_PKEY_PTR pkey, const char *propquery) __attribute__((tag("3")));
 void EVP_PKEY_CTX_free(_EVP_PKEY_CTX_PTR arg0);
 int EVP_PKEY_CTX_ctrl(_EVP_PKEY_CTX_PTR ctx, int keytype, int optype, int cmd, int p1, void *p2);
+int EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR ctx, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),noescape,nocallback));
 int EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR arg0, int arg1) __attribute__((tag("3")));
 int EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR arg0, const _EVP_MD_PTR arg1) __attribute__((tag("3")));
 int EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2) __attribute__((tag("3"),slice("arg1","arg2")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -127,6 +127,7 @@ int (*_g_EVP_PKEY_CTX_set1_hkdf_key)(_EVP_PKEY_CTX_PTR, const unsigned char*, in
 int (*_g_EVP_PKEY_CTX_set1_hkdf_salt)(_EVP_PKEY_CTX_PTR, const unsigned char*, int);
 int (*_g_EVP_PKEY_CTX_set_hkdf_md)(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR);
 int (*_g_EVP_PKEY_CTX_set_hkdf_mode)(_EVP_PKEY_CTX_PTR, int);
+int (*_g_EVP_PKEY_CTX_set_params)(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR);
 _EVP_PKEY_PTR (*_g_EVP_PKEY_Q_keygen)(_OSSL_LIB_CTX_PTR, const char*, const char*, ...);
 int (*_g_EVP_PKEY_assign)(_EVP_PKEY_PTR, int, void*);
 int (*_g_EVP_PKEY_decapsulate)(_EVP_PKEY_CTX_PTR, unsigned char*, size_t*, const unsigned char*, size_t);
@@ -536,6 +537,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(EVP_PKEY_CTX_set1_hkdf_salt)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_md)
 	__mkcgo__dlsym(EVP_PKEY_CTX_set_hkdf_mode)
+	__mkcgo__dlsym(EVP_PKEY_CTX_set_params)
 	__mkcgo__dlsym(EVP_PKEY_Q_keygen)
 	__mkcgo__dlsym(EVP_PKEY_decapsulate)
 	__mkcgo__dlsym(EVP_PKEY_decapsulate_init)
@@ -609,6 +611,7 @@ void __mkcgo_unload_3() {
 	_g_EVP_PKEY_CTX_set1_hkdf_salt = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_md = NULL;
 	_g_EVP_PKEY_CTX_set_hkdf_mode = NULL;
+	_g_EVP_PKEY_CTX_set_params = NULL;
 	_g_EVP_PKEY_Q_keygen = NULL;
 	_g_EVP_PKEY_decapsulate = NULL;
 	_g_EVP_PKEY_decapsulate_init = NULL;
@@ -1416,6 +1419,12 @@ int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR _arg0, int _arg1, uintpt
 	return _ret;
 }
 
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR _arg0, const _OSSL_PARAM_PTR _arg1, uintptr_t *_err_state) {
+	int _ret = _g_EVP_PKEY_CTX_set_params(_arg0, _arg1);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, const char* _arg3, uintptr_t *_err_state) {
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2, _arg3);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
@@ -1423,6 +1432,12 @@ _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR _arg0, const char* _
 }
 
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, uintptr_t *_err_state) {
+	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2);
+	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_MLDSA(_OSSL_LIB_CTX_PTR _arg0, const char* _arg1, const char* _arg2, uintptr_t *_err_state) {
 	_EVP_PKEY_PTR _ret = _g_EVP_PKEY_Q_keygen(_arg0, _arg1, _arg2);
 	if (_ret == NULL) *_err_state = mkcgo_err_retrieve();
 	return _ret;

--- a/internal/ossl/zossl.go
+++ b/internal/ossl/zossl.go
@@ -23,6 +23,9 @@ const (
 	EVP_PKEY_DSA                        = 116
 	EVP_PKEY_MLKEM_768                  = 1455
 	EVP_PKEY_MLKEM_1024                 = 1456
+	EVP_PKEY_ML_DSA_44                  = 1457
+	EVP_PKEY_ML_DSA_65                  = 1458
+	EVP_PKEY_ML_DSA_87                  = 1459
 	EVP_PKEY_OP_DERIVE                  = (1 << 10)
 	EVP_MAX_MD_SIZE                     = 64
 	EVP_PKEY_PUBLIC_KEY                 = 0x86
@@ -45,6 +48,9 @@ const (
 	NID_secp521r1                       = 716
 	NID_ML_KEM_768                      = 1455
 	NID_ML_KEM_1024                     = 1456
+	NID_ML_DSA_44                       = 1457
+	NID_ML_DSA_65                       = 1458
+	NID_ML_DSA_87                       = 1459
 	RSA_PKCS1_PADDING                   = 1
 	RSA_NO_PADDING                      = 3
 	RSA_PKCS1_OAEP_PADDING              = 4

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -57,6 +57,9 @@ enum {
 	_EVP_PKEY_DSA = 116,
 	_EVP_PKEY_MLKEM_768 = 1455,
 	_EVP_PKEY_MLKEM_1024 = 1456,
+	_EVP_PKEY_ML_DSA_44 = 1457,
+	_EVP_PKEY_ML_DSA_65 = 1458,
+	_EVP_PKEY_ML_DSA_87 = 1459,
 	_EVP_PKEY_OP_DERIVE = (1 << 10),
 	_EVP_MAX_MD_SIZE = 64,
 	_EVP_PKEY_PUBLIC_KEY = 0x86,
@@ -79,6 +82,9 @@ enum {
 	_NID_secp521r1 = 716,
 	_NID_ML_KEM_768 = 1455,
 	_NID_ML_KEM_1024 = 1456,
+	_NID_ML_DSA_44 = 1457,
+	_NID_ML_DSA_65 = 1458,
+	_NID_ML_DSA_87 = 1459,
 	_RSA_PKCS1_PADDING = 1,
 	_RSA_NO_PADDING = 3,
 	_RSA_PKCS1_OAEP_PADDING = 4,
@@ -238,8 +244,10 @@ int _mkcgo_EVP_PKEY_CTX_set1_hkdf_key(_EVP_PKEY_CTX_PTR, const unsigned char*, i
 int _mkcgo_EVP_PKEY_CTX_set1_hkdf_salt(_EVP_PKEY_CTX_PTR, const unsigned char*, int, uintptr_t *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_md(_EVP_PKEY_CTX_PTR, const _EVP_MD_PTR, uintptr_t *);
 int _mkcgo_EVP_PKEY_CTX_set_hkdf_mode(_EVP_PKEY_CTX_PTR, int, uintptr_t *);
+int _mkcgo_EVP_PKEY_CTX_set_params(_EVP_PKEY_CTX_PTR, const _OSSL_PARAM_PTR, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_EC(_OSSL_LIB_CTX_PTR, const char*, const char*, const char*, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_ED25519(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
+_EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_MLDSA(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_MLKEM(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_RSA(_OSSL_LIB_CTX_PTR, const char*, const char*, size_t, uintptr_t *);
 _EVP_PKEY_PTR _mkcgo_EVP_PKEY_Q_keygen_X25519(_OSSL_LIB_CTX_PTR, const char*, const char*, uintptr_t *);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -47,10 +47,14 @@ package ossl
 #cgo nocallback _mkcgo_EVP_MD_CTX_get_params
 #cgo noescape _mkcgo_EVP_MD_CTX_set_params
 #cgo nocallback _mkcgo_EVP_MD_CTX_set_params
+#cgo noescape _mkcgo_EVP_PKEY_CTX_set_params
+#cgo nocallback _mkcgo_EVP_PKEY_CTX_set_params
 #cgo noescape _mkcgo_EVP_PKEY_Q_keygen_EC
 #cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_EC
 #cgo noescape _mkcgo_EVP_PKEY_Q_keygen_ED25519
 #cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_ED25519
+#cgo noescape _mkcgo_EVP_PKEY_Q_keygen_MLDSA
+#cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_MLDSA
 #cgo noescape _mkcgo_EVP_PKEY_Q_keygen_MLKEM
 #cgo nocallback _mkcgo_EVP_PKEY_Q_keygen_MLKEM
 #cgo noescape _mkcgo_EVP_PKEY_Q_keygen_RSA
@@ -826,6 +830,12 @@ func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error
 	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", uintptr(_err))
 }
 
+func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_PKEY_CTX_set_params(ctx, params, mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("EVP_PKEY_CTX_set_params", uintptr(_err))
+}
+
 func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_PKEY_Q_keygen_EC(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), (*C.char)(unsafe.Pointer(arg1)), mkcgoNoEscape(&_err))
@@ -836,6 +846,12 @@ func EVP_PKEY_Q_keygen_ED25519(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) 
 	var _err C.uintptr_t
 	_ret := C._mkcgo_EVP_PKEY_Q_keygen_ED25519(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), mkcgoNoEscape(&_err))
 	return _ret, newMkcgoErr("EVP_PKEY_Q_keygen_ED25519", uintptr(_err))
+}
+
+func EVP_PKEY_Q_keygen_MLDSA(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_EVP_PKEY_Q_keygen_MLDSA(ctx, (*C.char)(unsafe.Pointer(propq)), (*C.char)(unsafe.Pointer(__type)), mkcgoNoEscape(&_err))
+	return _ret, newMkcgoErr("EVP_PKEY_Q_keygen_MLDSA", uintptr(_err))
 }
 
 func EVP_PKEY_Q_keygen_MLKEM(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -948,6 +948,14 @@ func EVP_PKEY_CTX_set_hkdf_mode(arg0 EVP_PKEY_CTX_PTR, arg1 int32) (int32, error
 	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_hkdf_mode", _err)
 }
 
+var _mkcgo_EVP_PKEY_CTX_set_params uintptr
+
+func EVP_PKEY_CTX_set_params(ctx EVP_PKEY_CTX_PTR, params OSSL_PARAM_PTR) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_EVP_PKEY_CTX_set_params, uintptr(ctx), uintptr(params), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("EVP_PKEY_CTX_set_params", _err)
+}
+
 var _mkcgo_EVP_PKEY_Q_keygen uintptr
 
 func EVP_PKEY_Q_keygen_EC(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte, arg1 *byte) (EVP_PKEY_PTR, error) {
@@ -965,6 +973,12 @@ func EVP_PKEY_Q_keygen_ED25519(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) 
 	var _err uintptr
 	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
 	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_ED25519", _err)
+}
+
+func EVP_PKEY_Q_keygen_MLDSA(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
+	var _err uintptr
+	r0, _ := syscallN(1, _mkcgo_EVP_PKEY_Q_keygen, uintptr(ctx), uintptr(unsafe.Pointer(propq)), uintptr(unsafe.Pointer(__type)), uintptr(unsafe.Pointer(&_err)))
+	return EVP_PKEY_PTR(r0), newMkcgoErr("EVP_PKEY_Q_keygen_MLDSA", _err)
 }
 
 func EVP_PKEY_Q_keygen_MLKEM(ctx OSSL_LIB_CTX_PTR, propq *byte, __type *byte) (EVP_PKEY_PTR, error) {
@@ -2195,6 +2209,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = dlsym(handle, "EVP_PKEY_CTX_set1_hkdf_salt\x00", false)
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_md\x00", false)
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = dlsym(handle, "EVP_PKEY_CTX_set_hkdf_mode\x00", false)
+	_mkcgo_EVP_PKEY_CTX_set_params = dlsym(handle, "EVP_PKEY_CTX_set_params\x00", false)
 	_mkcgo_EVP_PKEY_Q_keygen = dlsym(handle, "EVP_PKEY_Q_keygen\x00", false)
 	_mkcgo_EVP_PKEY_decapsulate = dlsym(handle, "EVP_PKEY_decapsulate\x00", false)
 	_mkcgo_EVP_PKEY_decapsulate_init = dlsym(handle, "EVP_PKEY_decapsulate_init\x00", false)
@@ -2268,6 +2283,7 @@ func MkcgoUnload_3() {
 	_mkcgo_EVP_PKEY_CTX_set1_hkdf_salt = 0
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_md = 0
 	_mkcgo_EVP_PKEY_CTX_set_hkdf_mode = 0
+	_mkcgo_EVP_PKEY_CTX_set_params = 0
 	_mkcgo_EVP_PKEY_Q_keygen = 0
 	_mkcgo_EVP_PKEY_decapsulate = 0
 	_mkcgo_EVP_PKEY_decapsulate_init = 0

--- a/mldsa.go
+++ b/mldsa.go
@@ -1,0 +1,430 @@
+//go:build !cmd_go_bootstrap
+
+package openssl
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/golang-fips/openssl/v2/internal/ossl"
+)
+
+const (
+	// privateKeySizeMLDSA is the size of an ML-DSA private key seed.
+	privateKeySizeMLDSA = 32
+
+	// publicKeySizeMLDSA44 is the size of an ML-DSA-44 public key encoding.
+	publicKeySizeMLDSA44 = 1312
+
+	// publicKeySizeMLDSA65 is the size of an ML-DSA-65 public key encoding.
+	publicKeySizeMLDSA65 = 1952
+
+	// publicKeySizeMLDSA87 is the size of an ML-DSA-87 public key encoding.
+	publicKeySizeMLDSA87 = 2592
+
+	// signatureSizeMLDSA44 is the size of an ML-DSA-44 signature.
+	signatureSizeMLDSA44 = 2420
+
+	// signatureSizeMLDSA65 is the size of an ML-DSA-65 signature.
+	signatureSizeMLDSA65 = 3309
+
+	// signatureSizeMLDSA87 is the size of an ML-DSA-87 signature.
+	signatureSizeMLDSA87 = 4627
+
+	// muSizeMLDSA is the size of the pre-hashed mu input to the external-mu
+	// variants of Sign and Verify.
+	muSizeMLDSA = 64
+
+	// maxContextSizeMLDSA is the maximum allowed length of the context string
+	// passed to Sign and Verify.
+	maxContextSizeMLDSA = 255
+)
+
+// SupportsMLDSA returns true if ML-DSA is supported on this platform.
+func SupportsMLDSA() bool {
+	return supportsMLDSA()
+}
+
+var supportsMLDSA = sync.OnceValue(func() bool {
+	// ML-DSA was added in OpenSSL 3.5. Probe the algorithm via the keymgmt
+	// fetch interface, which was introduced in OpenSSL 3.0 and returns nil
+	// for unknown algorithms on older 3.x releases.
+	if !ossl.EVP_KEYMGMT_fetch_Available() {
+		return false
+	}
+	mgmt, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLDSA44.ptr(), nil)
+	if mgmt == nil {
+		return false
+	}
+	ossl.EVP_KEYMGMT_free(mgmt)
+	return true
+})
+
+// MLDSAParameters represents one of the fixed ML-DSA parameter sets.
+type MLDSAParameters struct {
+	name          string
+	keyType       int32
+	keyTypeName   cString
+	publicKeySize int
+	signatureSize int
+}
+
+var (
+	mldsa44 = MLDSAParameters{
+		name:          "ML-DSA-44",
+		keyType:       ossl.EVP_PKEY_ML_DSA_44,
+		keyTypeName:   _KeyTypeMLDSA44,
+		publicKeySize: publicKeySizeMLDSA44,
+		signatureSize: signatureSizeMLDSA44,
+	}
+	mldsa65 = MLDSAParameters{
+		name:          "ML-DSA-65",
+		keyType:       ossl.EVP_PKEY_ML_DSA_65,
+		keyTypeName:   _KeyTypeMLDSA65,
+		publicKeySize: publicKeySizeMLDSA65,
+		signatureSize: signatureSizeMLDSA65,
+	}
+	mldsa87 = MLDSAParameters{
+		name:          "ML-DSA-87",
+		keyType:       ossl.EVP_PKEY_ML_DSA_87,
+		keyTypeName:   _KeyTypeMLDSA87,
+		publicKeySize: publicKeySizeMLDSA87,
+		signatureSize: signatureSizeMLDSA87,
+	}
+)
+
+// MLDSA44 returns the ML-DSA-44 parameter set.
+func MLDSA44() MLDSAParameters { return mldsa44 }
+
+// MLDSA65 returns the ML-DSA-65 parameter set.
+func MLDSA65() MLDSAParameters { return mldsa65 }
+
+// MLDSA87 returns the ML-DSA-87 parameter set.
+func MLDSA87() MLDSAParameters { return mldsa87 }
+
+func (params MLDSAParameters) valid() bool {
+	switch params {
+	case mldsa44, mldsa65, mldsa87:
+		return true
+	default:
+		return false
+	}
+}
+
+// PublicKeySize returns the size of public keys for this parameter set, in bytes.
+func (params MLDSAParameters) PublicKeySize() int { return params.publicKeySize }
+
+// SignatureSize returns the size of signatures for this parameter set, in bytes.
+func (params MLDSAParameters) SignatureSize() int { return params.signatureSize }
+
+// String returns the name of the parameter set.
+func (params MLDSAParameters) String() string { return params.name }
+
+var errInvalidMLDSAParameters = errors.New("mldsa: invalid parameters")
+
+// PrivateKeyMLDSA is an ML-DSA private key seed.
+type PrivateKeyMLDSA struct {
+	params MLDSAParameters
+	seed   [privateKeySizeMLDSA]byte
+}
+
+// GenerateKeyMLDSA generates a new ML-DSA private key.
+func GenerateKeyMLDSA(params MLDSAParameters) (*PrivateKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	key := &PrivateKeyMLDSA{params: params}
+	if err := generateMLDSASeed(params.keyType, key.seed[:]); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// NewPrivateKeyMLDSA constructs an ML-DSA private key from its 32-byte seed.
+func NewPrivateKeyMLDSA(params MLDSAParameters, seed []byte) (*PrivateKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	if len(seed) != privateKeySizeMLDSA {
+		return nil, errors.New("mldsa: invalid private key size")
+	}
+	key := &PrivateKeyMLDSA{params: params}
+	copy(key.seed[:], seed)
+	return key, nil
+}
+
+// Bytes returns the private key seed.
+func (key *PrivateKeyMLDSA) Bytes() []byte {
+	return key.seed[:]
+}
+
+// Parameters returns the parameters associated with this private key.
+func (key *PrivateKeyMLDSA) Parameters() MLDSAParameters { return key.params }
+
+// PublicKey returns the corresponding public key.
+func (key *PrivateKeyMLDSA) PublicKey() *PublicKeyMLDSA {
+	publicKey := &PublicKeyMLDSA{params: key.params}
+	if err := mldsaExtractPublicKey(key.params, key.seed[:], publicKey.bytes[:key.params.publicKeySize]); err != nil {
+		panic(err)
+	}
+	return publicKey
+}
+
+// Sign signs message with the private key, optionally binding the signature
+// to a context string. The context string must be at most 255 bytes long.
+func (key *PrivateKeyMLDSA) Sign(message []byte, context string) ([]byte, error) {
+	return mldsaSign(key.params, key.seed[:], message, context)
+}
+
+// SignExternalMu signs a pre-hashed mu message representative using ML-DSA.
+// mu must be exactly 64 bytes long.
+func (key *PrivateKeyMLDSA) SignExternalMu(mu []byte) ([]byte, error) {
+	if len(mu) != muSizeMLDSA {
+		return nil, errors.New("mldsa: invalid message hash length")
+	}
+	return mldsaSignExternalMu(key.params, key.seed[:], mu)
+}
+
+// PublicKeyMLDSA is an ML-DSA public key.
+type PublicKeyMLDSA struct {
+	params MLDSAParameters
+	bytes  [publicKeySizeMLDSA87]byte
+}
+
+// NewPublicKeyMLDSA constructs an ML-DSA public key from its encoding.
+func NewPublicKeyMLDSA(params MLDSAParameters, publicKey []byte) (*PublicKeyMLDSA, error) {
+	if !params.valid() {
+		return nil, errInvalidMLDSAParameters
+	}
+	if len(publicKey) != params.publicKeySize {
+		return nil, errors.New("mldsa: invalid public key size")
+	}
+	// Validate by attempting a key import.
+	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	if err != nil {
+		return nil, err
+	}
+	ossl.EVP_PKEY_free(pkey)
+	key := &PublicKeyMLDSA{params: params}
+	copy(key.bytes[:], publicKey)
+	return key, nil
+}
+
+// Bytes returns the public key encoding.
+func (key *PublicKeyMLDSA) Bytes() []byte {
+	return key.bytes[:key.params.publicKeySize]
+}
+
+// Parameters returns the parameters associated with this public key.
+func (key *PublicKeyMLDSA) Parameters() MLDSAParameters { return key.params }
+
+// Verify verifies an ML-DSA signature over message bound to the given context.
+func (key *PublicKeyMLDSA) Verify(message, signature []byte, context string) error {
+	return mldsaVerify(key.params, key.bytes[:key.params.publicKeySize], message, signature, context)
+}
+
+// VerifyExternalMu verifies an ML-DSA signature over a pre-hashed mu message
+// representative. mu must be exactly 64 bytes long.
+func (key *PublicKeyMLDSA) VerifyExternalMu(mu, signature []byte) error {
+	if len(mu) != muSizeMLDSA {
+		return errors.New("mldsa: invalid message hash length")
+	}
+	return mldsaVerifyExternalMu(key.params, key.bytes[:key.params.publicKeySize], mu, signature)
+}
+
+// Helper functions
+
+// generateMLDSASeed generates a new ML-DSA private key and extracts the seed.
+func generateMLDSASeed(keyType int32, seed []byte) error {
+	pkey, err := generateEVPPKey(keyType, 0, "")
+	if err != nil {
+		return err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	_, err = ossl.EVP_PKEY_get_octet_string_param(pkey, _OSSL_PKEY_PARAM_ML_DSA_SEED.ptr(), seed, nil)
+	return err
+}
+
+// createMLDSAPrivateKey creates an ML-DSA EVP_PKEY from a 32-byte seed.
+func createMLDSAPrivateKey(id int32, seed []byte) (ossl.EVP_PKEY_PTR, error) {
+	if len(seed) != privateKeySizeMLDSA {
+		return nil, errors.New("mldsa: invalid seed size")
+	}
+
+	bld := newParamBuilder()
+	defer bld.finalize()
+
+	bld.addOctetString(_OSSL_PKEY_PARAM_ML_DSA_SEED, seed)
+
+	params, err := bld.build()
+	if err != nil {
+		return nil, err
+	}
+	defer ossl.OSSL_PARAM_free(params)
+
+	return newEvpFromParams(id, ossl.EVP_PKEY_KEYPAIR, params)
+}
+
+// createMLDSAPublicKey creates an ML-DSA EVP_PKEY from encoded public key bytes.
+func createMLDSAPublicKey(id int32, pubKeyBytes []byte) (ossl.EVP_PKEY_PTR, error) {
+	bld := newParamBuilder()
+	defer bld.finalize()
+
+	bld.addOctetString(_OSSL_PKEY_PARAM_PUB_KEY, pubKeyBytes)
+
+	params, err := bld.build()
+	if err != nil {
+		return nil, err
+	}
+	defer ossl.OSSL_PARAM_free(params)
+
+	return newEvpFromParams(id, ossl.EVP_PKEY_PUBLIC_KEY, params)
+}
+
+// mldsaExtractPublicKey derives and copies the encoded public key bytes from
+// a private key seed.
+func mldsaExtractPublicKey(params MLDSAParameters, seed, dst []byte) error {
+	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	if err != nil {
+		return err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	var pubLen int
+	if _, err := ossl.EVP_PKEY_get_octet_string_param(pkey, _OSSL_PKEY_PARAM_PUB_KEY.ptr(), dst, &pubLen); err != nil {
+		return err
+	}
+	if pubLen != params.publicKeySize {
+		return errors.New("mldsa: unexpected public key size")
+	}
+	return nil
+}
+
+// mldsaSigParams builds the OSSL_PARAM array used to bind a context string
+// (and/or the external-mu flag) to an ML-DSA Sign or Verify operation.
+// Returns nil params when neither is set.
+func mldsaSigParams(context string, externalMu bool) (ossl.OSSL_PARAM_PTR, error) {
+	if len(context) > maxContextSizeMLDSA {
+		return nil, errors.New("mldsa: context too long")
+	}
+	if context == "" && !externalMu {
+		return nil, nil
+	}
+	bld := newParamBuilder()
+	defer bld.finalize()
+	if context != "" {
+		bld.addOctetString(_OSSL_SIGNATURE_PARAM_CONTEXT_STRING, []byte(context))
+	}
+	if externalMu {
+		bld.addInt32(_OSSL_SIGNATURE_PARAM_MU, 1)
+	}
+	return bld.build()
+}
+
+func mldsaSign(params MLDSAParameters, seed, message []byte, context string) ([]byte, error) {
+	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	if err != nil {
+		return nil, err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	return mldsaSignWithKey(pkey, params, message, context, false)
+}
+
+func mldsaSignExternalMu(params MLDSAParameters, seed, mu []byte) ([]byte, error) {
+	pkey, err := createMLDSAPrivateKey(params.keyType, seed)
+	if err != nil {
+		return nil, err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	return mldsaSignWithKey(pkey, params, mu, "", true)
+}
+
+func mldsaSignWithKey(pkey ossl.EVP_PKEY_PTR, params MLDSAParameters, message []byte, context string, externalMu bool) ([]byte, error) {
+	mdctx, err := ossl.EVP_MD_CTX_new()
+	if err != nil {
+		return nil, err
+	}
+	defer ossl.EVP_MD_CTX_free(mdctx)
+
+	var pctx ossl.EVP_PKEY_CTX_PTR
+	if _, err := ossl.EVP_DigestSignInit(mdctx, &pctx, nil, nil, pkey); err != nil {
+		return nil, err
+	}
+	sigParams, err := mldsaSigParams(context, externalMu)
+	if err != nil {
+		return nil, err
+	}
+	if sigParams != nil {
+		defer ossl.OSSL_PARAM_free(sigParams)
+		if _, err := ossl.EVP_PKEY_CTX_set_params(pctx, sigParams); err != nil {
+			return nil, err
+		}
+	}
+
+	signature := make([]byte, params.signatureSize)
+	siglen := params.signatureSize
+	if _, err := ossl.EVP_DigestSign(mdctx, signature, &siglen, message); err != nil {
+		return nil, err
+	}
+	if siglen != params.signatureSize {
+		return nil, errors.New("mldsa: unexpected signature length")
+	}
+	return signature[:siglen], nil
+}
+
+func mldsaVerify(params MLDSAParameters, publicKey, message, signature []byte, context string) error {
+	if len(signature) != params.signatureSize {
+		return errors.New("mldsa: invalid signature length")
+	}
+	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	if err != nil {
+		return err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	return mldsaVerifyWithKey(pkey, message, signature, context, false)
+}
+
+func mldsaVerifyExternalMu(params MLDSAParameters, publicKey, mu, signature []byte) error {
+	if len(signature) != params.signatureSize {
+		return errors.New("mldsa: invalid signature length")
+	}
+	pkey, err := createMLDSAPublicKey(params.keyType, publicKey)
+	if err != nil {
+		return err
+	}
+	defer ossl.EVP_PKEY_free(pkey)
+
+	return mldsaVerifyWithKey(pkey, mu, signature, "", true)
+}
+
+func mldsaVerifyWithKey(pkey ossl.EVP_PKEY_PTR, message, signature []byte, context string, externalMu bool) error {
+	mdctx, err := ossl.EVP_MD_CTX_new()
+	if err != nil {
+		return err
+	}
+	defer ossl.EVP_MD_CTX_free(mdctx)
+
+	var pctx ossl.EVP_PKEY_CTX_PTR
+	if _, err := ossl.EVP_DigestVerifyInit(mdctx, &pctx, nil, nil, pkey); err != nil {
+		return err
+	}
+	sigParams, err := mldsaSigParams(context, externalMu)
+	if err != nil {
+		return err
+	}
+	if sigParams != nil {
+		defer ossl.OSSL_PARAM_free(sigParams)
+		if _, err := ossl.EVP_PKEY_CTX_set_params(pctx, sigParams); err != nil {
+			return err
+		}
+	}
+
+	if _, err := ossl.EVP_DigestVerify(mdctx, signature, message); err != nil {
+		return errors.New("mldsa: invalid signature")
+	}
+	return nil
+}

--- a/mldsa.go
+++ b/mldsa.go
@@ -40,25 +40,43 @@ const (
 	maxContextSizeMLDSA = 255
 )
 
-// SupportsMLDSA returns true if ML-DSA is supported on this platform.
-func SupportsMLDSA() bool {
-	return supportsMLDSA()
+// SupportsMLDSA returns true if the given ML-DSA parameter set is supported
+// on this platform. Providers may not implement every security level, so
+// callers must probe each parameter set they intend to use.
+func SupportsMLDSA(params MLDSAParameters) bool {
+	switch params.keyType {
+	case ossl.EVP_PKEY_ML_DSA_44:
+		return supportsMLDSA44()
+	case ossl.EVP_PKEY_ML_DSA_65:
+		return supportsMLDSA65()
+	case ossl.EVP_PKEY_ML_DSA_87:
+		return supportsMLDSA87()
+	default:
+		return false
+	}
 }
 
-var supportsMLDSA = sync.OnceValue(func() bool {
-	// ML-DSA was added in OpenSSL 3.5. Probe the algorithm via the keymgmt
-	// fetch interface, which was introduced in OpenSSL 3.0 and returns nil
-	// for unknown algorithms on older 3.x releases.
+// probeMLDSA reports whether the OpenSSL provider exposes the given ML-DSA
+// algorithm via the keymgmt fetch interface. ML-DSA was added in OpenSSL 3.5;
+// older 3.x releases return nil for unknown algorithm names, and 1.x lacks
+// the fetch interface entirely.
+func probeMLDSA(name cString) bool {
 	if !ossl.EVP_KEYMGMT_fetch_Available() {
 		return false
 	}
-	mgmt, _ := ossl.EVP_KEYMGMT_fetch(nil, _KeyTypeMLDSA44.ptr(), nil)
+	mgmt, _ := ossl.EVP_KEYMGMT_fetch(nil, name.ptr(), nil)
 	if mgmt == nil {
 		return false
 	}
 	ossl.EVP_KEYMGMT_free(mgmt)
 	return true
-})
+}
+
+var (
+	supportsMLDSA44 = sync.OnceValue(func() bool { return probeMLDSA(_KeyTypeMLDSA44) })
+	supportsMLDSA65 = sync.OnceValue(func() bool { return probeMLDSA(_KeyTypeMLDSA65) })
+	supportsMLDSA87 = sync.OnceValue(func() bool { return probeMLDSA(_KeyTypeMLDSA87) })
+)
 
 // MLDSAParameters represents one of the fixed ML-DSA parameter sets.
 type MLDSAParameters struct {

--- a/mldsa_test.go
+++ b/mldsa_test.go
@@ -1,0 +1,432 @@
+package openssl_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/golang-fips/openssl/v2"
+)
+
+type mldsaTestCase struct {
+	name string
+	seed string
+	msg  string
+}
+
+type mldsaExternalMuTestCase struct {
+	name   string
+	params openssl.MLDSAParameters
+	seed   string
+	mu     string
+}
+
+var mldsaParameterTests = []struct {
+	name   string
+	params openssl.MLDSAParameters
+}{
+	{"44", openssl.MLDSA44()},
+	{"65", openssl.MLDSA65()},
+	{"87", openssl.MLDSA87()},
+}
+
+var mldsaACVPTestCases = []mldsaTestCase{
+	// From crypto/internal/fips140/mldsa/mldsa_test.go TestACVPRejectionKATs.
+	{"Path/ML-DSA-44/1", "5C624FCC1862452452D0C665840D8237F43108E5499EDCDC108FBC49D596E4B7", "951FDF5473A4CBA6D9E5B5DB7E79FB8173921BA5B13E9271401B8F907B8B7D5B"},
+	{"Path/ML-DSA-44/2", "836EABEDB4D2CD9BE6A4D957CF5EE6BF489304136864C55C2C5F01DA5047D18B", "199A0AB735E9004163DD02D319A61CFE81638E3BF47BB1E90E90D6E3EA545247"},
+	{"Path/ML-DSA-44/3", "CA5A01E1EA6552CB5C9803462B94C2F1DC9D13BB17A6ACE510D157056A2C6114", "8C8CACA88FFF52B9330510537B3701B3993F3726136A650F48F8604551550832"},
+	{"Path/ML-DSA-44/4", "9C005F1550B4F31855C6B92F978736733F37791CB39DD182D7BA5732BDC2483E", "B744343F30F7FEE088998BA574E799F1BF3939C06C29BF9AC10F3588A57E21E2"},
+	{"Path/ML-DSA-44/5", "4FAB5485B009399E8AE6FC3D3EEFBFE8E09796E4477AABD5EB1CC908FA734DE3", "7CAB0FDCF4BEA5F039137478AA45C9C48EF96D906FC49F6E2F138111BF1B4A4E"},
+	{"Path/ML-DSA-65/1", "464756A985E5DF03739D95DD309C1ED9C5B04254CC294E7E7EB9B9365EE15117", "491101BBA044DE6E44A63796C33CDA051BB05A60725B87AF4BA9DB940C03AC09"},
+	{"Path/ML-DSA-65/2", "235A48DB4CA7916B884F424A8586EFD517E87C64AECEC0FCE9A3CC212BA1522E", "F8CE85CB2EC474FFBF5A3FFAE029CE6F4526B8D597655067F97F438B81071E9B"},
+	{"Path/ML-DSA-65/3", "E13131B705A760305FEFFEBFE99082E2691A444BBEFCC3EDF67D909886200207", "CD365512C7E61BBAA130800B37F3BB46AAF1BEEF3742EA8A9010A6DD4576ED0B"},
+	{"Path/ML-DSA-65/4", "0A4793E040A4BC0D0F37643D12C1EA1F10648724609936C76E0EC83E37209E92", "6D9C7A795E48D80A892CBF4D4558429787277E3806EB5D0BCE1640EEBBBF9AEC"},
+	{"Path/ML-DSA-65/5", "F865B889E5022D54BABC81CA67E7EB39F1AC42F92CF5295C3DA5C9667DB1B924", "047AFAADBE020ED2D766DA85317DEDE80BE550545F0B21E3F555A990F8004258"},
+	{"Path/ML-DSA-87/1", "0D58219132746BE077DFE821E9F8FD87857B28AB91D6A567E312A73E2636032C", "3AA49EF72D010AEC19383BA1E83EC2DD3DCC207A96FFCEB9FFA269E3E3D66400"},
+	{"Path/ML-DSA-87/2", "146C47AB9F88408EB76A813294D533B29D7E0FDA75DA5A4E7C69EB61EFEEBB78", "82C44F998A8D24F056084D0E80ECFD8434493385A284C69974923C270D397782"},
+	{"Path/ML-DSA-87/3", "049D9B0B646A2AC7F50B63CE5E4BFE44C9B87634F4FF6C14C513E388B8A1F808", "FEBC9F8AE159002BE1A11D395959DD7FC20718135690CDAA2BCFB5801C02AB89"},
+	{"Path/ML-DSA-87/4", "9823DDDE446A8EA883DAD3AC6477F79839FDC2D2DEF2416BE0A8B71CFBC3F5C6", "F7592C97C1A96A2F4053588F5CDAD4C50BF7C3752709854FA27779B445DD2BA2"},
+	{"Path/ML-DSA-87/5", "AE213FE8589B414F53780D8B9B6837179967E13CB474C5AD365C043778D2BC90", "19C1913BA76FF04596BB7CC80FD825A5AEDEF5D5AD61CEDB5203E6D7EDB18877"},
+	{"Count/ML-DSA-44/77", "090D97C1F4166EB32CA67C5FB564ACBE0735DB4AF4B8DB3A7C2CE7402357CA44", "E3838364B37F47EDFCA2B577B20B80C3CB51B9F56E0E4CDB7DF002C874039252"},
+	{"Count/ML-DSA-44/100", "CFC73D07A883543A804F770070861825143A62F2F97D05FCE00FD8B25D29A43F", "0960C13E9BA467A938450120CC96FF6F04B7E557C99A838619A48F9A38738AB8"},
+	{"Count/ML-DSA-65/64a", "26B605C78AC762FA1634C6F91DD117C4FBFF7F3A7E7781F0CC83B6281F04AD7F", "C9B07E7DDC0274468F312F5C692A54AC73D1E34D8638E20A2CD3C788F27D4355"},
+	{"Count/ML-DSA-65/73", "9191CF381BEE17475C011986EFB6AFB1EFA6997442FD33427353F1DA1AA39FC0", "E616E36E81AA1EC39262109421AE0DDDA5E3B5A8F4A252BCA27AE882538DF618"},
+	{"Count/ML-DSA-65/66", "516912C7B90A3DBE009B7478DBCAF0F5C5C9ED9699A20D0CA56CC516E5A444CD", "9247CA75F9456226A0C783DABCC33FF5B4B489575ADED543E74B29B45F9C8EF2"},
+	{"Count/ML-DSA-65/65", "D4B841F882D50AB9E590066BAFABA0F0D04D32641C0B978E54CCAA69A6E8D2C4", "175231657B0F3C7065947999467C342064F29BFAEB553E97561407D5560E3AEB"},
+	{"Count/ML-DSA-65/64b", "5492EB8D811072C030A30CC66B23A173059EBA0D4868CCB92FBE2510B4A5915F", "33D2753ED87D0003B44C1AF5F72EB931F559C6B4931AF7E249F65D3FA7613295"},
+	{"Count/ML-DSA-87/64a", "B5C07ECEFE9E7C3B885FDEF032BDF9F807B4011E2DFE6806C088D2081631C8EB", "D1D5C2D167D6E62906790A5FEDF5A0A754CFAF47E6A11AEB93FB8C41934C31F8"},
+	{"Count/ML-DSA-87/65", "E8FC3C9FAD711DDA2946334FBBD331468D6E9AB48EB86DCD03F300A17AEBC5E5", "3B435F7A2CE431C7AB8EAE0991C5DAC610827C99D27803046FBC6C567D6B71F2"},
+	{"Count/ML-DSA-87/64b", "151F80886D6CE8C3B428964FE02C40CA0C8EFFA100EE089E54D785344FCCF719", "C628CE94D2AA99AA50CF15B147D4F9A9C62A3D4612152DE0A502C377F472D614"},
+	{"Count/ML-DSA-87/64c", "48BEFFB4C97E59E474E1906F39888BE5AE62F6A011C05EF6A6B8D1E54F2171B7", "D2756A8FB4E47F796AF704ED0FC8C6E573D42DFAB443B329F00F8DB2FF12C465"},
+	{"Count/ML-DSA-87/69", "FE2DA9DD93A077FCB6452AC88D0A5762EB896BAAAC6CE7D01CB1370BA8322390", "A86B29ADF2300D2636E21D4A350CD18E55A254379C3659A7A95D8734CEC1F005"},
+}
+
+var mldsaExternalMuTestCases = []mldsaExternalMuTestCase{
+	// From crypto/internal/fips140/mldsa/mldsa_test.go BenchmarkCAST.
+	{"CAST/ML-DSA-44", openssl.MLDSA44(), "5C624FCC1862452452D0C665840D8237F43108E5499EDCDC108FBC49D596E4B7", "2ad1c72bb0fcbe28099ce8bd2ed836dfebe520aad38fbac66ef785a3cfb10fb419327fa57818ee4e3718da4be48d24b59a208f8807271fdb7eda6e60141bd263"},
+	{"CAST/ML-DSA-65", openssl.MLDSA65(), "F215BA2280D86F142012FC05FFC04F2C7D22FF5DD7D69AA0EFB081E3A53E9318", "35cdb7dddbed44af4641bac659f46598ed769ea9693fd4ed2152b84c45811d2e66eded1eb20cde1c1f4b82642a330d8e86ac432a2aefaa56cd9b2b5f4affd450"},
+}
+
+func TestMLDSARoundTrip(t *testing.T) {
+	if !openssl.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaParameterTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMLDSARoundTrip(t, test.params)
+		})
+	}
+}
+
+func testMLDSARoundTrip(t *testing.T, params openssl.MLDSAParameters) {
+	t.Parallel()
+
+	generated1, err := openssl.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated2, err := openssl.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(generated1.Bytes(), generated2.Bytes()) {
+		t.Error("two generated private keys are equal")
+	}
+	if bytes.Equal(generated1.PublicKey().Bytes(), generated2.PublicKey().Bytes()) {
+		t.Error("two generated public keys are equal")
+	}
+
+	for _, testCase := range mldsaACVPTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			seed := fromHexBytes(testCase.seed)
+			privateKey, err := openssl.NewPrivateKeyMLDSA(params, seed)
+			if err != nil {
+				t.Fatalf("NewPrivateKey: %v", err)
+			}
+			if !bytes.Equal(privateKey.Bytes(), seed) {
+				t.Error("private key seed changed")
+			}
+
+			publicKey := privateKey.PublicKey()
+			publicKeyBytes := publicKey.Bytes()
+			if len(publicKeyBytes) != params.PublicKeySize() {
+				t.Fatalf("public key length = %d, want %d", len(publicKeyBytes), params.PublicKeySize())
+			}
+			reparsedPublicKey, err := openssl.NewPublicKeyMLDSA(params, publicKeyBytes)
+			if err != nil {
+				t.Fatalf("NewPublicKey: %v", err)
+			}
+			if !bytes.Equal(reparsedPublicKey.Bytes(), publicKeyBytes) {
+				t.Error("reparsed public key changed")
+			}
+
+			message := fromHexBytes(testCase.msg)
+			signature, err := privateKey.Sign(message, "")
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+			if len(signature) != params.SignatureSize() {
+				t.Fatalf("signature length = %d, want %d", len(signature), params.SignatureSize())
+			}
+			if err := reparsedPublicKey.Verify(message, signature, ""); err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			wrongMessage := append([]byte(nil), message...)
+			wrongMessage[0] ^= 0x80
+			if err := reparsedPublicKey.Verify(wrongMessage, signature, ""); err == nil {
+				t.Error("Verify passed on wrong message")
+			}
+
+			contextSignature, err := privateKey.Sign(message, "context")
+			if err != nil {
+				t.Fatalf("Sign with context: %v", err)
+			}
+			if err := reparsedPublicKey.Verify(message, contextSignature, "context"); err != nil {
+				t.Fatalf("Verify with context: %v", err)
+			}
+			if err := reparsedPublicKey.Verify(message, contextSignature, "wrong context"); err == nil {
+				t.Error("Verify passed with wrong context")
+			}
+
+			mu := append(fromHexBytes(testCase.msg), fromHexBytes(testCase.msg)...)
+			externalSignature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				t.Fatalf("SignExternalMu: %v", err)
+			}
+			if len(externalSignature) != params.SignatureSize() {
+				t.Fatalf("external signature length = %d, want %d", len(externalSignature), params.SignatureSize())
+			}
+			if err := reparsedPublicKey.VerifyExternalMu(mu, externalSignature); err != nil {
+				t.Fatalf("VerifyExternalMu: %v", err)
+			}
+			wrongMu := append([]byte(nil), mu...)
+			wrongMu[0] ^= 0x80
+			if err := reparsedPublicKey.VerifyExternalMu(wrongMu, externalSignature); err == nil {
+				t.Error("VerifyExternalMu passed on wrong message")
+			}
+		})
+	}
+}
+
+func TestMLDSABadLengths(t *testing.T) {
+	if !openssl.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaParameterTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMLDSABadLengths(t, test.params)
+		})
+	}
+}
+
+func TestMLDSAExternalMuCASTVectors(t *testing.T) {
+	if !openssl.SupportsMLDSA() {
+		t.Skip("ML-DSA not supported on this platform")
+	}
+	t.Parallel()
+	for _, test := range mldsaExternalMuTestCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			privateKey, err := openssl.NewPrivateKeyMLDSA(test.params, fromHexBytes(test.seed))
+			if err != nil {
+				t.Fatalf("NewPrivateKey: %v", err)
+			}
+			publicKey := privateKey.PublicKey()
+			mu := fromHexBytes(test.mu)
+
+			signature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				t.Fatalf("SignExternalMu: %v", err)
+			}
+			if len(signature) != test.params.SignatureSize() {
+				t.Fatalf("signature length = %d, want %d", len(signature), test.params.SignatureSize())
+			}
+			if err := publicKey.VerifyExternalMu(mu, signature); err != nil {
+				t.Fatalf("VerifyExternalMu: %v", err)
+			}
+			wrongMu := append([]byte(nil), mu...)
+			wrongMu[0] ^= 0x80
+			if err := publicKey.VerifyExternalMu(wrongMu, signature); err == nil {
+				t.Error("VerifyExternalMu passed on wrong message")
+			}
+		})
+	}
+}
+
+func testMLDSABadLengths(t *testing.T, params openssl.MLDSAParameters) {
+	t.Parallel()
+	privateKey, err := openssl.GenerateKeyMLDSA(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKeyBytes := privateKey.Bytes()
+	publicKeyBytes := privateKey.PublicKey().Bytes()
+	publicKey, err := openssl.NewPublicKeyMLDSA(params, publicKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := []byte("message")
+	signature, err := privateKey.Sign(message, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := openssl.NewPrivateKeyMLDSA(params, privateKeyBytes[:len(privateKeyBytes)-1]); err == nil {
+		t.Error("NewPrivateKey accepted a short seed")
+	}
+	if _, err := openssl.NewPrivateKeyMLDSA(params, append(privateKeyBytes, 0)); err == nil {
+		t.Error("NewPrivateKey accepted a long seed")
+	}
+	if _, err := openssl.NewPublicKeyMLDSA(params, publicKeyBytes[:len(publicKeyBytes)-1]); err == nil {
+		t.Error("NewPublicKey accepted a short encoding")
+	}
+	if _, err := openssl.NewPublicKeyMLDSA(params, append(publicKeyBytes, 0)); err == nil {
+		t.Error("NewPublicKey accepted a long encoding")
+	}
+	if err := publicKey.Verify(message, signature[:params.SignatureSize()-1], ""); err == nil {
+		t.Error("Verify accepted a short signature")
+	}
+	if err := publicKey.Verify(message, append(signature, 0), ""); err == nil {
+		t.Error("Verify accepted a long signature")
+	}
+	if _, err := privateKey.Sign(message, string(make([]byte, 256))); err == nil {
+		t.Error("Sign accepted a long context")
+	}
+	if _, err := privateKey.SignExternalMu(make([]byte, 63)); err == nil {
+		t.Error("SignExternalMu accepted a short mu")
+	}
+	if err := publicKey.VerifyExternalMu(make([]byte, 63), signature); err == nil {
+		t.Error("VerifyExternalMu accepted a short mu")
+	}
+}
+
+func TestMLDSAConstantSizes(t *testing.T) {
+	// Sanity-check the package-private size constants against the publicly
+	// observable parameter set values.
+	if openssl.PrivateKeySizeMLDSA != 32 {
+		t.Errorf("PrivateKeySizeMLDSA = %d, want 32", openssl.PrivateKeySizeMLDSA)
+	}
+	if openssl.MLDSA44().PublicKeySize() != openssl.PublicKeySizeMLDSA44 {
+		t.Errorf("MLDSA44 public key size mismatch")
+	}
+	if openssl.MLDSA65().PublicKeySize() != openssl.PublicKeySizeMLDSA65 {
+		t.Errorf("MLDSA65 public key size mismatch")
+	}
+	if openssl.MLDSA87().PublicKeySize() != openssl.PublicKeySizeMLDSA87 {
+		t.Errorf("MLDSA87 public key size mismatch")
+	}
+	if openssl.MLDSA44().SignatureSize() != openssl.SignatureSizeMLDSA44 {
+		t.Errorf("MLDSA44 signature size mismatch")
+	}
+	if openssl.MLDSA65().SignatureSize() != openssl.SignatureSizeMLDSA65 {
+		t.Errorf("MLDSA65 signature size mismatch")
+	}
+	if openssl.MLDSA87().SignatureSize() != openssl.SignatureSizeMLDSA87 {
+		t.Errorf("MLDSA87 signature size mismatch")
+	}
+}
+
+func BenchmarkMLDSAKeyGen(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				privateKey, err := openssl.GenerateKeyMLDSA(test.params)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= privateKey.Bytes()[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAPublicKey(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				publicKey := privateKey.PublicKey()
+				sink ^= publicKey.Bytes()[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSASign(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			message := []byte("testing")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				signature, err := privateKey.Sign(message, "")
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= signature[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSASignExternalMu(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			mu := make([]byte, 64)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				signature, err := privateKey.SignExternalMu(mu)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sink ^= signature[0]
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAVerify(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			publicKey := privateKey.PublicKey()
+			message := []byte("testing")
+			signature, err := privateKey.Sign(message, "")
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := publicKey.Verify(message, signature, ""); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMLDSAVerifyExternalMu(b *testing.B) {
+	if !openssl.SupportsMLDSA() {
+		b.Skip("ML-DSA not supported on this platform")
+	}
+	for _, test := range mldsaParameterTests {
+		b.Run(test.name, func(b *testing.B) {
+			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
+			publicKey := privateKey.PublicKey()
+			mu := make([]byte, 64)
+			signature, err := privateKey.SignExternalMu(mu)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if err := publicKey.VerifyExternalMu(mu, signature); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func newBenchmarkMLDSAPrivateKey(b *testing.B, params openssl.MLDSAParameters) *openssl.PrivateKeyMLDSA {
+	b.Helper()
+	seed := make([]byte, 32)
+	privateKey, err := openssl.NewPrivateKeyMLDSA(params, seed)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return privateKey
+}
+
+func fromHexBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/mldsa_test.go
+++ b/mldsa_test.go
@@ -68,9 +68,6 @@ var mldsaExternalMuTestCases = []mldsaExternalMuTestCase{
 }
 
 func TestMLDSARoundTrip(t *testing.T) {
-	if !openssl.SupportsMLDSA() {
-		t.Skip("ML-DSA not supported on this platform")
-	}
 	t.Parallel()
 	for _, test := range mldsaParameterTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -80,6 +77,9 @@ func TestMLDSARoundTrip(t *testing.T) {
 }
 
 func testMLDSARoundTrip(t *testing.T, params openssl.MLDSAParameters) {
+	if !openssl.SupportsMLDSA(params) {
+		t.Skipf("%s not supported on this platform", params)
+	}
 	t.Parallel()
 
 	generated1, err := openssl.GenerateKeyMLDSA(params)
@@ -170,9 +170,6 @@ func testMLDSARoundTrip(t *testing.T, params openssl.MLDSAParameters) {
 }
 
 func TestMLDSABadLengths(t *testing.T) {
-	if !openssl.SupportsMLDSA() {
-		t.Skip("ML-DSA not supported on this platform")
-	}
 	t.Parallel()
 	for _, test := range mldsaParameterTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -182,12 +179,12 @@ func TestMLDSABadLengths(t *testing.T) {
 }
 
 func TestMLDSAExternalMuCASTVectors(t *testing.T) {
-	if !openssl.SupportsMLDSA() {
-		t.Skip("ML-DSA not supported on this platform")
-	}
 	t.Parallel()
 	for _, test := range mldsaExternalMuTestCases {
 		t.Run(test.name, func(t *testing.T) {
+			if !openssl.SupportsMLDSA(test.params) {
+				t.Skipf("%s not supported on this platform", test.params)
+			}
 			t.Parallel()
 			privateKey, err := openssl.NewPrivateKeyMLDSA(test.params, fromHexBytes(test.seed))
 			if err != nil {
@@ -216,6 +213,9 @@ func TestMLDSAExternalMuCASTVectors(t *testing.T) {
 }
 
 func testMLDSABadLengths(t *testing.T, params openssl.MLDSAParameters) {
+	if !openssl.SupportsMLDSA(params) {
+		t.Skipf("%s not supported on this platform", params)
+	}
 	t.Parallel()
 	privateKey, err := openssl.GenerateKeyMLDSA(params)
 	if err != nil {
@@ -289,11 +289,11 @@ func TestMLDSAConstantSizes(t *testing.T) {
 }
 
 func BenchmarkMLDSAKeyGen(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			b.ReportAllocs()
 			for b.Loop() {
 				privateKey, err := openssl.GenerateKeyMLDSA(test.params)
@@ -307,11 +307,11 @@ func BenchmarkMLDSAKeyGen(b *testing.B) {
 }
 
 func BenchmarkMLDSAPublicKey(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -324,11 +324,11 @@ func BenchmarkMLDSAPublicKey(b *testing.B) {
 }
 
 func BenchmarkMLDSASign(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
 			message := []byte("testing")
 			b.ReportAllocs()
@@ -345,11 +345,11 @@ func BenchmarkMLDSASign(b *testing.B) {
 }
 
 func BenchmarkMLDSASignExternalMu(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
 			mu := make([]byte, 64)
 			b.ReportAllocs()
@@ -366,11 +366,11 @@ func BenchmarkMLDSASignExternalMu(b *testing.B) {
 }
 
 func BenchmarkMLDSAVerify(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
 			publicKey := privateKey.PublicKey()
 			message := []byte("testing")
@@ -390,11 +390,11 @@ func BenchmarkMLDSAVerify(b *testing.B) {
 }
 
 func BenchmarkMLDSAVerifyExternalMu(b *testing.B) {
-	if !openssl.SupportsMLDSA() {
-		b.Skip("ML-DSA not supported on this platform")
-	}
 	for _, test := range mldsaParameterTests {
 		b.Run(test.name, func(b *testing.B) {
+			if !openssl.SupportsMLDSA(test.params) {
+				b.Skipf("%s not supported on this platform", test.params)
+			}
 			privateKey := newBenchmarkMLDSAPrivateKey(b, test.params)
 			publicKey := privateKey.PublicKey()
 			mu := make([]byte, 64)


### PR DESCRIPTION
This pull request adds support for the ML-DSA (post-quantum digital signature) key types to the codebase, including new constants, key generation, and integration with the OpenSSL backend. It also exposes new signature-related parameters and updates the test exports for ML-DSA. The changes span the Go and C interop layers, ensuring the new key types are available and usable.

### ML-DSA key type support

* Added new ML-DSA key types (`ML-DSA-44`, `ML-DSA-65`, `ML-DSA-87`) as constants in `const.go`, `internal/ossl/shims.h`, `internal/ossl/zossl.go`, and `internal/ossl/zossl.h`, and registered their corresponding NIDs. [[1]](diffhunk://#diff-94dacef0ac41aa5d49ab2c28c5299940b98a347553b11239fc2be03f8e19e314R40-R42) [[2]](diffhunk://#diff-1acc007d5daf079caa0b3f8c251c8ae36a7345531ca7058627056ac4f9cf0ac6R56-R58) [[3]](diffhunk://#diff-1acc007d5daf079caa0b3f8c251c8ae36a7345531ca7058627056ac4f9cf0ac6R88-R90) [[4]](diffhunk://#diff-c86d023e33edc30c2791e08d0abaf8a167b7e3fc5378bbdbc74f9c3133e0aa72R26-R28) [[5]](diffhunk://#diff-c86d023e33edc30c2791e08d0abaf8a167b7e3fc5378bbdbc74f9c3133e0aa72R51-R53) [[6]](diffhunk://#diff-e80a9a9ddf23e7c5734488c54a89843dfd1bedebbc24cdf484b307b281809dedR60-R62) [[7]](diffhunk://#diff-e80a9a9ddf23e7c5734488c54a89843dfd1bedebbc24cdf484b307b281809dedR85-R87)
* Implemented ML-DSA key generation support in the Go and C layers, including new `EVP_PKEY_Q_keygen_MLDSA` functions and wiring through the CGO and syscall layers. [[1]](diffhunk://#diff-1aae60417ffcca46d3492af4bcde318cdd9635fee8e7c1c40e610dae254a8430R250-R255) [[2]](diffhunk://#diff-1acc007d5daf079caa0b3f8c251c8ae36a7345531ca7058627056ac4f9cf0ac6R332-R339) [[3]](diffhunk://#diff-c0f248cb8be4a45d0474fe8fdd174a5730d5f117991e92feb54056b7aeb7ecdeR1440-R1445) [[4]](diffhunk://#diff-e80a9a9ddf23e7c5734488c54a89843dfd1bedebbc24cdf484b307b281809dedR247-R250) [[5]](diffhunk://#diff-17d9fd965a226c6be296a654a9627a3e726571ad1dbcad4ee6ff184e850fea02R851-R856) [[6]](diffhunk://#diff-af663eb3360ca0455d6234c7e7a046313cf9e3126e2b2195d1a20db2e301ae5aR978-R983)

### OpenSSL parameter integration

* Added and exported new signature parameters (`context-string`, `mu`) and ML-DSA seed parameter in `const.go` for use with ML-DSA keys.
* Exposed and implemented the `EVP_PKEY_CTX_set_params` function in the C, CGO, and syscall layers for setting arbitrary OpenSSL parameters. [[1]](diffhunk://#diff-1acc007d5daf079caa0b3f8c251c8ae36a7345531ca7058627056ac4f9cf0ac6R332-R339) [[2]](diffhunk://#diff-c0f248cb8be4a45d0474fe8fdd174a5730d5f117991e92feb54056b7aeb7ecdeR130) [[3]](diffhunk://#diff-c0f248cb8be4a45d0474fe8fdd174a5730d5f117991e92feb54056b7aeb7ecdeR540) [[4]](diffhunk://#diff-c0f248cb8be4a45d0474fe8fdd174a5730d5f117991e92feb54056b7aeb7ecdeR614) [[5]](diffhunk://#diff-c0f248cb8be4a45d0474fe8fdd174a5730d5f117991e92feb54056b7aeb7ecdeR1422-R1427) [[6]](diffhunk://#diff-e80a9a9ddf23e7c5734488c54a89843dfd1bedebbc24cdf484b307b281809dedR247-R250) [[7]](diffhunk://#diff-17d9fd965a226c6be296a654a9627a3e726571ad1dbcad4ee6ff184e850fea02R50-R57) [[8]](diffhunk://#diff-17d9fd965a226c6be296a654a9627a3e726571ad1dbcad4ee6ff184e850fea02R833-R838) [[9]](diffhunk://#diff-af663eb3360ca0455d6234c7e7a046313cf9e3126e2b2195d1a20db2e301ae5aR951-R958) [[10]](diffhunk://#diff-af663eb3360ca0455d6234c7e7a046313cf9e3126e2b2195d1a20db2e301ae5aR2212) [[11]](diffhunk://#diff-af663eb3360ca0455d6234c7e7a046313cf9e3126e2b2195d1a20db2e301ae5aR2286)

### Testing and exports

* Exported ML-DSA key and signature size constants for use in tests via `export_test.go`.

- https://github.com/microsoft/go-lab/issues/294