### PR TITLE
Use RAND_bytes_ex in OpenSSL 3+

### DIFF
--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -190,7 +190,8 @@ _OSSL_PROVIDER_PTR OSSL_PROVIDER_try_load(_OSSL_LIB_CTX_PTR libctx, const char *
 const char *OSSL_PROVIDER_get0_name(const _OSSL_PROVIDER_PTR prov) __attribute__((tag("3"),noerror));
 
 // RAND API
-int RAND_bytes(unsigned char *arg0, int arg1) __attribute__((noescape,nocallback,slice("arg0","arg1")));
+int RAND_bytes(unsigned char *buf, int num) __attribute__((tag("legacy_1"),noescape,nocallback,slice("buf","num")));
+int RAND_bytes_ex(_OSSL_LIB_CTX_PTR ctx, unsigned char *buf, size_t num, unsigned int strength) __attribute__((tag("3"),noescape,nocallback,slice("buf","num")));
 
 // EVP_MD API
 _EVP_MD_PTR EVP_MD_fetch(_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties) __attribute__((tag("3"),tag("init_3")));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -237,6 +237,7 @@ const char* (*_g_OpenSSL_version)(int);
 unsigned long (*_g_OpenSSL_version_num)(void);
 int (*_g_PKCS5_PBKDF2_HMAC)(const char*, int, const unsigned char*, int, int, const _EVP_MD_PTR, int, unsigned char*);
 int (*_g_RAND_bytes)(unsigned char*, int);
+int (*_g_RAND_bytes_ex)(_OSSL_LIB_CTX_PTR, unsigned char*, size_t, unsigned int);
 void (*_g_RSA_free)(_RSA_PTR);
 void (*_g_RSA_get0_crt_params)(const _RSA_PTR, const _BIGNUM_PTR*, const _BIGNUM_PTR*, const _BIGNUM_PTR*);
 void (*_g_RSA_get0_factors)(const _RSA_PTR, const _BIGNUM_PTR*, const _BIGNUM_PTR*);
@@ -374,7 +375,6 @@ void __mkcgo_load_(void* handle) {
 	__mkcgo__dlsym(OPENSSL_init_crypto)
 	__mkcgo__dlsym(OpenSSL_version)
 	__mkcgo__dlsym(PKCS5_PBKDF2_HMAC)
-	__mkcgo__dlsym(RAND_bytes)
 }
 
 void __mkcgo_unload_() {
@@ -494,7 +494,6 @@ void __mkcgo_unload_() {
 	_g_OPENSSL_init_crypto = NULL;
 	_g_OpenSSL_version = NULL;
 	_g_PKCS5_PBKDF2_HMAC = NULL;
-	_g_RAND_bytes = NULL;
 }
 
 void __mkcgo_load_3(void* handle) {
@@ -569,6 +568,7 @@ void __mkcgo_load_3(void* handle) {
 	__mkcgo__dlsym(OSSL_PROVIDER_available)
 	__mkcgo__dlsym(OSSL_PROVIDER_get0_name)
 	__mkcgo__dlsym(OSSL_PROVIDER_try_load)
+	__mkcgo__dlsym(RAND_bytes_ex)
 }
 
 void __mkcgo_unload_3() {
@@ -643,6 +643,7 @@ void __mkcgo_unload_3() {
 	_g_OSSL_PROVIDER_available = NULL;
 	_g_OSSL_PROVIDER_get0_name = NULL;
 	_g_OSSL_PROVIDER_try_load = NULL;
+	_g_RAND_bytes_ex = NULL;
 }
 
 void __mkcgo_load_33(void* handle) {
@@ -725,6 +726,7 @@ void __mkcgo_load_legacy_1(void* handle) {
 	__mkcgo__dlsym(HMAC_Final)
 	__mkcgo__dlsym(HMAC_Init_ex)
 	__mkcgo__dlsym(HMAC_Update)
+	__mkcgo__dlsym(RAND_bytes)
 	__mkcgo__dlsym(RSA_free)
 	__mkcgo__dlsym(RSA_get0_crt_params)
 	__mkcgo__dlsym(RSA_get0_factors)
@@ -771,6 +773,7 @@ void __mkcgo_unload_legacy_1() {
 	_g_HMAC_Final = NULL;
 	_g_HMAC_Init_ex = NULL;
 	_g_HMAC_Update = NULL;
+	_g_RAND_bytes = NULL;
 	_g_RSA_free = NULL;
 	_g_RSA_get0_crt_params = NULL;
 	_g_RSA_get0_factors = NULL;
@@ -2025,6 +2028,12 @@ int _mkcgo_PKCS5_PBKDF2_HMAC(const char* _arg0, int _arg1, const unsigned char* 
 
 int _mkcgo_RAND_bytes(unsigned char* _arg0, int _arg1, uintptr_t *_err_state) {
 	int _ret = _g_RAND_bytes(_arg0, _arg1);
+	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
+	return _ret;
+}
+
+int _mkcgo_RAND_bytes_ex(_OSSL_LIB_CTX_PTR _arg0, unsigned char* _arg1, size_t _arg2, unsigned int _arg3, uintptr_t *_err_state) {
+	int _ret = _g_RAND_bytes_ex(_arg0, _arg1, _arg2, _arg3);
 	if (_ret <= 0) *_err_state = mkcgo_err_retrieve();
 	return _ret;
 }

--- a/internal/ossl/zossl.h
+++ b/internal/ossl/zossl.h
@@ -359,6 +359,7 @@ const char* _mkcgo_OpenSSL_version(int);
 unsigned long _mkcgo_OpenSSL_version_num(void);
 int _mkcgo_PKCS5_PBKDF2_HMAC(const char*, int, const unsigned char*, int, int, const _EVP_MD_PTR, int, unsigned char*, uintptr_t *);
 int _mkcgo_RAND_bytes(unsigned char*, int, uintptr_t *);
+int _mkcgo_RAND_bytes_ex(_OSSL_LIB_CTX_PTR, unsigned char*, size_t, unsigned int, uintptr_t *);
 void _mkcgo_RSA_free(_RSA_PTR);
 void _mkcgo_RSA_get0_crt_params(const _RSA_PTR, const _BIGNUM_PTR*, const _BIGNUM_PTR*, const _BIGNUM_PTR*);
 void _mkcgo_RSA_get0_factors(const _RSA_PTR, const _BIGNUM_PTR*, const _BIGNUM_PTR*);

--- a/internal/ossl/zossl_cgo.go
+++ b/internal/ossl/zossl_cgo.go
@@ -83,6 +83,8 @@ package ossl
 #cgo nocallback _mkcgo_HMAC_Update
 #cgo noescape _mkcgo_RAND_bytes
 #cgo nocallback _mkcgo_RAND_bytes
+#cgo noescape _mkcgo_RAND_bytes_ex
+#cgo nocallback _mkcgo_RAND_bytes_ex
 */
 import "C"
 import "unsafe"
@@ -1455,10 +1457,16 @@ func PKCS5_PBKDF2_HMAC(pass []byte, salt []byte, iter int32, digest EVP_MD_PTR, 
 	return int32(_ret), newMkcgoErr("PKCS5_PBKDF2_HMAC", uintptr(_err))
 }
 
-func RAND_bytes(arg0 []byte) (int32, error) {
+func RAND_bytes(buf []byte) (int32, error) {
 	var _err C.uintptr_t
-	_ret := C._mkcgo_RAND_bytes((*C.uchar)(unsafe.Pointer(unsafe.SliceData(arg0))), C.int(len(arg0)), mkcgoNoEscape(&_err))
+	_ret := C._mkcgo_RAND_bytes((*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.int(len(buf)), mkcgoNoEscape(&_err))
 	return int32(_ret), newMkcgoErr("RAND_bytes", uintptr(_err))
+}
+
+func RAND_bytes_ex(ctx OSSL_LIB_CTX_PTR, buf []byte, strength uint32) (int32, error) {
+	var _err C.uintptr_t
+	_ret := C._mkcgo_RAND_bytes_ex(ctx, (*C.uchar)(unsafe.Pointer(unsafe.SliceData(buf))), C.size_t(len(buf)), C.uint(strength), mkcgoNoEscape(&_err))
+	return int32(_ret), newMkcgoErr("RAND_bytes_ex", uintptr(_err))
 }
 
 func RSA_free(arg0 RSA_PTR) {

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -1847,10 +1847,18 @@ func PKCS5_PBKDF2_HMAC(pass []byte, salt []byte, iter int32, digest EVP_MD_PTR, 
 
 var _mkcgo_RAND_bytes uintptr
 
-func RAND_bytes(arg0 []byte) (int32, error) {
+func RAND_bytes(buf []byte) (int32, error) {
 	var _err uintptr
-	r0, _ := syscallN(3, _mkcgo_RAND_bytes, uintptr(unsafe.Pointer(unsafe.SliceData(arg0))), uintptr(len(arg0)), uintptr(unsafe.Pointer(&_err)))
+	r0, _ := syscallN(3, _mkcgo_RAND_bytes, uintptr(unsafe.Pointer(unsafe.SliceData(buf))), uintptr(len(buf)), uintptr(unsafe.Pointer(&_err)))
 	return int32(r0), newMkcgoErr("RAND_bytes", _err)
+}
+
+var _mkcgo_RAND_bytes_ex uintptr
+
+func RAND_bytes_ex(ctx OSSL_LIB_CTX_PTR, buf []byte, strength uint32) (int32, error) {
+	var _err uintptr
+	r0, _ := syscallN(3, _mkcgo_RAND_bytes_ex, uintptr(ctx), uintptr(unsafe.Pointer(unsafe.SliceData(buf))), uintptr(len(buf)), uintptr(strength), uintptr(unsafe.Pointer(&_err)))
+	return int32(r0), newMkcgoErr("RAND_bytes_ex", _err)
 }
 
 var _mkcgo_RSA_free uintptr
@@ -2046,7 +2054,6 @@ func MkcgoLoad_(handle unsafe.Pointer) {
 	_mkcgo_OPENSSL_init_crypto = dlsym(handle, "OPENSSL_init_crypto\x00", false)
 	_mkcgo_OpenSSL_version = dlsym(handle, "OpenSSL_version\x00", false)
 	_mkcgo_PKCS5_PBKDF2_HMAC = dlsym(handle, "PKCS5_PBKDF2_HMAC\x00", false)
-	_mkcgo_RAND_bytes = dlsym(handle, "RAND_bytes\x00", false)
 }
 
 func MkcgoUnload_() {
@@ -2166,7 +2173,6 @@ func MkcgoUnload_() {
 	_mkcgo_OPENSSL_init_crypto = 0
 	_mkcgo_OpenSSL_version = 0
 	_mkcgo_PKCS5_PBKDF2_HMAC = 0
-	_mkcgo_RAND_bytes = 0
 }
 
 func MkcgoLoad_3(handle unsafe.Pointer) {
@@ -2241,6 +2247,7 @@ func MkcgoLoad_3(handle unsafe.Pointer) {
 	_mkcgo_OSSL_PROVIDER_available = dlsym(handle, "OSSL_PROVIDER_available\x00", false)
 	_mkcgo_OSSL_PROVIDER_get0_name = dlsym(handle, "OSSL_PROVIDER_get0_name\x00", false)
 	_mkcgo_OSSL_PROVIDER_try_load = dlsym(handle, "OSSL_PROVIDER_try_load\x00", false)
+	_mkcgo_RAND_bytes_ex = dlsym(handle, "RAND_bytes_ex\x00", false)
 }
 
 func MkcgoUnload_3() {
@@ -2315,6 +2322,7 @@ func MkcgoUnload_3() {
 	_mkcgo_OSSL_PROVIDER_available = 0
 	_mkcgo_OSSL_PROVIDER_get0_name = 0
 	_mkcgo_OSSL_PROVIDER_try_load = 0
+	_mkcgo_RAND_bytes_ex = 0
 }
 
 func MkcgoLoad_33(handle unsafe.Pointer) {
@@ -2397,6 +2405,7 @@ func MkcgoLoad_legacy_1(handle unsafe.Pointer) {
 	_mkcgo_HMAC_Final = dlsym(handle, "HMAC_Final\x00", false)
 	_mkcgo_HMAC_Init_ex = dlsym(handle, "HMAC_Init_ex\x00", false)
 	_mkcgo_HMAC_Update = dlsym(handle, "HMAC_Update\x00", false)
+	_mkcgo_RAND_bytes = dlsym(handle, "RAND_bytes\x00", false)
 	_mkcgo_RSA_free = dlsym(handle, "RSA_free\x00", false)
 	_mkcgo_RSA_get0_crt_params = dlsym(handle, "RSA_get0_crt_params\x00", false)
 	_mkcgo_RSA_get0_factors = dlsym(handle, "RSA_get0_factors\x00", false)
@@ -2443,6 +2452,7 @@ func MkcgoUnload_legacy_1() {
 	_mkcgo_HMAC_Final = 0
 	_mkcgo_HMAC_Init_ex = 0
 	_mkcgo_HMAC_Update = 0
+	_mkcgo_RAND_bytes = 0
 	_mkcgo_RSA_free = 0
 	_mkcgo_RSA_get0_crt_params = 0
 	_mkcgo_RSA_get0_factors = 0

--- a/rand.go
+++ b/rand.go
@@ -2,7 +2,11 @@
 
 package openssl
 
-import "github.com/golang-fips/openssl/v2/internal/ossl"
+import (
+	"math"
+
+	"github.com/golang-fips/openssl/v2/internal/ossl"
+)
 
 type randReader int
 
@@ -10,10 +14,21 @@ func (randReader) Read(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
-	// We check it even so.
-	if _, err := ossl.RAND_bytes(b); err != nil {
-		return 0, err
+	switch major() {
+	case 1:
+		if len(b) > math.MaxInt32 {
+			// OpenSSL 1 does not support reading more than 2^31-1 bytes at once.
+			// Instead of erroring out, read only up to 2^31-1 bytes and return
+			// the number of bytes read.
+			b = b[:math.MaxInt32]
+		}
+		if _, err := ossl.RAND_bytes(b); err != nil {
+			return 0, err
+		}
+	default:
+		if _, err := ossl.RAND_bytes_ex(nil, b, 0); err != nil {
+			return 0, err
+		}
 	}
 	return len(b), nil
 }


### PR DESCRIPTION
[RAND_bytes_ex](https://docs.openssl.org/3.0/man3/RAND_bytes_ex/) can generate more randomness at a time and it is available since OpenSSL 3.0.

Keep using `RAND_bytes` in OpenSSL 1, but cap the input to 2^31-1 bytes so that we can generate at most that amount of random data without erroring out. The standard library will loop appropriately to retrieve the remaining randomness.