### PR TITLE
Implement PBKDF2 using EVP_KDF_derive in OpenSSL 3

### DIFF
--- a/const.go
+++ b/const.go
@@ -54,13 +54,16 @@ const ( //checkheader:ignore
 	_OSSL_MAC_NAME_HMAC      cString = "HMAC\x00"
 
 	// KDF parameters
-	_OSSL_KDF_PARAM_DIGEST cString = "digest\x00"
-	_OSSL_KDF_PARAM_SECRET cString = "secret\x00"
-	_OSSL_KDF_PARAM_SEED   cString = "seed\x00"
-	_OSSL_KDF_PARAM_KEY    cString = "key\x00"
-	_OSSL_KDF_PARAM_INFO   cString = "info\x00"
-	_OSSL_KDF_PARAM_SALT   cString = "salt\x00"
-	_OSSL_KDF_PARAM_MODE   cString = "mode\x00"
+	_OSSL_KDF_PARAM_DIGEST   cString = "digest\x00"
+	_OSSL_KDF_PARAM_SECRET   cString = "secret\x00"
+	_OSSL_KDF_PARAM_SEED     cString = "seed\x00"
+	_OSSL_KDF_PARAM_KEY      cString = "key\x00"
+	_OSSL_KDF_PARAM_PASSWORD cString = "pass\x00"
+	_OSSL_KDF_PARAM_ITER     cString = "iter\x00"
+	_OSSL_KDF_PARAM_PKCS5    cString = "pkcs5\x00"
+	_OSSL_KDF_PARAM_INFO     cString = "info\x00"
+	_OSSL_KDF_PARAM_SALT     cString = "salt\x00"
+	_OSSL_KDF_PARAM_MODE     cString = "mode\x00"
 
 	// KDF FIPS parameters
 	_OSSL_KDF_PARAM_FIPS_KEY_CHECK cString = "key-check\x00"

--- a/internal/ossl/shims.h
+++ b/internal/ossl/shims.h
@@ -427,7 +427,7 @@ int EVP_KDF_CTX_set_params(_EVP_KDF_CTX_PTR ctx, const _OSSL_PARAM_PTR params) _
 void EVP_KDF_CTX_free(_EVP_KDF_CTX_PTR ctx) __attribute__((tag("3")));
 size_t EVP_KDF_CTX_get_kdf_size(_EVP_KDF_CTX_PTR ctx) __attribute__((tag("3")));
 int EVP_KDF_derive(_EVP_KDF_CTX_PTR ctx, unsigned char *key, size_t keylen, const _OSSL_PARAM_PTR params) __attribute__((tag("3"),slice("key","keylen")));
-int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const _EVP_MD_PTR digest, int keylen, unsigned char *out) __attribute__((slice("pass","passlen"),slice("salt","saltlen"),slice("out","keylen")));
+int PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const _EVP_MD_PTR digest, int keylen, unsigned char *out) __attribute__((tag("legacy_1"),slice("pass","passlen"),slice("salt","saltlen"),slice("out","keylen")));
 
 // OBJ API
 const char *OBJ_nid2sn(int n) __attribute__((noerror));

--- a/internal/ossl/zossl.c
+++ b/internal/ossl/zossl.c
@@ -374,7 +374,6 @@ void __mkcgo_load_(void* handle) {
 	__mkcgo__dlsym(OPENSSL_init)
 	__mkcgo__dlsym(OPENSSL_init_crypto)
 	__mkcgo__dlsym(OpenSSL_version)
-	__mkcgo__dlsym(PKCS5_PBKDF2_HMAC)
 }
 
 void __mkcgo_unload_() {
@@ -493,7 +492,6 @@ void __mkcgo_unload_() {
 	_g_OPENSSL_init = NULL;
 	_g_OPENSSL_init_crypto = NULL;
 	_g_OpenSSL_version = NULL;
-	_g_PKCS5_PBKDF2_HMAC = NULL;
 }
 
 void __mkcgo_load_3(void* handle) {
@@ -726,6 +724,7 @@ void __mkcgo_load_legacy_1(void* handle) {
 	__mkcgo__dlsym(HMAC_Final)
 	__mkcgo__dlsym(HMAC_Init_ex)
 	__mkcgo__dlsym(HMAC_Update)
+	__mkcgo__dlsym(PKCS5_PBKDF2_HMAC)
 	__mkcgo__dlsym(RAND_bytes)
 	__mkcgo__dlsym(RSA_free)
 	__mkcgo__dlsym(RSA_get0_crt_params)
@@ -773,6 +772,7 @@ void __mkcgo_unload_legacy_1() {
 	_g_HMAC_Final = NULL;
 	_g_HMAC_Init_ex = NULL;
 	_g_HMAC_Update = NULL;
+	_g_PKCS5_PBKDF2_HMAC = NULL;
 	_g_RAND_bytes = NULL;
 	_g_RSA_free = NULL;
 	_g_RSA_get0_crt_params = NULL;

--- a/internal/ossl/zossl_nocgo.go
+++ b/internal/ossl/zossl_nocgo.go
@@ -2053,7 +2053,6 @@ func MkcgoLoad_(handle unsafe.Pointer) {
 	_mkcgo_OPENSSL_init = dlsym(handle, "OPENSSL_init\x00", false)
 	_mkcgo_OPENSSL_init_crypto = dlsym(handle, "OPENSSL_init_crypto\x00", false)
 	_mkcgo_OpenSSL_version = dlsym(handle, "OpenSSL_version\x00", false)
-	_mkcgo_PKCS5_PBKDF2_HMAC = dlsym(handle, "PKCS5_PBKDF2_HMAC\x00", false)
 }
 
 func MkcgoUnload_() {
@@ -2172,7 +2171,6 @@ func MkcgoUnload_() {
 	_mkcgo_OPENSSL_init = 0
 	_mkcgo_OPENSSL_init_crypto = 0
 	_mkcgo_OpenSSL_version = 0
-	_mkcgo_PKCS5_PBKDF2_HMAC = 0
 }
 
 func MkcgoLoad_3(handle unsafe.Pointer) {
@@ -2405,6 +2403,7 @@ func MkcgoLoad_legacy_1(handle unsafe.Pointer) {
 	_mkcgo_HMAC_Final = dlsym(handle, "HMAC_Final\x00", false)
 	_mkcgo_HMAC_Init_ex = dlsym(handle, "HMAC_Init_ex\x00", false)
 	_mkcgo_HMAC_Update = dlsym(handle, "HMAC_Update\x00", false)
+	_mkcgo_PKCS5_PBKDF2_HMAC = dlsym(handle, "PKCS5_PBKDF2_HMAC\x00", false)
 	_mkcgo_RAND_bytes = dlsym(handle, "RAND_bytes\x00", false)
 	_mkcgo_RSA_free = dlsym(handle, "RSA_free\x00", false)
 	_mkcgo_RSA_get0_crt_params = dlsym(handle, "RSA_get0_crt_params\x00", false)
@@ -2452,6 +2451,7 @@ func MkcgoUnload_legacy_1() {
 	_mkcgo_HMAC_Final = 0
 	_mkcgo_HMAC_Init_ex = 0
 	_mkcgo_HMAC_Update = 0
+	_mkcgo_PKCS5_PBKDF2_HMAC = 0
 	_mkcgo_RAND_bytes = 0
 	_mkcgo_RSA_free = 0
 	_mkcgo_RSA_get0_crt_params = 0

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -46,9 +46,40 @@ func PBKDF2(password, salt []byte, iter, keyLen int, fh func() hash.Hash) ([]byt
 		return nil, errors.New("unsupported hash function")
 	}
 	out := make([]byte, keyLen)
-	_, err = ossl.PKCS5_PBKDF2_HMAC(password, salt, int32(iter), md, out)
-	if err != nil {
-		return nil, err
+	switch major() {
+	case 1:
+		if _, err = ossl.PKCS5_PBKDF2_HMAC(password, salt, int32(iter), md, out); err != nil {
+			return nil, err
+		}
+	default:
+		kdf, err := fetchPBKDF2()
+		if err != nil {
+			return nil, err
+		}
+		ctx, err := ossl.EVP_KDF_CTX_new(kdf)
+		if err != nil {
+			return nil, err
+		}
+		defer ossl.EVP_KDF_CTX_free(ctx)
+
+		bld := newParamBuilder()
+		defer bld.finalize()
+		bld.addOctetString(_OSSL_KDF_PARAM_PASSWORD, password)
+		bld.addOctetString(_OSSL_KDF_PARAM_SALT, salt)
+		bld.addInt32(_OSSL_KDF_PARAM_ITER, int32(iter))
+		bld.addInt32(_OSSL_KDF_PARAM_PKCS5, 1) // disable SP800-132 compliance checks, they are done at the crypto/pbkdf2 level
+		bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, ossl.EVP_MD_get0_name(md), 0)
+		params, err := bld.build()
+		if err != nil {
+			return nil, err
+		}
+		defer ossl.OSSL_PARAM_free(params)
+
+		_, err = ossl.EVP_KDF_derive(ctx, out, params)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return out, nil
 }


### PR DESCRIPTION
[PKCS5_PBKDF2_HMAC](https://docs.openssl.org/3.0/man3/PKCS5_PBKDF2_HMAC/) has strict buffer lengths limitations and has a stricter compliance checks than `crypto/pbkdf2`.

We can sidestep these limitations by using the OpenSSL 3 API `EVP_KDF_derive`, which we already use elsewhere.

@xnox