### PR TITLE
Drop hardcoded 3, 4 major version literals in switch statements

### DIFF
--- a/cipher.go
+++ b/cipher.go
@@ -83,8 +83,7 @@ func loadCipher(k cipherKind, mode cipherMode) (cipher ossl.EVP_CIPHER_PTR) {
 	}
 	defer func() {
 		if cipher != nil {
-			switch major() {
-			case 3, 4:
+			if major() != 1 {
 				// On OpenSSL 3, directly operating on a EVP_CIPHER object
 				// not created by EVP_CIPHER has negative performance
 				// implications, as cipher operations will have

--- a/dsa.go
+++ b/dsa.go
@@ -92,7 +92,7 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_pqg(dsa, &p, &q, &g)
-	case 3, 4:
+	default:
 		defer func() {
 			ossl.BN_free(p)
 			ossl.BN_free(q)
@@ -107,8 +107,6 @@ func GenerateParametersDSA(l, n int) (DSAParameters, error) {
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_FFC_G.ptr(), &g); err != nil {
 			return DSAParameters{}, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	return DSAParameters{
@@ -158,7 +156,7 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 	case 1:
 		dsa := getDSA(pkey)
 		ossl.DSA_get0_key(dsa, &by, &bx)
-	case 3, 4:
+	default:
 		defer func() {
 			ossl.BN_clear_free(bx)
 			ossl.BN_free(by)
@@ -169,8 +167,6 @@ func GenerateKeyDSA(params DSAParameters) (x, y BigInt, err error) {
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &bx); err != nil {
 			return nil, nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return bnToBig(bx), bnToBig(by), nil
 }
@@ -189,10 +185,8 @@ func newDSA(params DSAParameters, x, y BigInt) (ossl.EVP_PKEY_PTR, error) {
 	switch major() {
 	case 1:
 		return newDSA1(params, x, y)
-	case 3, 4:
-		return newDSA3(params, x, y)
 	default:
-		panic(errUnsupportedVersion())
+		return newDSA3(params, x, y)
 	}
 }
 

--- a/ecdh.go
+++ b/ecdh.go
@@ -106,7 +106,7 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			if bytes, err = encodeEcPoint(group, pt); err != nil {
 				return nil, err
 			}
-		case 3, 4:
+		default:
 			pkey = k._pkey
 			if _, err := ossl.EVP_PKEY_up_ref(pkey); err != nil {
 				return nil, err
@@ -118,8 +118,6 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			}
 			bytes = goBytes(unsafe.Pointer(cbytes), n)
 			cryptoFree(unsafe.Pointer(cbytes))
-		default:
-			panic(errUnsupportedVersion())
 		}
 	}
 	pub := &PublicKeyECDH{pkey, bytes}
@@ -140,10 +138,8 @@ func newECDHPkey(curve string, bytes []byte, isPrivate bool) (ossl.EVP_PKEY_PTR,
 	switch major() {
 	case 1:
 		return newECDHPkey1(nid, bytes, isPrivate)
-	case 3, 4:
-		return newECDHPkey3(nid, bytes, isPrivate)
 	default:
-		panic(errUnsupportedVersion())
+		return newECDHPkey3(nid, bytes, isPrivate)
 	}
 }
 
@@ -312,13 +308,11 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 			if priv == nil {
 				return nil, nil, fail("missing ECDH private key")
 			}
-		case 3, 4:
+		default:
 			if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_PRIV_KEY.ptr(), &priv); err != nil {
 				return nil, nil, err
 			}
 			defer ossl.BN_clear_free(priv)
-		default:
-			panic(errUnsupportedVersion())
 		}
 		// We should not leak bit length of the secret scalar in the key.
 		// For this reason, we use BN_bn2binpad instead of BN_bn2bin with fixed length.

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -91,7 +91,7 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 		}
 		// Get Z. We don't need to free it, get0 does not increase the reference count.
 		bd = ossl.EC_KEY_get0_private_key(key)
-	case 3, 4:
+	default:
 		if _, err := ossl.EVP_PKEY_get_bn_param(pkey, _OSSL_PKEY_PARAM_EC_PUB_X.ptr(), &bx); err != nil {
 			return nil, nil, nil, err
 		}
@@ -102,8 +102,6 @@ func GenerateKeyECDSA(curve string) (x, y, d BigInt, err error) {
 			return nil, nil, nil, err
 		}
 		defer ossl.BN_clear_free(bd)
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	// Get D.
@@ -149,10 +147,8 @@ func newECDSAKey(curve string, x, y, d BigInt) (ossl.EVP_PKEY_PTR, error) {
 	switch major() {
 	case 1:
 		return newECDSAKey1(nid, bx, by, bd)
-	case 3, 4:
-		return newECDSAKey3(nid, bx, by, bd)
 	default:
-		panic(errUnsupportedVersion())
+		return newECDSAKey3(nid, bx, by, bd)
 	}
 }
 

--- a/ed25519.go
+++ b/ed25519.go
@@ -33,7 +33,7 @@ var supportsEd25519 = sync.OnceValue(func() bool {
 			ossl.EVP_PKEY_CTX_free(ctx)
 			return true
 		}
-	case 3, 4:
+	default:
 		sig, _ := ossl.EVP_SIGNATURE_fetch(nil, _KeyTypeED25519.ptr(), nil)
 		if sig != nil {
 			ossl.EVP_SIGNATURE_free(sig)

--- a/evp.go
+++ b/evp.go
@@ -158,8 +158,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	hash.ch = ch
 	hash.size = int(ossl.EVP_MD_get_size(hash.md))
 	hash.blockSize = int(ossl.EVP_MD_get_block_size(hash.md))
-	switch major() {
-	case 3, 4:
+	if major() != 1 {
 		// On OpenSSL 3, directly operating on a EVP_MD object
 		// not created by EVP_MD_fetch has negative performance
 		// implications, as digest operations will have
@@ -180,7 +179,7 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 	switch major() {
 	case 1:
 		hash.provider = providerOSSLDefault
-	case 3, 4:
+	default:
 		if prov := ossl.EVP_MD_get0_provider(hash.md); prov != nil {
 			cname := ossl.OSSL_PROVIDER_get0_name(prov)
 			switch goString(cname) {
@@ -195,8 +194,6 @@ func loadHash(ch crypto.Hash, must bool) (h *hashAlgorithm) {
 				hash.marshallable = hash.magic != "" && isSymCryptHashStateSerializable(hash.md)
 			}
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	cacheMD.Store(ch, &hash)
@@ -232,7 +229,7 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 		if _, err := ossl.EVP_PKEY_keygen(ctx, &pkey); err != nil {
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		switch id {
 		case ossl.EVP_PKEY_RSA:
@@ -259,8 +256,6 @@ func generateEVPPKey(id, bits int32, curve string) (ossl.EVP_PKEY_PTR, error) {
 		if err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	return pkey, nil
@@ -385,10 +380,10 @@ func setOAEPPadding(ctx ossl.EVP_PKEY_CTX_PTR, h, mgfHash hash.Hash, label []byt
 		copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 		var err error
 		switch major() {
-		case 3, 4:
-			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
-		default:
+		case 1:
 			_, err = ossl.EVP_PKEY_CTX_ctrl(ctx, ossl.EVP_PKEY_RSA, -1, ossl.EVP_PKEY_CTRL_RSA_OAEP_LABEL, int32(len(label)), unsafe.Pointer(clabel))
+		default:
+			_, err = ossl.EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, unsafe.Slice(clabel, len(label)))
 		}
 		if err != nil {
 			cryptoFree(unsafe.Pointer(clabel))

--- a/hkdf.go
+++ b/hkdf.go
@@ -18,11 +18,9 @@ func SupportsHKDF() bool {
 	switch major() {
 	case 1:
 		return true
-	case 3, 4:
+	default:
 		_, err := fetchHKDF3()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -31,12 +29,10 @@ func SupportsTLS13KDF() bool {
 	switch major() {
 	case 1:
 		return false
-	case 3, 4:
+	default:
 		// TLS13-KDF is available in OpenSSL 3.0.0 and later.
 		_, err := fetchTLS13_KDF()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -169,7 +165,7 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 			return nil, err
 		}
 		return out[:keylen], nil
-	case 3, 4:
+	default:
 		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXTRACT_ONLY, secret, salt, nil, nil)
 		if err != nil {
 			return nil, err
@@ -184,8 +180,6 @@ func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 			return nil, err
 		}
 		return out, nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -218,7 +212,7 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 		if _, err := ossl.EVP_PKEY_derive(ctx, out, &keylen); err != nil {
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 		if err != nil {
 			return nil, err
@@ -233,8 +227,6 @@ func ExpandHKDFOneShot(h func() hash.Hash, pseudorandomKey, info []byte, keyLeng
 		if _, err := ossl.EVP_KDF_derive(ctx, out, nil); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return out, nil
 }
@@ -285,7 +277,7 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, er
 		c := &hkdf1{ctx: ctx, hashLen: size}
 		runtime.SetFinalizer(c, (*hkdf1).finalize)
 		return c, nil
-	case 3, 4:
+	default:
 		ctx, err := newHKDFCtx3(md, ossl.EVP_KDF_HKDF_MODE_EXPAND_ONLY, nil, nil, pseudorandomKey, info)
 		if err != nil {
 			return nil, err
@@ -293,8 +285,6 @@ func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, er
 		c := &hkdf3{ctx: ctx, hashLen: size}
 		runtime.SetFinalizer(c, (*hkdf3).finalize)
 		return c, nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 

--- a/hmac.go
+++ b/hmac.go
@@ -43,14 +43,12 @@ func NewHMAC(fh func() hash.Hash, key []byte) hash.Hash {
 			return nil
 		}
 		hmac.ctx1 = ctx
-	case 3, 4:
+	default:
 		ctx := newHMAC3(key, md)
 		if ctx.ctx == nil {
 			return nil
 		}
 		hmac.ctx3 = ctx
-	default:
-		panic(errUnsupportedVersion())
 	}
 	runtime.SetFinalizer(hmac, (*opensslHMAC).finalize)
 	return hmac
@@ -168,12 +166,10 @@ func (h *opensslHMAC) Reset() {
 		if _, err := ossl.HMAC_Init_ex(h.ctx1.ctx, nil, nil, nil); err != nil {
 			panic(err)
 		}
-	case 3, 4:
+	default:
 		if _, err := ossl.EVP_MAC_init(h.ctx3.ctx, h.ctx3.key, nil); err != nil {
 			panic(err)
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 
 	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
@@ -193,10 +189,8 @@ func (h *opensslHMAC) Write(p []byte) (int, error) {
 		switch major() {
 		case 1:
 			ossl.HMAC_Update(h.ctx1.ctx, p)
-		case 3, 4:
-			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 		default:
-			panic(errUnsupportedVersion())
+			ossl.EVP_MAC_update(h.ctx3.ctx, p)
 		}
 	}
 	runtime.KeepAlive(h)
@@ -227,15 +221,13 @@ func (h *opensslHMAC) Sum(in []byte) []byte {
 			panic(err)
 		}
 		ossl.HMAC_Final(ctx2, h.sum[:h.size], nil)
-	case 3, 4:
+	default:
 		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 		if err != nil {
 			panic(err)
 		}
 		defer ossl.EVP_MAC_CTX_free(ctx2)
 		ossl.EVP_MAC_final(ctx2, h.sum[:h.size], nil)
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return append(in, h.sum[:h.size]...)
 }
@@ -259,7 +251,7 @@ func (h *opensslHMAC) Clone() (HashCloner, error) {
 		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 		return cl, nil
 
-	case 3, 4:
+	default:
 		ctx2, err := ossl.EVP_MAC_CTX_dup(h.ctx3.ctx)
 		if err != nil {
 			panic(err)
@@ -272,8 +264,5 @@ func (h *opensslHMAC) Clone() (HashCloner, error) {
 		}
 		runtime.SetFinalizer(cl, (*opensslHMAC).finalize)
 		return cl, nil
-
-	default:
-		panic(errUnsupportedVersion())
 	}
 }

--- a/osslsetup/fips.go
+++ b/osslsetup/fips.go
@@ -51,7 +51,7 @@ func FIPS() bool {
 	switch vMajor {
 	case 1:
 		return ossl.FIPS_mode() == 1
-	case 3, 4:
+	default:
 		// Check if the default properties contain `fips=1`.
 		if ossl.EVP_default_properties_is_fips_enabled(nil) != 1 {
 			// Note that it is still possible that the provider used by default is FIPS-compliant,
@@ -66,8 +66,6 @@ func FIPS() bool {
 		// It also has a small chance of false positive if the FIPS provider implements the SHA-256 algorithm but not the other algorithms
 		// used by the caller application, but that is also unlikely because the FIPS provider should provide all common algorithms.
 		return proveSHA256("")
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -89,8 +87,7 @@ func FIPSCapable() bool {
 	if FIPS() {
 		return true
 	}
-	switch vMajor {
-	case 3, 4:
+	if vMajor != 1 {
 		// Load the provider with and without the `fips=yes` query.
 		// If the providers are the same, then the default provider is FIPS-capable.
 		provFIPS := sha256Provider(_ProviderNameFips)
@@ -124,7 +121,7 @@ func SetFIPS(enable bool) error {
 			return err
 		}
 		return nil
-	case 3, 4:
+	default:
 		var shaProps, provName cString
 		if enable {
 			shaProps = _PropFIPSYes
@@ -143,8 +140,6 @@ func SetFIPS(enable bool) error {
 		}
 		_, err := ossl.EVP_default_properties_enable_fips(nil, mode)
 		return err
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -15,11 +15,9 @@ func SupportsPBKDF2() bool {
 	switch major() {
 	case 1:
 		return true
-	case 3, 4:
+	default:
 		_, err := fetchPBKDF2()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 

--- a/rsa.go
+++ b/rsa.go
@@ -37,7 +37,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 		N, E, D = bnToBig(n), bnToBig(e), bnToBig(d)
 		P, Q = bnToBig(p), bnToBig(q)
 		Dp, Dq, Qinv = bnToBig(dmp1), bnToBig(dmq1), bnToBig(iqmp)
-	case 3, 4:
+	default:
 		tmp, err := ossl.BN_new()
 		if err != nil {
 			return bad(err)
@@ -66,8 +66,6 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 			setBigInt(&Qinv, _OSSL_PKEY_PARAM_RSA_COEFFICIENT1)) {
 			return bad(err)
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	return
 }
@@ -105,13 +103,11 @@ func NewPublicKeyRSA(n, e BigInt) (*PublicKeyRSA, error) {
 			ossl.EVP_PKEY_free(pkey)
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		if pkey, err = newRSAKey3(false, n, e, nil, nil, nil, nil, nil, nil); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	k := &PublicKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PublicKeyRSA).finalize)
@@ -184,13 +180,11 @@ func NewPrivateKeyRSA(n, e, d, p, q, dp, dq, qinv BigInt) (*PrivateKeyRSA, error
 			ossl.EVP_PKEY_free(pkey)
 			return nil, err
 		}
-	case 3, 4:
+	default:
 		var err error
 		if pkey, err = newRSAKey3(true, n, e, d, p, q, dp, dq, qinv); err != nil {
 			return nil, err
 		}
-	default:
-		panic(errUnsupportedVersion())
 	}
 	k := &PrivateKeyRSA{_pkey: pkey}
 	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -16,11 +16,9 @@ func SupportsTLS1PRF() bool {
 	switch major() {
 	case 1:
 		return minor() >= 1
-	case 3, 4:
+	default:
 		_, err := fetchTLS1PRF3()
 		return err == nil
-	default:
-		panic(errUnsupportedVersion())
 	}
 }
 
@@ -50,10 +48,8 @@ func TLS1PRF(result, secret, label, seed []byte, fh func() hash.Hash) error {
 	switch major() {
 	case 1:
 		return tls1PRF1(result, secret, label, seed, md)
-	case 3, 4:
-		return tls1PRF3(result, secret, label, seed, md)
 	default:
-		return errUnsupportedVersion()
+		return tls1PRF3(result, secret, label, seed, md)
 	}
 }
 


### PR DESCRIPTION
Need to clean up leftover switch statements that hardcoded ossl 3 and 4 to fully support forward compatibility. 

Convert:
  switch major() {
  case 1:            ... legacy ...
  case 3, 4:         ... modern ...
  default:           panic(errUnsupportedVersion())
  }

to:
  switch major() {
  case 1:            ... legacy ...
  default:           ... modern ...
  }

No behavior change for the currently tested majors. Future OpenSSL 5+ will exercise the 3+ code paths automatically once added to testedMajors in osslsetup/init.go.